### PR TITLE
Connect node agent to authenticated Gateway WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@
 - 记录追加式操作审计，提醒和审计文件权限为 `0600`。
 - 默认只监听 `127.0.0.1`，并关闭 Harness 遥测。
 - 单调拒绝非 Jarvis 工具，模型不能绕过策略调用终端或文件工具。
-- 已实现节点命令安全核心：节点绑定、能力版本、本地暂停、应用白名单、过期检查和幂等执行；出站连接与配对仍属于后续阶段。
+- 已实现节点命令安全核心：节点绑定、能力版本、本地暂停、应用白名单、过期检查和幂等执行。
 - 已实现版本化 Mac 能力注册协议；未知能力、版本变更和异常注册字段会被拒绝。
-- 已实现仅主动发起的 `wss://` 节点 Agent 原型；认证、注册、断线重连和命令去重已覆盖，正式配对与 Keychain 凭据仍未开放。
+- 已实现仅主动发起的 `wss://` 节点 Agent 原型；认证、注册、断线重连、命令去重和 Keychain 凭据读取已覆盖。
 - 已实现 macOS Keychain 凭据存储层；写入通过 `security` 标准输入完成，凭据不进入命令参数、普通文件或日志。
 - Node Agent 支持异步凭据提供器；每次启动读取当前凭据，停止时清除内存副本。
-- 已实现配对协议核心：Ed25519 设备身份、短期单次验证码、凭据轮换和撤销；Gateway/API 接入仍未开放。
-- 已实现 loopback-only `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销和请求 correlation ID；未绑定公网。
+- 已实现配对协议核心及 Gateway API：Ed25519 设备身份、短期单次验证码、凭据轮换、撤销和原子状态持久化。
+- 已实现 loopback-only `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销、请求 correlation ID，以及 `/v1/node` WebSocket 的认证、能力注册和在线连接管理；未绑定公网。
 
 ## 环境要求
 
