### PR TITLE
Keep Dependabot on supported toolchain majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     labels:
       - "type: dependencies"
       - "status: triage"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Ignore automatic major-version updates for TypeScript and Node type definitions while Jarvis targets TypeScript 6 and Node 24.

## Verification

- Dependabot YAML parses successfully.
- Existing source and runtime behavior are unchanged.

Closes no product Issue.