### PR TITLE
Add loopback authenticated gateway core

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - 已实现 macOS Keychain 凭据存储层；写入通过 `security` 标准输入完成，凭据不进入命令参数、普通文件或日志。
 - Node Agent 支持异步凭据提供器；每次启动读取当前凭据，停止时清除内存副本。
 - 已实现配对协议核心：Ed25519 设备身份、短期单次验证码、凭据轮换和撤销；Gateway/API 接入仍未开放。
+- 已实现 loopback-only `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销和请求 correlation ID；未绑定公网。
 
 ## 环境要求
 
@@ -64,6 +65,14 @@ npm start
 应用启动会停在 Harness 的审批界面，只有点击允许后才执行。白名单位于 `config/apps.json`，修改后需要重启。
 
 ## 后台启动
+
+Gateway 原型单独启动，必须通过环境变量提供 Owner Token：
+
+```bash
+JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:gateway
+```
+
+它只监听 `127.0.0.1:3090`，当前设备状态保存在内存中，不是可直接暴露给手机的生产 Gateway；正式远程访问还需要持久化、TLS/private overlay、WebSocket 事件和限流。
 
 确认前台运行正常后执行：
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && node --test test/*.test.js",
     "start": "./scripts/start-mac.sh",
+    "start:gateway": "./scripts/start-gateway.sh",
     "verify": "npm run typecheck && npm test",
     "verify:runtime": "./scripts/verify-local-runtime.sh"
   },

--- a/scripts/start-gateway.sh
+++ b/scripts/start-gateway.sh
@@ -1,0 +1,17 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -z "${JARVIS_OWNER_TOKEN:-}" ]]; then
+  print -u2 'JARVIS_OWNER_TOKEN is required and must not be committed.'
+  exit 1
+fi
+
+if [[ ! -d node_modules || ! -f dist/gateway-main.js ]]; then
+  "${NPM_BIN:-npm}" install
+  "${NPM_BIN:-npm}" run build
+fi
+
+exec node dist/gateway-main.js

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -1,0 +1,21 @@
+import { createJarvisGateway } from './gateway.js'
+
+const ownerToken = process.env.JARVIS_OWNER_TOKEN
+if (ownerToken === undefined) throw new Error('JARVIS_OWNER_TOKEN is required')
+
+const configuredPort = process.env.JARVIS_GATEWAY_PORT === undefined ? 3090 : Number(process.env.JARVIS_GATEWAY_PORT)
+if (!Number.isInteger(configuredPort) || configuredPort < 0 || configuredPort > 65_535) {
+  throw new Error('JARVIS_GATEWAY_PORT must be an integer from 0 to 65535')
+}
+
+const gateway = createJarvisGateway({ ownerToken })
+const running = await gateway.start(configuredPort)
+console.log(`Jarvis Gateway listening on 127.0.0.1:${running.port}`)
+
+async function stop(): Promise<void> {
+  await gateway.stop()
+  process.exit(0)
+}
+
+process.once('SIGINT', () => { void stop() })
+process.once('SIGTERM', () => { void stop() })

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,0 +1,184 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { randomUUID, timingSafeEqual } from 'node:crypto'
+import { PairingAuthority } from './pairing.js'
+
+const MAX_BODY_BYTES = 32 * 1024
+
+export interface JarvisGatewayOptions {
+  ownerToken: string
+  authority?: PairingAuthority
+  maxBodyBytes?: number
+}
+
+export interface RunningGateway {
+  server: Server
+  port: number
+}
+
+function sameSecret(expected: string, actual: string | undefined): boolean {
+  if (actual === undefined) return false
+  const left = Buffer.from(expected, 'utf8')
+  const right = Buffer.from(actual, 'utf8')
+  return left.length === right.length && timingSafeEqual(left, right)
+}
+
+function requestCorrelationId(request: IncomingMessage): string {
+  const supplied = request.headers['x-correlation-id']
+  if (typeof supplied === 'string' && /^[A-Za-z0-9._:-]{1,128}$/.test(supplied)) return supplied
+  return randomUUID()
+}
+
+function sendJson(response: ServerResponse, status: number, correlationId: string, value: unknown): void {
+  if (status === 204) {
+    response.writeHead(status, { 'x-correlation-id': correlationId })
+    response.end()
+    return
+  }
+  const body = JSON.stringify(value)
+  response.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+    'x-correlation-id': correlationId,
+  })
+  response.end(body)
+}
+
+function bearerToken(request: IncomingMessage, scheme: 'Bearer' | 'Device'): string | undefined {
+  const value = request.headers.authorization
+  const prefix = `${scheme} `
+  return typeof value === 'string' && value.startsWith(prefix) ? value.slice(prefix.length) : undefined
+}
+
+async function readJson(request: IncomingMessage, maxBytes: number): Promise<unknown> {
+  const chunks: Buffer[] = []
+  let size = 0
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    size += buffer.length
+    if (size > maxBytes) throw new Error('request body is too large')
+    chunks.push(buffer)
+  }
+  if (size === 0) return {}
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+  } catch {
+    throw new Error('request body must be valid JSON')
+  }
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function routeParts(request: IncomingMessage): string[] {
+  const parsed = new URL(request.url ?? '/', 'http://127.0.0.1')
+  return parsed.pathname.split('/').filter(Boolean)
+}
+
+export function createJarvisGateway(options: JarvisGatewayOptions): {
+  start(port?: number): Promise<RunningGateway>
+  stop(): Promise<void>
+} {
+  if (options.ownerToken.length < 16) throw new Error('ownerToken must contain at least 16 characters')
+  const authority = options.authority ?? new PairingAuthority()
+  const maxBodyBytes = options.maxBodyBytes ?? MAX_BODY_BYTES
+  if (!Number.isInteger(maxBodyBytes) || maxBodyBytes < 1) throw new RangeError('maxBodyBytes must be positive')
+  let server: Server | undefined
+
+  const handle = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
+    const correlationId = requestCorrelationId(request)
+    const parts = routeParts(request)
+    try {
+      if (request.method === 'GET' && parts.length === 2 && parts[0] === 'v1' && parts[1] === 'health') {
+        sendJson(response, 200, correlationId, { service: 'jarvis-gateway', status: 'ok', scope: 'loopback-only' })
+        return
+      }
+      const ownerAuthenticated = sameSecret(options.ownerToken, bearerToken(request, 'Bearer'))
+      const deviceCredential = bearerToken(request, 'Device')
+      if (parts[0] !== 'v1' || (!ownerAuthenticated && deviceCredential === undefined)) {
+        sendJson(response, 401, correlationId, { error: 'authentication required', correlationId })
+        return
+      }
+      if (request.method === 'POST' && parts.length === 3 && parts[1] === 'pairing' && parts[2] === 'requests') {
+        if (!ownerAuthenticated) {
+          sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
+          return
+        }
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body)) throw new Error('pairing request body must be an object')
+        const requestValue = authority.createRequest({
+          nodeId: body.nodeId as string,
+          publicKey: body.publicKey as string,
+          displayName: body.displayName as string,
+          platform: body.platform as 'macos',
+        })
+        sendJson(response, 201, correlationId, requestValue)
+        return
+      }
+      if (request.method === 'POST' && parts.length === 4 && parts[1] === 'pairing' && parts[2] === 'requests' && parts[3] === 'confirm') {
+        if (!ownerAuthenticated) {
+          sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
+          return
+        }
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || typeof body.requestId !== 'string' || typeof body.verificationCode !== 'string') {
+          throw new Error('pairing confirmation body is invalid')
+        }
+        sendJson(response, 200, correlationId, authority.confirm(body.requestId, body.verificationCode))
+        return
+      }
+      if (parts.length === 3 && parts[1] === 'devices' && typeof parts[2] === 'string') {
+        const nodeId = parts[2]
+        if (request.method === 'POST' && parts.length === 3 && parts[2] === nodeId) {
+          if (deviceCredential === undefined) {
+            sendJson(response, 401, correlationId, { error: 'device authentication required', correlationId })
+            return
+          }
+          sendJson(response, 200, correlationId, authority.rotate(nodeId, deviceCredential))
+          return
+        }
+        if (request.method === 'DELETE' && parts.length === 3 && parts[2] === nodeId) {
+          if (!ownerAuthenticated) {
+            sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
+            return
+          }
+          if (!authority.revoke(nodeId)) {
+            sendJson(response, 404, correlationId, { error: 'device not found or already revoked', correlationId })
+            return
+          }
+          sendJson(response, 204, correlationId, {})
+          return
+        }
+      }
+      sendJson(response, 404, correlationId, { error: 'route not found', correlationId })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'request failed'
+      const status = message.includes('too large') ? 413 : 400
+      sendJson(response, status, correlationId, { error: message, correlationId })
+    }
+  }
+
+  return {
+    start(port = 0) {
+      if (server !== undefined) return Promise.reject(new Error('gateway is already running'))
+      server = createServer((request, response) => { void handle(request, response) })
+      return new Promise<RunningGateway>((resolve, reject) => {
+        server?.once('error', reject)
+        server?.listen(port, '127.0.0.1', () => {
+          const address = server?.address()
+          if (address === null || typeof address === 'string' || address === undefined) {
+            reject(new Error('gateway did not expose a TCP address'))
+            return
+          }
+          resolve({ server: server as Server, port: address.port })
+        })
+      })
+    },
+    stop() {
+      if (server === undefined) return Promise.resolve()
+      const current = server
+      server = undefined
+      return new Promise<void>((resolve, reject) => current.close(error => error === undefined ? resolve() : reject(error)))
+    },
+  }
+}

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createJarvisGateway } from '../dist/gateway.js'
+import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
+
+const ownerToken = 'owner-token-for-gateway-tests'
+
+async function request(gateway, path, options = {}) {
+  return fetch(`http://127.0.0.1:${gateway.port}${path}`, options)
+}
+
+test('serves loopback health and protects versioned routes with owner auth', async () => {
+  const service = createJarvisGateway({ ownerToken })
+  const gateway = await service.start()
+  try {
+    assert.equal(new URL(`http://127.0.0.1:${gateway.port}`).hostname, '127.0.0.1')
+    const health = await request(gateway, '/v1/health')
+    assert.equal(health.status, 200)
+    assert.equal((await health.json()).scope, 'loopback-only')
+    const unauthorized = await request(gateway, '/v1/pairing/requests', { method: 'POST' })
+    assert.equal(unauthorized.status, 401)
+    assert.match(unauthorized.headers.get('x-correlation-id') ?? '', /^[0-9a-f-]{36}$/)
+  } finally {
+    await service.stop()
+  }
+})
+
+test('runs authenticated pairing, device rotation, and owner revocation over versioned HTTP', async () => {
+  const authority = new PairingAuthority(() => 1_000, 60_000)
+  const service = createJarvisGateway({ ownerToken, authority })
+  const gateway = await service.start()
+  try {
+    const identity = createDeviceIdentity()
+    const headers = { authorization: `Bearer ${ownerToken}`, 'content-type': 'application/json' }
+    const created = await request(gateway, '/v1/pairing/requests', {
+      method: 'POST', headers, body: JSON.stringify({
+        nodeId: 'node-1', publicKey: identity.publicKey, displayName: 'Test Mac', platform: 'macos',
+      }),
+    })
+    assert.equal(created.status, 201)
+    const pairing = await created.json()
+    const confirmed = await request(gateway, '/v1/pairing/requests/confirm', {
+      method: 'POST', headers, body: JSON.stringify({ requestId: pairing.requestId, verificationCode: pairing.verificationCode }),
+    })
+    assert.equal(confirmed.status, 200)
+    const first = await confirmed.json()
+    const rotated = await request(gateway, '/v1/devices/node-1', {
+      method: 'POST', headers: { authorization: `Device ${first.credential}` },
+    })
+    assert.equal(rotated.status, 200)
+    const second = await rotated.json()
+    assert.equal(authority.authenticate('node-1', first.credential), false)
+    assert.equal(authority.authenticate('node-1', second.credential), true)
+    const revoked = await request(gateway, '/v1/devices/node-1', { method: 'DELETE', headers: { authorization: `Bearer ${ownerToken}` } })
+    assert.equal(revoked.status, 204)
+    assert.equal(authority.authenticate('node-1', second.credential), false)
+    const rejectedRotation = await request(gateway, '/v1/devices/node-1', {
+      method: 'POST', headers: { authorization: `Device ${second.credential}` },
+    })
+    assert.equal(rejectedRotation.status, 400)
+  } finally {
+    await service.stop()
+  }
+})
+
+test('rejects oversized and malformed requests without exposing secrets', async () => {
+  const service = createJarvisGateway({ ownerToken, maxBodyBytes: 32 })
+  const gateway = await service.start()
+  try {
+    const response = await request(gateway, '/v1/pairing/requests', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${ownerToken}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ value: 'this body is larger than thirty two bytes' }),
+    })
+    assert.equal(response.status, 413)
+    assert.doesNotMatch(await response.text(), /owner-token-for-gateway-tests/)
+  } finally {
+    await service.stop()
+  }
+})


### PR DESCRIPTION
## Summary
- add a loopback-only versioned `/v1` HTTP Gateway
- separate Owner Bearer and Device Credential authentication
- expose pairing confirmation, device rotation, revocation, health, correlation IDs, and body limits
- add a guarded `start:gateway` entry requiring `JARVIS_OWNER_TOKEN`

## Scope
First Gateway slice for #10. The process does not proxy Harness, persist device state, expose WebSocket events, provide TLS/private-overlay ingress, or bind beyond `127.0.0.1`.

## Verification
- `npm run verify` (40 tests)
- `npm run verify:runtime`
- real Gateway process smoke on a loopback dynamic port

Related to #10, #3, and #13; does not close any issue.