### PR TITLE
Add repeatable Mac MVP runtime qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run verify
+      - run: npm run verify:runtime

--- a/docs/verification/mac-mvp-qualification.md
+++ b/docs/verification/mac-mvp-qualification.md
@@ -1,0 +1,46 @@
+# Mac MVP Qualification
+
+This document records the evidence boundary for the first public Mac release.
+It deliberately never records an API key, transcript, reminder text, device identifier, or raw audit log.
+
+## Automated checks
+
+Run from a clean checkout:
+
+```bash
+npm ci
+npm run verify
+npm run verify:runtime
+```
+
+These checks prove TypeScript compilation, unit behavior, a no-key local startup,
+the loopback health response, and rejection of an unsupported HTTP method. They do
+not prove that the DeepSeek API accepts an owner's key or that the Web UI can
+complete a model conversation.
+
+## Owner-operated checks
+
+Use a disposable reminder and a harmless allowlisted application. Keep the values
+local and report only pass/fail plus timestamps.
+
+1. Put the owner-provided key in the untracked `.env` file, start Jarvis, and open the local Web UI.
+2. Start a fresh conversation and ask for a short text reply. Confirm committed assistant text appears.
+3. Ask for current Mac status and create/list a reminder. Confirm both tool results appear.
+4. Ask to open `Notes`. Confirm the request pauses for approval; decline once and confirm no launch; repeat and approve once.
+5. Restart Jarvis. Reopen the same conversation and confirm the reminder remains available.
+6. Remove the local key and disposable data after the check if the machine is not the development host.
+
+Record evidence in the GitHub Issue without attaching secrets or private content:
+
+```text
+Date: YYYY-MM-DD
+Automated checks: pass/fail
+Fresh text conversation: pass/fail
+System status and reminder tools: pass/fail
+Decline and approved Notes launch: pass/fail
+Restart persistence: pass/fail
+Evidence retained locally: yes/no
+```
+
+The Mac MVP is not considered fully qualified until these owner-operated checks
+are recorded separately from automated startup and unit-test evidence.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && node --test test/*.test.js",
     "start": "./scripts/start-mac.sh",
-    "verify": "npm run typecheck && npm test"
+    "verify": "npm run typecheck && npm test",
+    "verify:runtime": "./scripts/verify-local-runtime.sh"
   },
   "dependencies": {
     "@deepseek-ai/cordis": "4.0.1",

--- a/scripts/verify-local-runtime.sh
+++ b/scripts/verify-local-runtime.sh
@@ -1,0 +1,46 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PORT="${JARVIS_RUNTIME_PORT:-3183}"
+LOG_FILE="$(mktemp -t jarvis-runtime.XXXXXX.log)"
+PID=""
+
+cleanup() {
+  if [[ -n "$PID" ]]; then
+    kill "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+  fi
+  rm -f "$LOG_FILE"
+}
+trap cleanup EXIT INT TERM
+
+npm run build >/dev/null
+env -u DEEPSEEK_API_KEY JARVIS_PORT="$PORT" npm start >"$LOG_FILE" 2>&1 &
+PID=$!
+
+for attempt in {1..30}; do
+  if curl -fsS "http://127.0.0.1:$PORT/jarvis/health" > /tmp/jarvis-health.json; then
+    break
+  fi
+  if ! kill -0 "$PID" 2>/dev/null; then
+    cat "$LOG_FILE" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ -s /tmp/jarvis-health.json ]]
+node --input-type=module -e '
+  import { readFileSync } from "node:fs"
+  const health = JSON.parse(readFileSync("/tmp/jarvis-health.json", "utf8"))
+  if (health.service !== "jarvis-mac-mvp" || health.status !== "ok" || health.scope !== "loopback-only") {
+    throw new Error(`unexpected health response: ${JSON.stringify(health)}`)
+  }
+'
+
+http_status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/jarvis/health")"
+[[ "$http_status" == "405" ]]
+echo "local runtime verification passed on 127.0.0.1:$PORT"


### PR DESCRIPTION
## Summary
- add a no-key local runtime verification script
- run the runtime check in macOS CI
- document the evidence boundary and owner-operated real-key qualification for #5

## Verification
- `npm run verify`
- `npm run verify:runtime`

Closes #17? No. This supports #5 and does not close the real-key acceptance gate.