### PR TITLE
Add node command safety core

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - 记录追加式操作审计，提醒和审计文件权限为 `0600`。
 - 默认只监听 `127.0.0.1`，并关闭 Harness 遥测。
 - 单调拒绝非 Jarvis 工具，模型不能绕过策略调用终端或文件工具。
+- 已实现节点命令安全核心：节点绑定、能力版本、本地暂停、应用白名单、过期检查和幂等执行；出站连接与配对仍属于后续阶段。
 
 ## 环境要求
 
@@ -40,6 +41,7 @@ cp .env.example .env
 # 编辑 .env，填入 DEEPSEEK_API_KEY
 npm install
 npm run verify
+npm run verify:runtime
 npm start
 ```
 

--- a/src/node-command.ts
+++ b/src/node-command.ts
@@ -1,0 +1,182 @@
+import { commandDigest } from './approval.js'
+
+export type NodeCommandState = 'acknowledged' | 'running' | 'succeeded' | 'failed' | 'expired' | 'denied'
+
+export interface NodeCommand {
+  commandId: string
+  idempotencyKey: string
+  nodeId: string
+  capability: string
+  capabilityVersion: number
+  arguments: unknown
+  expiresAt: number
+}
+
+export interface NodeCommandOutcome {
+  commandId: string
+  idempotencyKey: string
+  capability: string
+  state: NodeCommandState
+  result?: unknown
+  error?: string
+}
+
+export interface NodeCapabilityPolicy {
+  enabled?: boolean
+  version: number
+  allowedApplications?: readonly string[]
+}
+
+export interface NodePolicyConfig {
+  capabilities: Readonly<Record<string, NodeCapabilityPolicy>>
+}
+
+export type NodeCommandTransition = {
+  command: NodeCommand
+  state: NodeCommandState
+}
+
+function applicationFromArguments(argumentsValue: unknown): string | undefined {
+  if (typeof argumentsValue !== 'object' || argumentsValue === null) return undefined
+  const application = Reflect.get(argumentsValue, 'application')
+  return typeof application === 'string' ? application : undefined
+}
+
+export class NodePolicy {
+  private paused = false
+
+  constructor(private readonly config: NodePolicyConfig) {}
+
+  setPaused(paused: boolean): void {
+    this.paused = paused
+  }
+
+  denial(command: NodeCommand): string | undefined {
+    if (this.paused) return 'node policy is paused'
+    const capability = this.config.capabilities[command.capability]
+    if (capability === undefined || capability.enabled === false) {
+      return `capability is not enabled: ${command.capability}`
+    }
+    if (capability.version !== command.capabilityVersion) {
+      return `capability version is not supported: ${command.capability}@${command.capabilityVersion}`
+    }
+    if (capability.allowedApplications !== undefined) {
+      const application = applicationFromArguments(command.arguments)
+      if (application === undefined || !capability.allowedApplications.includes(application)) {
+        return `application is not allowed for capability: ${String(application)}`
+      }
+    }
+    return undefined
+  }
+}
+
+type PendingCommand = {
+  command: NodeCommand
+  resolve: (outcome: NodeCommandOutcome) => void
+}
+
+type OutcomeRecord = {
+  fingerprint: string
+  promise: Promise<NodeCommandOutcome>
+}
+
+function commandFingerprint(command: NodeCommand): string {
+  return commandDigest({
+    nodeId: command.nodeId,
+    capability: command.capability,
+    capabilityVersion: command.capabilityVersion,
+    arguments: command.arguments,
+    expiresAt: command.expiresAt,
+  })
+}
+
+export class NodeCommandWorker {
+  private readonly outcomes = new Map<string, OutcomeRecord>()
+  private readonly queue: PendingCommand[] = []
+  private active = 0
+
+  constructor(
+    private readonly nodeId: string,
+    private readonly policy: NodePolicy,
+    private readonly execute: (command: NodeCommand) => Promise<unknown>,
+    private readonly now: () => number = Date.now,
+    private readonly maxConcurrency = 1,
+    private readonly onTransition?: (transition: NodeCommandTransition) => void,
+  ) {
+    if (maxConcurrency < 1 || !Number.isInteger(maxConcurrency)) {
+      throw new RangeError('maxConcurrency must be a positive integer')
+    }
+  }
+
+  dispatch(command: NodeCommand): Promise<NodeCommandOutcome> {
+    const fingerprint = commandFingerprint(command)
+    const existing = this.outcomes.get(command.idempotencyKey)
+    if (existing !== undefined) {
+      if (existing.fingerprint === fingerprint) return existing.promise
+      return Promise.resolve(this.finish(command, 'denied', 'idempotency key was reused for a different command'))
+    }
+
+    const denial = command.nodeId === this.nodeId
+      ? this.policy.denial(command)
+      : `command targets a different node: ${command.nodeId}`
+    if (denial !== undefined) {
+      const outcome = Promise.resolve(this.finish(command, 'denied', denial))
+      this.outcomes.set(command.idempotencyKey, { fingerprint, promise: outcome })
+      return outcome
+    }
+    if (command.expiresAt <= this.now()) {
+      const outcome = Promise.resolve(this.finish(command, 'expired'))
+      this.outcomes.set(command.idempotencyKey, { fingerprint, promise: outcome })
+      return outcome
+    }
+
+    let resolveOutcome!: (outcome: NodeCommandOutcome) => void
+    const outcome = new Promise<NodeCommandOutcome>(resolve => { resolveOutcome = resolve })
+    this.outcomes.set(command.idempotencyKey, { fingerprint, promise: outcome })
+    this.transition(command, 'acknowledged')
+    this.queue.push({ command, resolve: resolveOutcome })
+    this.pump()
+    return outcome
+  }
+
+  private pump(): void {
+    while (this.active < this.maxConcurrency && this.queue.length > 0) {
+      const pending = this.queue.shift()
+      if (pending === undefined) return
+      if (pending.command.expiresAt <= this.now()) {
+        pending.resolve(this.finish(pending.command, 'expired'))
+        continue
+      }
+      this.active += 1
+      this.transition(pending.command, 'running')
+      void this.execute(pending.command)
+        .then(result => pending.resolve(this.finish(pending.command, 'succeeded', undefined, result)))
+        .catch(error => pending.resolve(this.finish(pending.command, 'failed', String(error))))
+        .finally(() => {
+          this.active -= 1
+          this.pump()
+        })
+    }
+  }
+
+  private finish(
+    command: NodeCommand,
+    state: Exclude<NodeCommandState, 'acknowledged' | 'running'>,
+    error?: string,
+    result?: unknown,
+  ): NodeCommandOutcome {
+    this.transition(command, state)
+    return {
+      commandId: command.commandId,
+      idempotencyKey: command.idempotencyKey,
+      capability: command.capability,
+      state,
+      ...(result === undefined ? {} : { result }),
+      ...(error === undefined ? {} : { error }),
+    }
+  }
+
+  private transition(command: NodeCommand, state: NodeCommandState): void {
+    this.onTransition?.({ command, state })
+  }
+}

--- a/test/node-command.test.js
+++ b/test/node-command.test.js
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { NodeCommandWorker, NodePolicy } from '../dist/node-command.js'
+
+const policy = () => new NodePolicy({
+  capabilities: {
+    system_status: { version: 1 },
+    open_app: { version: 1, allowedApplications: ['notes'] },
+  },
+})
+
+const command = (overrides = {}) => ({
+  commandId: 'command-1',
+  idempotencyKey: 'idempotency-1',
+  nodeId: 'node-1',
+  capability: 'open_app',
+  capabilityVersion: 1,
+  arguments: { application: 'notes' },
+  expiresAt: 10_000,
+  ...overrides,
+})
+
+test('acknowledgement is distinct from terminal success and duplicate delivery executes once', async () => {
+  const transitions = []
+  let executions = 0
+  const worker = new NodeCommandWorker('node-1', policy(), async () => {
+    executions += 1
+    return { launched: true }
+  }, () => 1_000, 1, transition => transitions.push(transition.state))
+
+  const first = worker.dispatch(command())
+  const duplicate = worker.dispatch(command({ commandId: 'different-delivery' }))
+  assert.deepEqual(await first, {
+    commandId: 'command-1',
+    idempotencyKey: 'idempotency-1',
+    capability: 'open_app',
+    state: 'succeeded',
+    result: { launched: true },
+  })
+  assert.strictEqual(await duplicate, await first)
+  assert.equal(executions, 1)
+  assert.deepEqual(transitions, ['acknowledged', 'running', 'succeeded'])
+})
+
+test('expired queued command never reaches the executor', async () => {
+  let now = 1_000
+  let releaseFirst
+  const firstStarted = new Promise(resolve => { releaseFirst = resolve })
+  let executions = 0
+  const worker = new NodeCommandWorker('node-1', policy(), async () => {
+    executions += 1
+    if (executions === 1) await firstStarted
+    return true
+  }, () => now, 1)
+
+  const first = worker.dispatch(command())
+  const second = worker.dispatch(command({ commandId: 'command-2', idempotencyKey: 'idempotency-2', expiresAt: 1_500 }))
+  now = 2_000
+  releaseFirst()
+  assert.equal((await first).state, 'succeeded')
+  assert.equal((await second).state, 'expired')
+  assert.equal(executions, 1)
+})
+
+test('local policy denies wrong node, unsupported capability version, and application', async () => {
+  const executed = []
+  const worker = new NodeCommandWorker('node-1', policy(), async input => {
+    executed.push(input)
+    return true
+  }, () => 1_000)
+  assert.equal((await worker.dispatch(command({ nodeId: 'node-2' }))).state, 'denied')
+  assert.equal((await worker.dispatch(command({ idempotencyKey: 'version', capabilityVersion: 2 }))).state, 'denied')
+  assert.equal((await worker.dispatch(command({ idempotencyKey: 'app', arguments: { application: 'terminal' } }))).state, 'denied')
+  assert.equal(executed.length, 0)
+})
+
+test('idempotency key cannot be reused with changed command data', async () => {
+  let executions = 0
+  const worker = new NodeCommandWorker('node-1', policy(), async () => {
+    executions += 1
+    return true
+  }, () => 1_000)
+  const first = worker.dispatch(command())
+  const changed = await worker.dispatch(command({ arguments: { application: 'terminal' } }))
+  assert.equal(changed.state, 'denied')
+  assert.match(changed.error ?? '', /different command/)
+  assert.equal((await first).state, 'succeeded')
+  assert.equal(executions, 1)
+})
+
+test('emergency pause applies to new commands', async () => {
+  const localPolicy = policy()
+  localPolicy.setPaused(true)
+  const worker = new NodeCommandWorker('node-1', localPolicy, async () => true, () => 1_000)
+  assert.equal((await worker.dispatch(command())).state, 'denied')
+})


### PR DESCRIPTION
## Summary
- add node-bound, versioned local capability policy
- add emergency pause, expiry, bounded concurrency, and terminal outcomes
- bind idempotency keys to exact command data and prove duplicate delivery is single-execution

## Scope
This is the first implementation slice for #3. It does not add a network listener, pairing, credentials, or arbitrary shell execution.

## Verification
- `npm run verify` (13 tests)
- `npm run verify:runtime`

Related to #3; does not close the complete outbound node-agent issue.