### PR TITLE
Add interactive Keychain-backed node pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - 已实现版本化 Mac 能力注册协议；未知能力、版本变更和异常注册字段会被拒绝。
 - 已实现仅主动发起的 `wss://` 节点 Agent 原型；认证、注册、断线重连、命令去重和 Keychain 凭据读取已覆盖。
 - 已实现 macOS Keychain 凭据存储层；写入通过 `security` 标准输入完成，凭据不进入命令参数、普通文件或日志。
+- Ed25519 设备私钥同样只保存在 macOS Keychain；读取时会验证公私钥匹配和指纹，已有身份不会被静默覆盖。
 - Node Agent 支持异步凭据提供器；每次启动读取当前凭据，停止时清除内存副本。
 - 已实现配对协议核心及 Gateway API：Ed25519 设备身份、短期单次验证码、凭据轮换、撤销和原子状态持久化。
 - 已实现 loopback-only `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销、请求 correlation ID，以及 `/v1/node` WebSocket 的认证、能力注册和在线连接管理；未绑定公网。
@@ -73,6 +74,16 @@ JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:
 ```
 
 它只监听 `127.0.0.1:3090`，配对状态默认原子写入未纳入 Git 的 `data/pairing-state.json`。节点 WebSocket 同样只接受 loopback 上的 `/v1/node`，并限制消息大小、握手时间和连接数。当前仍不是可直接暴露给手机的生产 Gateway；正式远程访问还需要 TLS/private overlay、外部用户认证与限流，以及可从游标恢复的会话事件。
