### PR TITLE
Run CI actions on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary

Upgrade checkout and setup-node to v5 so the actions runtime uses Node 24 instead of deprecated Node 20.

## Verification

- Workflow YAML parses successfully.
- The pull request CI run must pass without the Node 20 deprecation annotation.