@@ -72,7 +72,7 @@ Gateway 原型单独启动，必须通过环境变量提供 Owner Token：
 JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:gateway
 ```
 
-它只监听 `127.0.0.1:3090`，配对状态默认原子写入未纳入 Git 的 `data/pairing-state.json`；当前仍不是可直接暴露给手机的生产 Gateway，正式远程访问还需要 TLS/private overlay、WebSocket 事件和限流。
+它只监听 `127.0.0.1:3090`，配对状态默认原子写入未纳入 Git 的 `data/pairing-state.json`。节点 WebSocket 同样只接受 loopback 上的 `/v1/node`，并限制消息大小、握手时间和连接数。当前仍不是可直接暴露给手机的生产 Gateway；正式远程访问还需要 TLS/private overlay、外部用户认证与限流，以及可从游标恢复的会话事件。
 
 确认前台运行正常后执行：
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
         "@deepseek-ai/cordis": "4.0.1",
         "@deepseek-ai/dsh": "0.1.0-rc.6",
         "@deepseek-ai/dsh-host-webserver": "0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "0.1.0-rc.6"
+        "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+        "ws": "8.21.3"
       },
       "devDependencies": {
         "@types/node": "24.13.3",
+        "@types/ws": "8.18.1",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -5634,6 +5636,16 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "@deepseek-ai/cordis": "4.0.1",
     "@deepseek-ai/dsh": "0.1.0-rc.6",
     "@deepseek-ai/dsh-host-webserver": "0.1.0-rc.6",
-    "@deepseek-ai/dsh-tools": "0.1.0-rc.6"
+    "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+    "ws": "8.21.3"
   },
   "devDependencies": {
     "@types/node": "24.13.3",
+    "@types/ws": "8.18.1",
     "typescript": "6.0.3"
   }
 }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,19 +1,42 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { randomUUID, timingSafeEqual } from 'node:crypto'
+import { WebSocket, WebSocketServer, type RawData } from 'ws'
+import { NODE_PROTOCOL_VERSION, parseNodeRegistration, type NodeRegistration } from './node-capabilities.js'
+import type { NodeCommand } from './node-command.js'
 import { FilePairingStateStore, PairingAuthority } from './pairing.js'
 
 const MAX_BODY_BYTES = 32 * 1024
+const NODE_PATH = '/v1/node'
+const NODE_HANDSHAKE_TIMEOUT_MS = 10_000
+const MAX_NODE_CONNECTIONS = 128
 
 export interface JarvisGatewayOptions {
   ownerToken: string
   authority?: PairingAuthority
   pairingStatePath?: string
   maxBodyBytes?: number
+  nodeHandshakeTimeoutMs?: number
+  maxNodeConnections?: number
 }
 
 export interface RunningGateway {
   server: Server
   port: number
+}
+
+export interface JarvisGateway {
+  start(port?: number): Promise<RunningGateway>
+  stop(): Promise<void>
+  connectedNodeIds(): readonly string[]
+  dispatchCommand(command: NodeCommand): boolean
+}
+
+interface NodeConnectionState {
+  phase: 'authenticate' | 'register' | 'ready'
+  correlationId: string
+  nodeId?: string
+  registration?: NodeRegistration
+  handshakeTimer: ReturnType<typeof setTimeout>
 }
 
 function sameSecret(expected: string, actual: string | undefined): boolean {
@@ -71,15 +94,33 @@ function record(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function parseSocketMessage(data: RawData, isBinary: boolean): Record<string, unknown> | undefined {
+  if (isBinary) return undefined
+  try {
+    const value: unknown = JSON.parse(data.toString())
+    return record(value) ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function sendSocket(socket: WebSocket, message: Record<string, unknown>): boolean {
+  if (socket.readyState !== WebSocket.OPEN) return false
+  socket.send(JSON.stringify(message))
+  return true
+}
+
+function rejectUpgrade(socket: import('node:stream').Duplex, status: 403 | 404 | 503): void {
+  const reason = status === 403 ? 'Forbidden' : status === 404 ? 'Not Found' : 'Service Unavailable'
+  socket.end(`HTTP/1.1 ${status} ${reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`)
+}
+
 function routeParts(request: IncomingMessage): string[] {
   const parsed = new URL(request.url ?? '/', 'http://127.0.0.1')
   return parsed.pathname.split('/').filter(Boolean)
 }
 
-export function createJarvisGateway(options: JarvisGatewayOptions): {
-  start(port?: number): Promise<RunningGateway>
-  stop(): Promise<void>
-} {
+export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGateway {
   if (options.ownerToken.length < 16) throw new Error('ownerToken must contain at least 16 characters')
   const authority = options.authority ?? new PairingAuthority(
     undefined,
@@ -88,7 +129,106 @@ export function createJarvisGateway(options: JarvisGatewayOptions): {
   )
   const maxBodyBytes = options.maxBodyBytes ?? MAX_BODY_BYTES
   if (!Number.isInteger(maxBodyBytes) || maxBodyBytes < 1) throw new RangeError('maxBodyBytes must be positive')
+  const nodeHandshakeTimeoutMs = options.nodeHandshakeTimeoutMs ?? NODE_HANDSHAKE_TIMEOUT_MS
+  if (!Number.isInteger(nodeHandshakeTimeoutMs) || nodeHandshakeTimeoutMs < 1) {
+    throw new RangeError('nodeHandshakeTimeoutMs must be a positive integer')
+  }
+  const maxNodeConnections = options.maxNodeConnections ?? MAX_NODE_CONNECTIONS
+  if (!Number.isInteger(maxNodeConnections) || maxNodeConnections < 1) {
+    throw new RangeError('maxNodeConnections must be a positive integer')
+  }
   let server: Server | undefined
+  let socketServer: WebSocketServer | undefined
+  const nodeConnections = new Map<string, WebSocket>()
+  const connectionStates = new Map<WebSocket, NodeConnectionState>()
+
+  const rejectNode = (socket: WebSocket, reason: string): void => {
+    const state = connectionStates.get(socket)
+    if (state !== undefined) clearTimeout(state.handshakeTimer)
+    if (socket.readyState !== WebSocket.OPEN) {
+      socket.terminate()
+      return
+    }
+    socket.send(JSON.stringify({
+      type: 'node.rejected',
+      reason,
+      correlationId: state?.correlationId ?? randomUUID(),
+    }), () => socket.close(1008, reason))
+  }
+
+  const disconnectNode = (nodeId: string, reason: string): void => {
+    const socket = nodeConnections.get(nodeId)
+    if (socket !== undefined) rejectNode(socket, reason)
+  }
+
+  const handleNodeMessage = (socket: WebSocket, data: RawData, isBinary: boolean): void => {
+    const state = connectionStates.get(socket)
+    if (state === undefined) return
+    const message = parseSocketMessage(data, isBinary)
+    if (message === undefined || typeof message.type !== 'string') {
+      rejectNode(socket, 'invalid node message')
+      return
+    }
+    if (state.phase === 'authenticate') {
+      if (message.type !== 'node.authenticate'
+        || message.protocolVersion !== NODE_PROTOCOL_VERSION
+        || typeof message.nodeId !== 'string'
+        || typeof message.credential !== 'string'
+        || !authority.authenticate(message.nodeId, message.credential)) {
+        rejectNode(socket, 'node authentication rejected')
+        return
+      }
+      state.nodeId = message.nodeId
+      state.phase = 'register'
+      sendSocket(socket, { type: 'node.authenticated', correlationId: state.correlationId })
+      return
+    }
+    if (state.phase === 'register') {
+      if (message.type !== 'node.register') {
+        rejectNode(socket, 'node registration required')
+        return
+      }
+      try {
+        const registration = parseNodeRegistration(message.registration)
+        if (registration.nodeId !== state.nodeId) throw new Error('registration node identity does not match')
+        const previous = nodeConnections.get(registration.nodeId)
+        state.registration = registration
+        state.phase = 'ready'
+        clearTimeout(state.handshakeTimer)
+        nodeConnections.set(registration.nodeId, socket)
+        if (previous !== undefined && previous !== socket) rejectNode(previous, 'node connection replaced')
+        sendSocket(socket, { type: 'node.ready', correlationId: state.correlationId })
+      } catch {
+        rejectNode(socket, 'node registration rejected')
+      }
+      return
+    }
+    if (message.type !== 'command.acknowledged'
+      && message.type !== 'command.running'
+      && message.type !== 'command.outcome'
+      && message.type !== 'node.error') {
+      rejectNode(socket, 'unsupported node message')
+    }
+  }
+
+  const handleNodeConnection = (socket: WebSocket): void => {
+    const state: NodeConnectionState = {
+      phase: 'authenticate',
+      correlationId: randomUUID(),
+      handshakeTimer: setTimeout(() => rejectNode(socket, 'node handshake timed out'), nodeHandshakeTimeoutMs),
+    }
+    state.handshakeTimer.unref()
+    connectionStates.set(socket, state)
+    socket.on('message', (data, isBinary) => handleNodeMessage(socket, data, isBinary))
+    socket.on('close', () => {
+      clearTimeout(state.handshakeTimer)
+      connectionStates.delete(socket)
+      if (state.nodeId !== undefined && nodeConnections.get(state.nodeId) === socket) {
+        nodeConnections.delete(state.nodeId)
+      }
+    })
+    socket.on('error', () => socket.terminate())
+  }
 
   const handle = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
     const correlationId = requestCorrelationId(request)
@@ -139,7 +279,9 @@ export function createJarvisGateway(options: JarvisGatewayOptions): {
             sendJson(response, 401, correlationId, { error: 'device authentication required', correlationId })
             return
           }
-          sendJson(response, 200, correlationId, authority.rotate(nodeId, deviceCredential))
+          const credential = authority.rotate(nodeId, deviceCredential)
+          sendJson(response, 200, correlationId, credential)
+          disconnectNode(nodeId, 'device credential rotated')
           return
         }
         if (request.method === 'DELETE' && parts.length === 3 && parts[2] === nodeId) {
@@ -152,6 +294,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): {
             return
           }
           sendJson(response, 204, correlationId, {})
+          disconnectNode(nodeId, 'device access revoked')
           return
         }
       }
@@ -167,6 +310,24 @@ export function createJarvisGateway(options: JarvisGatewayOptions): {
     start(port = 0) {
       if (server !== undefined) return Promise.reject(new Error('gateway is already running'))
       server = createServer((request, response) => { void handle(request, response) })
+      socketServer = new WebSocketServer({ noServer: true, maxPayload: maxBodyBytes })
+      socketServer.on('connection', handleNodeConnection)
+      server.on('upgrade', (request, socket, head) => {
+        const path = new URL(request.url ?? '/', 'http://127.0.0.1').pathname
+        if (path !== NODE_PATH) {
+          rejectUpgrade(socket, 404)
+          return
+        }
+        if (request.headers.origin !== undefined) {
+          rejectUpgrade(socket, 403)
+          return
+        }
+        if (socketServer === undefined || socketServer.clients.size >= maxNodeConnections) {
+          rejectUpgrade(socket, 503)
+          return
+        }
+        socketServer.handleUpgrade(request, socket, head, upgraded => socketServer?.emit('connection', upgraded, request))
+      })
       return new Promise<RunningGateway>((resolve, reject) => {
         server?.once('error', reject)
         server?.listen(port, '127.0.0.1', () => {
@@ -182,8 +343,24 @@ export function createJarvisGateway(options: JarvisGatewayOptions): {
     stop() {
       if (server === undefined) return Promise.resolve()
       const current = server
+      const currentSocketServer = socketServer
       server = undefined
+      socketServer = undefined
+      for (const state of connectionStates.values()) clearTimeout(state.handshakeTimer)
+      for (const socket of currentSocketServer?.clients ?? []) socket.terminate()
+      nodeConnections.clear()
+      connectionStates.clear()
+      currentSocketServer?.close()
       return new Promise<void>((resolve, reject) => current.close(error => error === undefined ? resolve() : reject(error)))
+    },
+    connectedNodeIds() {
+      return [...nodeConnections.keys()].sort()
+    },
+    dispatchCommand(command) {
+      const socket = nodeConnections.get(command.nodeId)
+      const state = socket === undefined ? undefined : connectionStates.get(socket)
+      if (socket === undefined || state?.phase !== 'ready') return false
+      return sendSocket(socket, { type: 'command.requested', command })
     },
   }
 }

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -1,12 +1,52 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import WebSocket from 'ws'
 import { createJarvisGateway } from '../dist/gateway.js'
+import { NodeAgent } from '../dist/node-agent.js'
+import { MAC_NODE_CAPABILITIES } from '../dist/node-capabilities.js'
+import { NodePolicy } from '../dist/node-command.js'
 import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
 
 const ownerToken = 'owner-token-for-gateway-tests'
 
 async function request(gateway, path, options = {}) {
   return fetch(`http://127.0.0.1:${gateway.port}${path}`, options)
+}
+
+async function waitFor(predicate, message, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message)
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+function issueCredential(authority, nodeId = 'node-1') {
+  const identity = createDeviceIdentity()
+  const pairing = authority.createRequest({
+    nodeId,
+    publicKey: identity.publicKey,
+    displayName: 'Test Mac',
+    platform: 'macos',
+  })
+  return authority.confirm(pairing.requestId, pairing.verificationCode).credential
+}
+
+function nodeAgentConfig(endpoint, credential, socketFactory, execute) {
+  return {
+    endpoint,
+    credential,
+    socketFactory,
+    reconnectDelayMs: 20,
+    registration: {
+      nodeId: 'node-1',
+      platform: 'macos',
+      softwareVersion: '0.2.0-dev',
+      capabilities: Object.values(MAC_NODE_CAPABILITIES),
+    },
+    policy: new NodePolicy({ capabilities: { system_status: { version: 1 } } }),
+    execute,
+  }
 }
 
 test('serves loopback health and protects versioned routes with owner auth', async () => {
@@ -75,6 +115,104 @@ test('rejects oversized and malformed requests without exposing secrets', async 
     assert.equal(response.status, 413)
     assert.doesNotMatch(await response.text(), /owner-token-for-gateway-tests/)
   } finally {
+    await service.stop()
+  }
+})
+
+test('isolates the node WebSocket path and requires authentication as the first message', async () => {
+  const service = createJarvisGateway({ ownerToken })
+  const gateway = await service.start()
+  try {
+    await assert.rejects(new Promise((resolve, reject) => {
+      const socket = new WebSocket(`ws://127.0.0.1:${gateway.port}/not-a-node`)
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    }), /Unexpected server response: 404/)
+    await assert.rejects(new Promise((resolve, reject) => {
+      const socket = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/node`, { origin: 'https://untrusted.example' })
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    }), /Unexpected server response: 403/)
+
+    const socket = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/node`)
+    const rejection = await new Promise((resolve, reject) => {
+      socket.once('open', () => socket.send(JSON.stringify({ type: 'node.register', registration: {} })))
+      socket.once('message', data => resolve(JSON.parse(data.toString())))
+      socket.once('error', reject)
+    })
+    assert.equal(rejection.type, 'node.rejected')
+    assert.equal(rejection.reason, 'node authentication rejected')
+    socket.close()
+  } finally {
+    await service.stop()
+  }
+})
+
+test('authenticates a real node, preserves idempotency across reconnect, and revokes active access', async () => {
+  const authority = new PairingAuthority()
+  const credential = issueCredential(authority)
+  const service = createJarvisGateway({ ownerToken, authority })
+  let gateway = await service.start()
+  let executions = 0
+  const socketFactory = () => new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/node`)
+  const agent = new NodeAgent(nodeAgentConfig(
+    `wss://127.0.0.1:${gateway.port}/v1/node`,
+    credential,
+    socketFactory,
+    async () => {
+      executions += 1
+      return { hostname: 'test-mac' }
+    },
+  ))
+  const command = {
+    commandId: 'gateway-command-1',
+    idempotencyKey: 'gateway-idempotency-1',
+    nodeId: 'node-1',
+    capability: 'system_status',
+    capabilityVersion: 1,
+    arguments: {},
+    expiresAt: Date.now() + 60_000,
+  }
+  let rejectedAgent
+  try {
+    await agent.start()
+    await waitFor(() => agent.state === 'ready', 'node did not become ready')
+    assert.deepEqual(service.connectedNodeIds(), ['node-1'])
+    assert.equal(service.dispatchCommand(command), true)
+    await waitFor(() => executions === 1, 'node did not execute the first command')
+
+    const port = gateway.port
+    await service.stop()
+    await waitFor(() => agent.state !== 'ready', 'node did not observe the gateway shutdown')
+    gateway = await service.start(port)
+    await waitFor(
+      () => agent.state === 'ready' && service.connectedNodeIds().includes('node-1'),
+      'node did not reconnect after gateway restart',
+    )
+    assert.equal(service.dispatchCommand(command), true)
+    await new Promise(resolve => setTimeout(resolve, 30))
+    assert.equal(executions, 1)
+
+    const revoked = await request(gateway, '/v1/devices/node-1', {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${ownerToken}` },
+    })
+    assert.equal(revoked.status, 204)
+    await waitFor(() => agent.state === 'stopped', 'revoked active node did not stop')
+    await waitFor(() => service.connectedNodeIds().length === 0, 'revoked node remained online')
+
+    rejectedAgent = new NodeAgent(nodeAgentConfig(
+      `wss://127.0.0.1:${gateway.port}/v1/node`,
+      credential,
+      socketFactory,
+      async () => { throw new Error('revoked node must not execute') },
+    ))
+    await rejectedAgent.start()
+    await waitFor(() => rejectedAgent.state === 'stopped', 'revoked node reconnect was not rejected')
+    assert.deepEqual(service.connectedNodeIds(), [])
+  } finally {
+    rejectedAgent?.stop()
+    agent.stop()
     await service.stop()
   }
 })


### PR DESCRIPTION
## Summary
- add a loopback-only `/v1/node` WebSocket upgrade path with device authentication and versioned capability registration
- track ready node connections, dispatch commands, and close active sessions on credential rotation or revocation
- enforce payload, handshake, connection, path, and browser-Origin limits
- add a real Gateway + NodeAgent integration test for reconnect idempotency and revoked reconnect rejection
- refresh README capability and remaining-security-boundary descriptions

## Verification
- `npm run verify` (43/43 tests)
- `npm run verify:runtime`
- `git diff --check`

Progresses #3
Progresses #10
Progresses #13