+
+Gateway 运行后，可以在另一个终端为当前 Mac 创建身份并完成人工验证码确认：
+
+```bash
+JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:node -- \
+  --node-id my-mac \
+  --display-name 'My Mac'
+```
+
+命令只连接 loopback Gateway。设备私钥和确认后签发的访问凭据分别写入 macOS Keychain，不会显示或写入项目文件；如果凭据保存失败，流程会立即撤销刚签发的服务端身份。
 
 确认前台运行正常后执行：
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm run build && node --test test/*.test.js",
     "start": "./scripts/start-mac.sh",
     "start:gateway": "./scripts/start-gateway.sh",
+    "pair:node": "npm run build --silent && node dist/node-pairing-main.js",
     "verify": "npm run typecheck && npm test",
     "verify:runtime": "./scripts/verify-local-runtime.sh"
   },

--- a/src/node-credentials.ts
+++ b/src/node-credentials.ts
@@ -1,4 +1,6 @@
 import { spawn } from 'node:child_process'
+import { createHash, createPrivateKey, createPublicKey } from 'node:crypto'
+import { createDeviceIdentity, type DeviceIdentity } from './pairing.js'
 
 const SECURITY_COMMAND = '/usr/bin/security'
 const NOT_FOUND_EXIT_CODE = 44
@@ -38,10 +40,43 @@ function validateAccount(value: string): string {
 }
 
 function validateCredential(value: string): string {
-  if (value.length < 16 || value.length > 4096 || /[\r\n]/.test(value)) {
-    throw new TypeError('credential must be 16 to 4096 characters without line breaks')
+  if (value.length < 16 || value.length > 127 || /[\r\n]/.test(value)) {
+    throw new TypeError('credential must be 16 to 127 characters without line breaks')
   }
   return value
+}
+
+function decodeBase64Url(value: unknown, field: string): Buffer {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]{40,256}$/.test(value)) {
+    throw new TypeError(`stored device ${field} is invalid`)
+  }
+  const decoded = Buffer.from(value, 'base64url')
+  if (decoded.toString('base64url') !== value) throw new TypeError(`stored device ${field} is invalid`)
+  return decoded
+}
+
+function identityFromPrivateKey(value: unknown): DeviceIdentity {
+  const privateKey = decodeBase64Url(value, 'private key')
+  try {
+    const privateKeyObject = createPrivateKey({ key: privateKey, format: 'der', type: 'pkcs8' })
+    if (privateKeyObject.asymmetricKeyType !== 'ed25519') throw new Error('unsupported key type')
+    const derivedPublicKey = createPublicKey(privateKeyObject).export({ format: 'der', type: 'spki' })
+    return {
+      publicKey: Buffer.from(derivedPublicKey).toString('base64url'),
+      privateKey: value as string,
+      fingerprint: createHash('sha256').update(derivedPublicKey).digest('hex'),
+    }
+  } catch {
+    throw new TypeError('stored device identity failed cryptographic validation')
+  }
+}
+
+function validateDeviceIdentity(identity: DeviceIdentity): DeviceIdentity {
+  const derived = identityFromPrivateKey(identity.privateKey)
+  if (derived.publicKey !== identity.publicKey || derived.fingerprint !== identity.fingerprint) {
+    throw new TypeError('device identity failed cryptographic validation')
+  }
+  return derived
 }
 
 export class KeychainCredentialStore {
@@ -89,6 +124,73 @@ export class KeychainCredentialStore {
     ])
     if (result.exitCode === NOT_FOUND_EXIT_CODE) return false
     if (result.exitCode !== 0) throw new Error('keychain credential removal failed')
+    return true
+  }
+}
+
+export class KeychainDeviceIdentityStore {
+  constructor(
+    private readonly service = 'ai.jarvis.node.identity',
+    private readonly run: SecurityCommandRunner = runSecurityCommand,
+  ) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(service)) {
+      throw new TypeError('keychain service contains unsupported characters')
+    }
+  }
+
+  async read(nodeId: string): Promise<DeviceIdentity | undefined> {
+    const account = validateAccount(nodeId)
+    const result = await this.run([
+      'find-generic-password',
+      '-a', account,
+      '-s', this.service,
+      '-w',
+    ])
+    if (result.exitCode === NOT_FOUND_EXIT_CODE) return undefined
+    if (result.exitCode !== 0) throw new Error('keychain device identity read failed')
+    try {
+      return identityFromPrivateKey(result.stdout.replace(/\r?\n$/, ''))
+    } catch {
+      throw new Error('keychain device identity is invalid')
+    }
+  }
+
+  async write(nodeId: string, identity: DeviceIdentity): Promise<void> {
+    const account = validateAccount(nodeId)
+    const secret = validateDeviceIdentity(identity).privateKey
+    if (secret.length > 127) throw new Error('device private key exceeds the macOS Keychain input limit')
+    const result = await this.run([
+      'add-generic-password',
+      '-a', account,
+      '-s', this.service,
+      '-w',
+    ], `${secret}\n${secret}\n`)
+    if (result.exitCode !== 0) throw new Error('keychain device identity write failed')
+  }
+
+  async loadOrCreate(nodeId: string): Promise<DeviceIdentity> {
+    const existing = await this.read(nodeId)
+    if (existing !== undefined) return existing
+    const identity = createDeviceIdentity()
+    try {
+      await this.write(nodeId, identity)
+      return identity
+    } catch {
+      const concurrentlyCreated = await this.read(nodeId)
+      if (concurrentlyCreated !== undefined) return concurrentlyCreated
+      throw new Error('keychain device identity creation failed')
+    }
+  }
+
+  async remove(nodeId: string): Promise<boolean> {
+    const account = validateAccount(nodeId)
+    const result = await this.run([
+      'delete-generic-password',
+      '-a', account,
+      '-s', this.service,
+    ])
+    if (result.exitCode === NOT_FOUND_EXIT_CODE) return false
+    if (result.exitCode !== 0) throw new Error('keychain device identity removal failed')
     return true
   }
 }

--- a/src/node-pairing-main.ts
+++ b/src/node-pairing-main.ts
@@ -1,0 +1,73 @@
+import { stdin, stdout } from 'node:process'
+import { createInterface } from 'node:readline/promises'
+import { parseArgs } from 'node:util'
+import { KeychainCredentialStore, KeychainDeviceIdentityStore } from './node-credentials.js'
+import { NodePairingCoordinator } from './node-pairing.js'
+
+function usage(): string {
+  return [
+    'Usage: npm run pair:node -- --node-id <id> --display-name <name>',
+    '',
+    'Required environment:',
+    '  JARVIS_OWNER_TOKEN   Gateway owner token',
+    '',
+    'Optional environment:',
+    '  JARVIS_GATEWAY_URL   Loopback Gateway origin (default http://127.0.0.1:3090)',
+  ].join('\n')
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      help: { type: 'boolean', default: false },
+      'node-id': { type: 'string' },
+      'display-name': { type: 'string' },
+    },
+    strict: true,
+    allowPositionals: false,
+  })
+  if (values.help) {
+    stdout.write(`${usage()}\n`)
+    return
+  }
+  if (values['node-id'] === undefined || values['display-name'] === undefined) throw new Error(usage())
+  const ownerToken = process.env.JARVIS_OWNER_TOKEN
+  if (ownerToken === undefined) throw new Error('JARVIS_OWNER_TOKEN is required')
+  if (!stdin.isTTY || !stdout.isTTY) throw new Error('pairing confirmation requires an interactive terminal')
+
+  const coordinator = new NodePairingCoordinator(
+    process.env.JARVIS_GATEWAY_URL ?? 'http://127.0.0.1:3090',
+    ownerToken,
+    new KeychainDeviceIdentityStore(),
+    new KeychainCredentialStore(),
+  )
+  const challenge = await coordinator.begin({
+    nodeId: values['node-id'],
+    displayName: values['display-name'],
+  })
+  stdout.write([
+    '',
+    `Device: ${challenge.displayName} (${challenge.nodeId})`,
+    `Public key fingerprint: ${challenge.fingerprint.match(/.{1,4}/g)?.join(' ') ?? challenge.fingerprint}`,
+    `Verification code: ${challenge.verificationCode}`,
+    `Expires at: ${new Date(challenge.expiresAt).toISOString()}`,
+    '',
+  ].join('\n'))
+
+  const prompt = createInterface({ input: stdin, output: stdout })
+  try {
+    const enteredCode = (await prompt.question('Re-enter the verification code to confirm this device: ')).trim()
+    const paired = await coordinator.confirm(challenge.requestId, enteredCode)
+    stdout.write(`Paired ${paired.nodeId} with credential generation ${paired.generation}.\n`)
+  } finally {
+    prompt.close()
+  }
+}
+
+try {
+  await main()
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'pairing failed'
+  process.stderr.write(`Pairing failed: ${message}\n`)
+  process.exitCode = 1
+}

--- a/src/node-pairing.ts
+++ b/src/node-pairing.ts
@@ -1,0 +1,224 @@
+import type { DeviceIdentity } from './pairing.js'
+
+const MAX_RESPONSE_BYTES = 32 * 1024
+
+export interface DeviceIdentityStore {
+  loadOrCreate(nodeId: string): Promise<DeviceIdentity>
+}
+
+export interface DeviceCredentialStore {
+  write(nodeId: string, credential: string): Promise<void>
+}
+
+export interface PairNodeInput {
+  nodeId: string
+  displayName: string
+}
+
+export interface NodePairingChallenge {
+  requestId: string
+  nodeId: string
+  displayName: string
+  verificationCode: string
+  fingerprint: string
+  expiresAt: number
+}
+
+export interface PairedNode {
+  nodeId: string
+  publicKey: string
+  fingerprint: string
+  generation: number
+  issuedAt: number
+}
+
+interface PendingChallenge extends NodePairingChallenge {
+  publicKey: string
+}
+
+function validateIdentifier(value: string, field: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) {
+    throw new TypeError(`${field} contains unsupported characters`)
+  }
+  return value
+}
+
+function validateDisplayName(value: string): string {
+  if (value.length < 1 || value.length > 128 || /[\u0000-\u001f\u007f]/.test(value)) {
+    throw new TypeError('displayName must be 1 to 128 characters without control characters')
+  }
+  return value
+}
+
+function validateOwnerToken(value: string): string {
+  if (value.length < 16 || value.length > 4096 || /[\r\n]/.test(value)) {
+    throw new TypeError('ownerToken must be 16 to 4096 characters without line breaks')
+  }
+  return value
+}
+
+function loopbackOrigin(value: string): string {
+  const url = new URL(value)
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:')
+    || url.hostname !== '127.0.0.1'
+    || url.username !== ''
+    || url.password !== ''
+    || (url.pathname !== '' && url.pathname !== '/')
+    || url.search !== ''
+    || url.hash !== '') {
+    throw new Error('pairing gateway must be an HTTP(S) 127.0.0.1 origin')
+  }
+  return url.origin
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function validatePublicKey(value: unknown): string {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]{40,256}$/.test(value)) {
+    throw new Error('gateway returned an invalid public key')
+  }
+  return value
+}
+
+function parseChallenge(value: unknown, input: PairNodeInput, identity: DeviceIdentity): PendingChallenge {
+  if (!record(value)
+    || typeof value.requestId !== 'string'
+    || !/^[A-Za-z0-9_-]{16,64}$/.test(value.requestId)
+    || value.nodeId !== input.nodeId
+    || value.displayName !== input.displayName
+    || value.platform !== 'macos'
+    || value.publicKey !== identity.publicKey
+    || typeof value.verificationCode !== 'string'
+    || !/^\d{6}$/.test(value.verificationCode)
+    || typeof value.expiresAt !== 'number'
+    || !Number.isFinite(value.expiresAt)) {
+    throw new Error('gateway returned an invalid pairing challenge')
+  }
+  return {
+    requestId: value.requestId,
+    nodeId: input.nodeId,
+    displayName: input.displayName,
+    publicKey: identity.publicKey,
+    verificationCode: value.verificationCode,
+    fingerprint: identity.fingerprint,
+    expiresAt: value.expiresAt,
+  }
+}
+
+function parseIssuedCredential(value: unknown, challenge: PendingChallenge): {
+  credential: string
+  pairedNode: PairedNode
+} {
+  if (!record(value)
+    || value.nodeId !== challenge.nodeId
+    || validatePublicKey(value.publicKey) !== challenge.publicKey
+    || typeof value.credential !== 'string'
+    || value.credential.length < 16
+    || value.credential.length > 127
+    || /[\r\n]/.test(value.credential)
+    || typeof value.generation !== 'number'
+    || !Number.isInteger(value.generation)
+    || value.generation < 1
+    || typeof value.issuedAt !== 'number'
+    || !Number.isFinite(value.issuedAt)) {
+    throw new Error('gateway returned an invalid device credential')
+  }
+  return {
+    credential: value.credential,
+    pairedNode: {
+      nodeId: challenge.nodeId,
+      publicKey: challenge.publicKey,
+      fingerprint: challenge.fingerprint,
+      generation: value.generation,
+      issuedAt: value.issuedAt,
+    },
+  }
+}
+
+export class NodePairingCoordinator {
+  private readonly origin: string
+  private readonly ownerToken: string
+  private readonly pending = new Map<string, PendingChallenge>()
+
+  constructor(
+    gatewayUrl: string,
+    ownerToken: string,
+    private readonly identities: DeviceIdentityStore,
+    private readonly credentials: DeviceCredentialStore,
+    private readonly fetchValue: typeof fetch = fetch,
+  ) {
+    this.origin = loopbackOrigin(gatewayUrl)
+    this.ownerToken = validateOwnerToken(ownerToken)
+  }
+
+  async begin(input: PairNodeInput): Promise<NodePairingChallenge> {
+    const validatedInput = {
+      nodeId: validateIdentifier(input.nodeId, 'nodeId'),
+      displayName: validateDisplayName(input.displayName),
+    }
+    const identity = await this.identities.loadOrCreate(validatedInput.nodeId)
+    const challenge = parseChallenge(await this.request('/v1/pairing/requests', {
+      method: 'POST',
+      body: JSON.stringify({
+        ...validatedInput,
+        publicKey: identity.publicKey,
+        platform: 'macos',
+      }),
+    }), validatedInput, identity)
+    this.pending.set(challenge.requestId, challenge)
+    const { publicKey: _publicKey, ...publicChallenge } = challenge
+    return publicChallenge
+  }
+
+  async confirm(requestId: string, verificationCode: string): Promise<PairedNode> {
+    const challenge = this.pending.get(requestId)
+    if (challenge === undefined) throw new Error('pairing challenge is not active in this process')
+    if (verificationCode !== challenge.verificationCode) {
+      throw new Error('verification code did not match; pairing was not confirmed')
+    }
+    const issued = parseIssuedCredential(await this.request('/v1/pairing/requests/confirm', {
+      method: 'POST',
+      body: JSON.stringify({ requestId, verificationCode }),
+    }), challenge)
+    this.pending.delete(requestId)
+    try {
+      await this.credentials.write(challenge.nodeId, issued.credential)
+    } catch {
+      try {
+        await this.revoke(challenge.nodeId)
+      } catch {
+        throw new Error('device credential storage failed and automatic revocation failed')
+      }
+      throw new Error('device credential storage failed; the paired device was revoked')
+    }
+    return issued.pairedNode
+  }
+
+  private async request(path: string, init: RequestInit): Promise<unknown> {
+    const response = await this.fetchValue(new URL(path, this.origin), {
+      ...init,
+      headers: {
+        authorization: `Bearer ${this.ownerToken}`,
+        'content-type': 'application/json',
+      },
+    })
+    const body = await response.text()
+    if (Buffer.byteLength(body) > MAX_RESPONSE_BYTES) throw new Error('gateway response is too large')
+    if (!response.ok) throw new Error(`gateway pairing request failed with status ${response.status}`)
+    try {
+      return JSON.parse(body)
+    } catch {
+      throw new Error('gateway returned invalid JSON')
+    }
+  }
+
+  private async revoke(nodeId: string): Promise<void> {
+    const response = await this.fetchValue(new URL(`/v1/devices/${encodeURIComponent(nodeId)}`, this.origin), {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${this.ownerToken}` },
+    })
+    if (response.status !== 204) throw new Error('automatic device revocation failed')
+  }
+}

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -92,8 +92,8 @@ function validateIdentifier(value: string, field: string): string {
 }
 
 function validateText(value: string, field: string): string {
-  if (value.length < 1 || value.length > 128 || /[\r\n]/.test(value)) {
-    throw new TypeError(`${field} must be 1 to 128 characters without line breaks`)
+  if (value.length < 1 || value.length > 128 || /[\u0000-\u001f\u007f]/.test(value)) {
+    throw new TypeError(`${field} must be 1 to 128 characters without control characters`)
   }
   return value
 }

--- a/test/node-credentials.test.js
+++ b/test/node-credentials.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { KeychainCredentialStore } from '../dist/node-credentials.js'
+import { KeychainCredentialStore, KeychainDeviceIdentityStore } from '../dist/node-credentials.js'
+import { createDeviceIdentity } from '../dist/pairing.js'
 
 test('writes credentials through stdin and never puts them in security arguments', async () => {
   const calls = []
@@ -38,7 +39,7 @@ test('treats an absent item as an absent credential', async () => {
 
 test('rejects malformed credentials returned by Keychain', async () => {
   const store = new KeychainCredentialStore('ai.jarvis.test', async () => ({ exitCode: 0, stdout: 'short\n' }))
-  await assert.rejects(store.read('node-1'), /16 to 4096/)
+  await assert.rejects(store.read('node-1'), /16 to 127/)
 })
 
 test('rejects unsafe accounts, services, and credentials before invoking security', async () => {
@@ -50,7 +51,71 @@ test('rejects unsafe accounts, services, and credentials before invoking securit
   assert.throws(() => new KeychainCredentialStore('bad service'), /service/)
   const store = new KeychainCredentialStore('ai.jarvis.test', run)
   await assert.rejects(store.write('node/1', 'credential-value-1234'), /nodeId/)
-  await assert.rejects(store.write('node-1', 'short'), /16 to 4096/)
+  await assert.rejects(store.write('node-1', 'short'), /16 to 127/)
+  await assert.rejects(store.write('node-1', 'x'.repeat(128)), /16 to 127/)
   await assert.rejects(store.write('node-1', 'credential-with\nline'), /line breaks/)
   assert.equal(calls, 0)
+})
+
+test('stores a cryptographically valid device identity through stdin without overwrite', async () => {
+  const calls = []
+  const identity = createDeviceIdentity()
+  const store = new KeychainDeviceIdentityStore('ai.jarvis.test.identity', async (args, stdin) => {
+    calls.push({ args: [...args], stdin })
+    return { exitCode: 0, stdout: '' }
+  })
+  await store.write('node-1', identity)
+  assert.deepEqual(calls[0].args, [
+    'add-generic-password', '-a', 'node-1', '-s', 'ai.jarvis.test.identity', '-w',
+  ])
+  assert.equal(calls[0].args.includes('-U'), false)
+  assert.equal(calls[0].args.includes(identity.privateKey), false)
+  const secretLines = calls[0].stdin.trim().split('\n')
+  assert.equal(secretLines.length, 2)
+  assert.equal(secretLines[0], secretLines[1])
+  assert.equal(secretLines[0], identity.privateKey)
+})
+
+test('reads and reuses the same valid device identity', async () => {
+  const identity = createDeviceIdentity()
+  let calls = 0
+  const store = new KeychainDeviceIdentityStore('ai.jarvis.test.identity', async args => {
+    calls += 1
+    assert.equal(args[0], 'find-generic-password')
+    return { exitCode: 0, stdout: `${identity.privateKey}\n` }
+  })
+  assert.deepEqual(await store.loadOrCreate('node-1'), identity)
+  assert.equal(calls, 1)
+})
+
+test('rejects malformed stored keys and refuses mismatched identity metadata before writing', async () => {
+  const first = createDeviceIdentity()
+  const second = createDeviceIdentity()
+  const malformedStore = new KeychainDeviceIdentityStore('ai.jarvis.test.identity', async () => ({
+    exitCode: 0,
+    stdout: `${first.publicKey}\n`,
+  }))
+  await assert.rejects(malformedStore.read('node-1'), /identity is invalid/)
+
+  let calls = 0
+  const writeStore = new KeychainDeviceIdentityStore('ai.jarvis.test.identity', async () => {
+    calls += 1
+    return { exitCode: 0, stdout: '' }
+  })
+  await assert.rejects(writeStore.write('node-1', { ...first, publicKey: second.publicKey }), /validation/)
+  await assert.rejects(writeStore.write('node-1', { ...first, fingerprint: second.fingerprint }), /validation/)
+  assert.equal(calls, 0)
+})
+
+test('creates a missing identity once and supports explicit removal', async () => {
+  const calls = []
+  const store = new KeychainDeviceIdentityStore('ai.jarvis.test.identity', async (args, stdin) => {
+    calls.push({ args: [...args], stdin })
+    if (args[0] === 'find-generic-password') return { exitCode: 44, stdout: '' }
+    return { exitCode: 0, stdout: '' }
+  })
+  const identity = await store.loadOrCreate('node-1')
+  assert.match(identity.fingerprint, /^[a-f0-9]{64}$/)
+  assert.equal(calls.filter(call => call.args[0] === 'add-generic-password').length, 1)
+  assert.equal(await store.remove('node-1'), true)
 })

--- a/test/node-pairing.test.js
+++ b/test/node-pairing.test.js
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createJarvisGateway } from '../dist/gateway.js'
+import { NodePairingCoordinator } from '../dist/node-pairing.js'
+import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
+
+const ownerToken = 'owner-token-for-pairing-tests'
+
+test('pairs through the real Gateway only after human code confirmation', async () => {
+  const authority = new PairingAuthority()
+  const identity = createDeviceIdentity()
+  const credentials = []
+  const service = createJarvisGateway({ ownerToken, authority })
+  const gateway = await service.start()
+  try {
+    const coordinator = new NodePairingCoordinator(
+      `http://127.0.0.1:${gateway.port}`,
+      ownerToken,
+      { loadOrCreate: async () => identity },
+      { write: async (nodeId, credential) => credentials.push({ nodeId, credential }) },
+    )
+    const challenge = await coordinator.begin({ nodeId: 'node-1', displayName: 'Test Mac' })
+    assert.equal(challenge.fingerprint, identity.fingerprint)
+    assert.match(challenge.verificationCode, /^\d{6}$/)
+    await assert.rejects(coordinator.confirm(challenge.requestId, 'not-the-code'), /not confirmed/)
+    assert.equal(credentials.length, 0)
+
+    const paired = await coordinator.confirm(challenge.requestId, challenge.verificationCode)
+    assert.deepEqual(paired, {
+      nodeId: 'node-1',
+      publicKey: identity.publicKey,
+      fingerprint: identity.fingerprint,
+      generation: 1,
+      issuedAt: paired.issuedAt,
+    })
+    assert.equal(credentials.length, 1)
+    assert.equal(authority.authenticate('node-1', credentials[0].credential), true)
+    await assert.rejects(coordinator.confirm(challenge.requestId, challenge.verificationCode), /not active/)
+  } finally {
+    await service.stop()
+  }
+})
+
+test('revokes the issued Gateway credential when local Keychain storage fails', async () => {
+  const authority = new PairingAuthority()
+  const identity = createDeviceIdentity()
+  let issuedCredential
+  const service = createJarvisGateway({ ownerToken, authority })
+  const gateway = await service.start()
+  try {
+    const coordinator = new NodePairingCoordinator(
+      `http://127.0.0.1:${gateway.port}`,
+      ownerToken,
+      { loadOrCreate: async () => identity },
+      {
+        write: async (_nodeId, credential) => {
+          issuedCredential = credential
+          throw new Error('simulated keychain failure')
+        },
+      },
+    )
+    const challenge = await coordinator.begin({ nodeId: 'node-1', displayName: 'Test Mac' })
+    await assert.rejects(
+      coordinator.confirm(challenge.requestId, challenge.verificationCode),
+      /paired device was revoked/,
+    )
+    assert.equal(typeof issuedCredential, 'string')
+    assert.equal(authority.authenticate('node-1', issuedCredential), false)
+  } finally {
+    await service.stop()
+  }
+})
+
+test('rejects non-loopback gateways and identity changes in Gateway responses', async () => {
+  const identity = createDeviceIdentity()
+  const dependencies = [
+    { loadOrCreate: async () => identity },
+    { write: async () => {} },
+  ]
+  assert.throws(
+    () => new NodePairingCoordinator('https://gateway.example', ownerToken, ...dependencies),
+    /127\.0\.0\.1/,
+  )
+  assert.throws(
+    () => new NodePairingCoordinator('http://localhost:3090', ownerToken, ...dependencies),
+    /127\.0\.0\.1/,
+  )
+
+  const coordinator = new NodePairingCoordinator(
+    'http://127.0.0.1:3090',
+    ownerToken,
+    ...dependencies,
+    async () => new Response(JSON.stringify({
+      requestId: 'valid-request-id-1234',
+      nodeId: 'another-node',
+      publicKey: identity.publicKey,
+      displayName: 'Test Mac',
+      platform: 'macos',
+      verificationCode: '123456',
+      expiresAt: Date.now() + 60_000,
+    }), { status: 201 }),
+  )
+  await assert.rejects(coordinator.begin({ nodeId: 'node-1', displayName: 'Test Mac' }), /invalid pairing challenge/)
+  await assert.rejects(coordinator.begin({ nodeId: 'node-1', displayName: 'Fake\u001b[2JMac' }), /control characters/)
+})

--- a/test/pairing.test.js
+++ b/test/pairing.test.js
@@ -119,4 +119,5 @@ test('rejects unsafe pairing data and unsupported platforms', () => {
   assert.throws(() => authority.createRequest(requestInput(identity, { nodeId: 'node/1' })), /nodeId/)
   assert.throws(() => authority.createRequest(requestInput(identity, { platform: 'linux' })), /platform/)
   assert.throws(() => authority.createRequest(requestInput(identity, { publicKey: 'short' })), /publicKey/)
+  assert.throws(() => authority.createRequest(requestInput(identity, { displayName: 'Fake\u001b[2JMac' })), /control characters/)
 })


### PR DESCRIPTION
## Summary
- store each Ed25519 device private key in macOS Keychain without passing it in process arguments or silently overwriting an existing identity
- derive and validate the public key and fingerprint from the stored PKCS#8 private key
- add an interactive `pair:node` flow that displays device identity and requires the six-digit code to be re-entered
- restrict owner-token pairing traffic to `127.0.0.1` and reject terminal control characters
- revoke the newly issued Gateway identity when local credential storage fails
- document the executable pairing workflow

## Verification
- `npm run verify` (50/50 tests)
- `npm run verify:runtime`
- `npm run pair:node -- --help`
- real temporary macOS Keychain identity write/read/delete smoke
- verified temporary Keychain services are empty
- `git diff --check`

Closes #13