### PR TITLE
Persist gateway pairing state atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Gateway 原型单独启动，必须通过环境变量提供 Owner Token：
 JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:gateway
 ```
 
-它只监听 `127.0.0.1:3090`，当前设备状态保存在内存中，不是可直接暴露给手机的生产 Gateway；正式远程访问还需要持久化、TLS/private overlay、WebSocket 事件和限流。
+它只监听 `127.0.0.1:3090`，配对状态默认原子写入未纳入 Git 的 `data/pairing-state.json`；当前仍不是可直接暴露给手机的生产 Gateway，正式远程访问还需要 TLS/private overlay、WebSocket 事件和限流。
 
 确认前台运行正常后执行：
 

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -1,4 +1,5 @@
 import { createJarvisGateway } from './gateway.js'
+import { join } from 'node:path'
 
 const ownerToken = process.env.JARVIS_OWNER_TOKEN
 if (ownerToken === undefined) throw new Error('JARVIS_OWNER_TOKEN is required')
@@ -8,7 +9,9 @@ if (!Number.isInteger(configuredPort) || configuredPort < 0 || configuredPort > 
   throw new Error('JARVIS_GATEWAY_PORT must be an integer from 0 to 65535')
 }
 
-const gateway = createJarvisGateway({ ownerToken })
+const statePath = process.env.JARVIS_PAIRING_STATE
+  ?? join(process.env.JARVIS_DATA_DIR ?? join(process.cwd(), 'data'), 'pairing-state.json')
+const gateway = createJarvisGateway({ ownerToken, pairingStatePath: statePath })
 const running = await gateway.start(configuredPort)
 console.log(`Jarvis Gateway listening on 127.0.0.1:${running.port}`)
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,12 +1,13 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { randomUUID, timingSafeEqual } from 'node:crypto'
-import { PairingAuthority } from './pairing.js'
+import { FilePairingStateStore, PairingAuthority } from './pairing.js'
 
 const MAX_BODY_BYTES = 32 * 1024
 
 export interface JarvisGatewayOptions {
   ownerToken: string
   authority?: PairingAuthority
+  pairingStatePath?: string
   maxBodyBytes?: number
 }
 
@@ -80,7 +81,11 @@ export function createJarvisGateway(options: JarvisGatewayOptions): {
   stop(): Promise<void>
 } {
   if (options.ownerToken.length < 16) throw new Error('ownerToken must contain at least 16 characters')
-  const authority = options.authority ?? new PairingAuthority()
+  const authority = options.authority ?? new PairingAuthority(
+    undefined,
+    undefined,
+    options.pairingStatePath === undefined ? undefined : new FilePairingStateStore(options.pairingStatePath),
+  )
   const maxBodyBytes = options.maxBodyBytes ?? MAX_BODY_BYTES
   if (!Number.isInteger(maxBodyBytes) || maxBodyBytes < 1) throw new RangeError('maxBodyBytes must be positive')
   let server: Server | undefined

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -1,4 +1,6 @@
 import { createHash, generateKeyPairSync, randomBytes, randomInt, timingSafeEqual } from 'node:crypto'
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
 
 export const DEFAULT_PAIRING_TTL_MS = 5 * 60_000
 
@@ -29,6 +31,24 @@ export interface IssuedCredential {
   issuedAt: number
 }
 
+export interface PairingStateSnapshot {
+  version: 1
+  requests: Array<PairingRequest & { used: boolean }>
+  devices: Array<{
+    nodeId: string
+    publicKey: string
+    credentialDigest: string
+    generation: number
+    issuedAt: number
+    revoked: boolean
+  }>
+}
+
+export interface PairingStateStore {
+  load(): PairingStateSnapshot | undefined
+  save(snapshot: PairingStateSnapshot): void
+}
+
 interface CredentialRecord {
   nodeId: string
   publicKey: string
@@ -40,6 +60,28 @@ interface CredentialRecord {
 
 interface PendingPairing extends PairingRequest {
   used: boolean
+}
+
+export class FilePairingStateStore implements PairingStateStore {
+  constructor(readonly path: string) {}
+
+  load(): PairingStateSnapshot | undefined {
+    try {
+      return JSON.parse(readFileSync(this.path, 'utf8')) as PairingStateSnapshot
+    } catch (error: unknown) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return undefined
+      throw new Error('pairing state could not be read')
+    }
+  }
+
+  save(snapshot: PairingStateSnapshot): void {
+    mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 })
+    const temporary = `${this.path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
+    writeFileSync(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    chmodSync(temporary, 0o600)
+    renameSync(temporary, this.path)
+    chmodSync(this.path, 0o600)
+  }
 }
 
 function validateIdentifier(value: string, field: string): string {
@@ -90,10 +132,12 @@ export class PairingAuthority {
   constructor(
     private readonly now: () => number = Date.now,
     private readonly pairingTtlMs = DEFAULT_PAIRING_TTL_MS,
+    private readonly store?: PairingStateStore,
   ) {
     if (!Number.isInteger(pairingTtlMs) || pairingTtlMs < 1_000) {
       throw new RangeError('pairingTtlMs must be at least one second')
     }
+    this.restore(this.store?.load())
   }
 
   createRequest(input: PairingRequestInput): PairingRequest {
@@ -112,6 +156,7 @@ export class PairingAuthority {
       used: false,
     }
     this.requests.set(request.requestId, request)
+    this.persist()
     return { ...request }
   }
 
@@ -144,7 +189,66 @@ export class PairingAuthority {
     const record = this.devices.get(nodeId)
     if (record === undefined || record.revoked) return false
     record.revoked = true
+    this.persist()
     return true
+  }
+
+  private persist(): void {
+    this.store?.save({
+      version: 1,
+      requests: [...this.requests.values()].map(request => ({ ...request })),
+      devices: [...this.devices.values()].map(device => ({
+        nodeId: device.nodeId,
+        publicKey: device.publicKey,
+        credentialDigest: device.credentialDigest.toString('base64url'),
+        generation: device.generation,
+        issuedAt: device.issuedAt,
+        revoked: device.revoked,
+      })),
+    })
+  }
+
+  private restore(snapshot: PairingStateSnapshot | undefined): void {
+    if (snapshot === undefined) return
+    if (snapshot.version !== 1 || !Array.isArray(snapshot.requests) || !Array.isArray(snapshot.devices)) {
+      throw new Error('pairing state has an unsupported format')
+    }
+    for (const request of snapshot.requests) {
+      if (typeof request.requestId !== 'string' || !/^[A-Za-z0-9_-]{16,64}$/.test(request.requestId)
+        || typeof request.verificationCode !== 'string' || !/^\d{6}$/.test(request.verificationCode)
+        || typeof request.expiresAt !== 'number' || !Number.isFinite(request.expiresAt)
+        || typeof request.used !== 'boolean') throw new Error('pairing state contains an invalid request')
+      const restored: PendingPairing = {
+        requestId: request.requestId,
+        nodeId: validateIdentifier(request.nodeId, 'nodeId'),
+        publicKey: validatePublicKey(request.publicKey),
+        displayName: validateText(request.displayName, 'displayName'),
+        platform: request.platform,
+        verificationCode: request.verificationCode,
+        expiresAt: request.expiresAt,
+        used: request.used,
+      }
+      if (restored.platform !== 'macos') throw new Error('pairing state contains an unsupported platform')
+      if (this.requests.has(restored.requestId)) throw new Error('pairing state contains duplicate requests')
+      this.requests.set(restored.requestId, restored)
+    }
+    for (const device of snapshot.devices) {
+      if (typeof device.credentialDigest !== 'string' || typeof device.generation !== 'number'
+        || !Number.isInteger(device.generation) || device.generation < 1
+        || typeof device.issuedAt !== 'number' || !Number.isFinite(device.issuedAt)
+        || typeof device.revoked !== 'boolean') throw new Error('pairing state contains an invalid device')
+      const digest = Buffer.from(device.credentialDigest, 'base64url')
+      const restored: CredentialRecord = {
+        nodeId: validateIdentifier(device.nodeId, 'nodeId'),
+        publicKey: validatePublicKey(device.publicKey),
+        credentialDigest: digest,
+        generation: device.generation,
+        issuedAt: device.issuedAt,
+        revoked: device.revoked,
+      }
+      if (digest.length !== 32 || this.devices.has(restored.nodeId)) throw new Error('pairing state contains duplicate or invalid devices')
+      this.devices.set(restored.nodeId, restored)
+    }
   }
 
   private requireAuthenticated(nodeId: string, credential: string): CredentialRecord {
@@ -166,6 +270,7 @@ export class PairingAuthority {
       issuedAt,
       revoked: false,
     })
+    this.persist()
     return { nodeId, publicKey, credential, generation, issuedAt }
   }
 }

--- a/test/pairing.test.js
+++ b/test/pairing.test.js
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
-import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
+import { FilePairingStateStore, PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
 
 const requestInput = (identity, overrides = {}) => ({
   nodeId: 'node-1',
@@ -84,6 +87,30 @@ test('revocation blocks current and future authentication', () => {
   assert.equal(authority.authenticate('node-1', issued.credential), false)
   assert.equal(authority.revoke('node-1'), false)
   assert.throws(() => authority.rotate('node-1', issued.credential), /invalid or revoked/)
+})
+
+test('persists credential digests and revocation across authority restart', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-pairing-'))
+  try {
+    const path = join(directory, 'pairing-state.json')
+    const identity = createDeviceIdentity()
+    const firstAuthority = new PairingAuthority(() => 1_000, 60_000, new FilePairingStateStore(path))
+    const request = firstAuthority.createRequest(requestInput(identity))
+    const issued = firstAuthority.confirm(request.requestId, request.verificationCode)
+    const stored = await readFile(path, 'utf8')
+    assert.doesNotMatch(stored, new RegExp(issued.credential))
+    assert.equal((await stat(path)).mode & 0o777, 0o600)
+
+    const restarted = new PairingAuthority(() => 1_000, 60_000, new FilePairingStateStore(path))
+    assert.equal(restarted.authenticate('node-1', issued.credential), true)
+    assert.throws(() => restarted.confirm(request.requestId, request.verificationCode), /already been used/)
+    assert.equal(restarted.revoke('node-1'), true)
+
+    const restoredAgain = new PairingAuthority(() => 1_000, 60_000, new FilePairingStateStore(path))
+    assert.equal(restoredAgain.authenticate('node-1', issued.credential), false)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 })
 
 test('rejects unsafe pairing data and unsupported platforms', () => {


### PR DESCRIPTION
## Summary
- persist pairing requests, public keys, credential digests, generations, and revocation state
- write atomically with a private directory and `0600` state file
- restore used requests and revoked devices across Gateway restart
- default the Gateway process to untracked `data/pairing-state.json`

## Safety
Raw device credentials and private keys are never written to the state file. The file remains local and untracked.

## Verification
- `npm run verify` (41 tests)
- `npm run verify:runtime`
- restart persistence, raw credential absence, and file mode assertions

Related to #10 and #13; does not close either issue.