### PR TITLE
Add private-network HTTPS and WSS Gateway mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ DEEPSEEK_API_KEY=replace-with-your-key
 # DEEPSEEK_BASE_URL=https://api.deepseek.com
 # JARVIS_PORT=3080
 # JARVIS_DATA_DIR=/absolute/path/to/private/jarvis-data
+# JARVIS_GATEWAY_HOST=127.0.0.1
+# JARVIS_GATEWAY_TLS_KEY=/absolute/path/to/private/tls-key.pem
+# JARVIS_GATEWAY_TLS_CERT=/absolute/path/to/tls-certificate-chain.pem

--- a/README.md
+++ b/README.md
@@ -73,7 +73,19 @@ Gateway 原型单独启动，必须通过环境变量提供 Owner Token：
 JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:gateway
 ```
 
-它只监听 `127.0.0.1:3090`，配对状态默认原子写入未纳入 Git 的 `data/pairing-state.json`。节点 WebSocket 同样只接受 loopback 上的 `/v1/node`，并限制消息大小、握手时间和连接数。当前仍不是可直接暴露给手机的生产 Gateway；正式远程访问还需要 TLS/private overlay、外部用户认证与限流，以及可从游标恢复的会话事件。
+默认模式只监听 `127.0.0.1:3090`，配对状态原子写入未纳入 Git 的 `data/pairing-state.json`。节点 WebSocket 只接受 `/v1/node`，并限制消息大小、握手时间和连接数。
+
+Gateway 也支持绑定到明确的 RFC 1918、Tailscale CGNAT 或 IPv6 ULA 地址。非 loopback 模式强制 HTTPS/WSS，拒绝公网地址、主机名和通配地址；TLS 私钥文件权限必须为 `0600` 或更严格：
+
+```bash
+JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' \
+JARVIS_GATEWAY_HOST='100.64.0.10' \
+JARVIS_GATEWAY_TLS_KEY='/private/path/gateway-key.pem' \
+JARVIS_GATEWAY_TLS_CERT='/private/path/gateway-certificate-chain.pem' \
+npm run start:gateway
+```
+
+证书必须由连接设备信任并覆盖客户端使用的 Gateway 名称。该配置不会安装或管理 Tailscale，也不能直接暴露到互联网；手机访问仍需短期用户会话、速率限制、Harness bridge 和可从游标恢复的事件同步。
 
 Gateway 运行后，可以在另一个终端为当前 Mac 创建身份并完成人工验证码确认：
 

--- a/scripts/start-gateway.sh
+++ b/scripts/start-gateway.sh
@@ -9,9 +9,9 @@ if [[ -z "${JARVIS_OWNER_TOKEN:-}" ]]; then
   exit 1
 fi
 
-if [[ ! -d node_modules || ! -f dist/gateway-main.js ]]; then
+if [[ ! -d node_modules ]]; then
   "${NPM_BIN:-npm}" install
-  "${NPM_BIN:-npm}" run build
 fi
+"${NPM_BIN:-npm}" run build --silent
 
 exec node dist/gateway-main.js

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -1,5 +1,6 @@
-import { createJarvisGateway } from './gateway.js'
+import { readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { createJarvisGateway, type GatewayTlsOptions } from './gateway.js'
 
 const ownerToken = process.env.JARVIS_OWNER_TOKEN
 if (ownerToken === undefined) throw new Error('JARVIS_OWNER_TOKEN is required')
@@ -11,9 +12,27 @@ if (!Number.isInteger(configuredPort) || configuredPort < 0 || configuredPort > 
 
 const statePath = process.env.JARVIS_PAIRING_STATE
   ?? join(process.env.JARVIS_DATA_DIR ?? join(process.cwd(), 'data'), 'pairing-state.json')
-const gateway = createJarvisGateway({ ownerToken, pairingStatePath: statePath })
+const bindHost = process.env.JARVIS_GATEWAY_HOST ?? '127.0.0.1'
+const tlsKeyPath = process.env.JARVIS_GATEWAY_TLS_KEY
+const tlsCertPath = process.env.JARVIS_GATEWAY_TLS_CERT
+if ((tlsKeyPath === undefined) !== (tlsCertPath === undefined)) {
+  throw new Error('JARVIS_GATEWAY_TLS_KEY and JARVIS_GATEWAY_TLS_CERT must be configured together')
+}
+
+let tls: GatewayTlsOptions | undefined
+if (tlsKeyPath !== undefined && tlsCertPath !== undefined) {
+  const keyStat = statSync(tlsKeyPath)
+  if (!keyStat.isFile() || (keyStat.mode & 0o077) !== 0) {
+    throw new Error('JARVIS_GATEWAY_TLS_KEY must be a regular file with mode 0600 or stricter')
+  }
+  tls = { key: readFileSync(tlsKeyPath), cert: readFileSync(tlsCertPath) }
+}
+
+const gateway = tls === undefined
+  ? createJarvisGateway({ ownerToken, pairingStatePath: statePath, bindHost })
+  : createJarvisGateway({ ownerToken, pairingStatePath: statePath, bindHost, tls })
 const running = await gateway.start(configuredPort)
-console.log(`Jarvis Gateway listening on 127.0.0.1:${running.port}`)
+console.log(`Jarvis Gateway listening on ${running.origin}`)
 
 async function stop(): Promise<void> {
   await gateway.stop()

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,5 +1,7 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { randomUUID, timingSafeEqual } from 'node:crypto'
+import { createServer as createHttpServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http'
+import { createServer as createHttpsServer, type Server as HttpsServer } from 'node:https'
+import { BlockList, isIP } from 'node:net'
 import { WebSocket, WebSocketServer, type RawData } from 'ws'
 import { NODE_PROTOCOL_VERSION, parseNodeRegistration, type NodeRegistration } from './node-capabilities.js'
 import type { NodeCommand } from './node-command.js'
@@ -9,6 +11,22 @@ const MAX_BODY_BYTES = 32 * 1024
 const NODE_PATH = '/v1/node'
 const NODE_HANDSHAKE_TIMEOUT_MS = 10_000
 const MAX_NODE_CONNECTIONS = 128
+const ALLOWED_BIND_ADDRESSES = new BlockList()
+ALLOWED_BIND_ADDRESSES.addAddress('127.0.0.1', 'ipv4')
+ALLOWED_BIND_ADDRESSES.addAddress('::1', 'ipv6')
+ALLOWED_BIND_ADDRESSES.addSubnet('10.0.0.0', 8, 'ipv4')
+ALLOWED_BIND_ADDRESSES.addSubnet('172.16.0.0', 12, 'ipv4')
+ALLOWED_BIND_ADDRESSES.addSubnet('192.168.0.0', 16, 'ipv4')
+ALLOWED_BIND_ADDRESSES.addSubnet('100.64.0.0', 10, 'ipv4')
+ALLOWED_BIND_ADDRESSES.addSubnet('fc00::', 7, 'ipv6')
+
+type GatewayServer = HttpServer | HttpsServer
+
+export interface GatewayTlsOptions {
+  key: string | Buffer
+  cert: string | Buffer
+  ca?: string | Buffer
+}
 
 export interface JarvisGatewayOptions {
   ownerToken: string
@@ -17,11 +35,16 @@ export interface JarvisGatewayOptions {
   maxBodyBytes?: number
   nodeHandshakeTimeoutMs?: number
   maxNodeConnections?: number
+  bindHost?: string
+  tls?: GatewayTlsOptions
 }
 
 export interface RunningGateway {
-  server: Server
+  server: GatewayServer
+  host: string
   port: number
+  secure: boolean
+  origin: string
 }
 
 export interface JarvisGateway {
@@ -120,6 +143,23 @@ function routeParts(request: IncomingMessage): string[] {
   return parsed.pathname.split('/').filter(Boolean)
 }
 
+function validateBindHost(value: string): { host: string, loopback: boolean } {
+  const family = isIP(value)
+  const type = family === 4 ? 'ipv4' : family === 6 ? 'ipv6' : undefined
+  if (type === undefined || !ALLOWED_BIND_ADDRESSES.check(value, type)) {
+    throw new Error('bindHost must be a specific loopback, private, or overlay IP address')
+  }
+  return { host: value, loopback: value === '127.0.0.1' || value === '::1' }
+}
+
+function validateTls(options: GatewayTlsOptions | undefined): GatewayTlsOptions | undefined {
+  if (options === undefined) return undefined
+  const present = (value: string | Buffer): boolean => typeof value === 'string' ? value.length > 0 : value.byteLength > 0
+  if (!present(options.key) || !present(options.cert)) throw new Error('TLS key and certificate must not be empty')
+  if (options.ca !== undefined && !present(options.ca)) throw new Error('TLS CA must not be empty')
+  return options
+}
+
 export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGateway {
   if (options.ownerToken.length < 16) throw new Error('ownerToken must contain at least 16 characters')
   const authority = options.authority ?? new PairingAuthority(
@@ -137,7 +177,12 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
   if (!Number.isInteger(maxNodeConnections) || maxNodeConnections < 1) {
     throw new RangeError('maxNodeConnections must be a positive integer')
   }
-  let server: Server | undefined
+  const binding = validateBindHost(options.bindHost ?? '127.0.0.1')
+  const tls = validateTls(options.tls)
+  if (!binding.loopback && tls === undefined) throw new Error('TLS is required for non-loopback Gateway binding')
+  const secure = tls !== undefined
+  const scope = binding.loopback ? 'loopback-only' : 'private-network-only'
+  let server: GatewayServer | undefined
   let socketServer: WebSocketServer | undefined
   const nodeConnections = new Map<string, WebSocket>()
   const connectionStates = new Map<WebSocket, NodeConnectionState>()
@@ -235,7 +280,12 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
     const parts = routeParts(request)
     try {
       if (request.method === 'GET' && parts.length === 2 && parts[0] === 'v1' && parts[1] === 'health') {
-        sendJson(response, 200, correlationId, { service: 'jarvis-gateway', status: 'ok', scope: 'loopback-only' })
+        sendJson(response, 200, correlationId, {
+          service: 'jarvis-gateway',
+          status: 'ok',
+          scope,
+          transport: secure ? 'https' : 'http',
+        })
         return
       }
       const ownerAuthenticated = sameSecret(options.ownerToken, bearerToken(request, 'Bearer'))
@@ -309,7 +359,9 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
   return {
     start(port = 0) {
       if (server !== undefined) return Promise.reject(new Error('gateway is already running'))
-      server = createServer((request, response) => { void handle(request, response) })
+      server = tls === undefined
+        ? createHttpServer((request, response) => { void handle(request, response) })
+        : createHttpsServer({ ...tls, minVersion: 'TLSv1.2' }, (request, response) => { void handle(request, response) })
       socketServer = new WebSocketServer({ noServer: true, maxPayload: maxBodyBytes })
       socketServer.on('connection', handleNodeConnection)
       server.on('upgrade', (request, socket, head) => {
@@ -330,13 +382,21 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
       })
       return new Promise<RunningGateway>((resolve, reject) => {
         server?.once('error', reject)
-        server?.listen(port, '127.0.0.1', () => {
+        server?.listen(port, binding.host, () => {
           const address = server?.address()
           if (address === null || typeof address === 'string' || address === undefined) {
             reject(new Error('gateway did not expose a TCP address'))
             return
           }
-          resolve({ server: server as Server, port: address.port })
+          const host = binding.host.includes(':') ? `[${binding.host}]` : binding.host
+          const protocol = secure ? 'https' : 'http'
+          resolve({
+            server: server as GatewayServer,
+            host: binding.host,
+            port: address.port,
+            secure,
+            origin: `${protocol}://${host}:${address.port}`,
+          })
         })
       })
     },

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -1,4 +1,9 @@
 import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { chmod, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { request as httpsRequest } from 'node:https'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
 import WebSocket from 'ws'
 import { createJarvisGateway } from '../dist/gateway.js'
@@ -10,7 +15,52 @@ import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
 const ownerToken = 'owner-token-for-gateway-tests'
 
 async function request(gateway, path, options = {}) {
-  return fetch(`http://127.0.0.1:${gateway.port}${path}`, options)
+  if (!gateway.secure) return fetch(`${gateway.origin}${path}`, options)
+  return new Promise((resolve, reject) => {
+    const requestValue = httpsRequest(`${gateway.origin}${path}`, {
+      method: options.method,
+      headers: options.headers,
+      rejectUnauthorized: false,
+    }, response => {
+      const chunks = []
+      response.on('data', chunk => chunks.push(Buffer.from(chunk)))
+      response.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8')
+        resolve({
+          status: response.statusCode,
+          headers: {
+            get(name) {
+              const value = response.headers[name.toLowerCase()]
+              return Array.isArray(value) ? value.join(', ') : value ?? null
+            },
+          },
+          json: async () => JSON.parse(body),
+          text: async () => body,
+        })
+      })
+    })
+    requestValue.once('error', reject)
+    if (options.body !== undefined) requestValue.write(options.body)
+    requestValue.end()
+  })
+}
+
+async function createTlsMaterial() {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-gateway-tls-'))
+  const keyPath = join(directory, 'key.pem')
+  const certPath = join(directory, 'cert.pem')
+  execFileSync('/usr/bin/openssl', [
+    'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+    '-subj', '/CN=127.0.0.1', '-days', '1',
+    '-keyout', keyPath, '-out', certPath,
+  ], { stdio: 'ignore' })
+  return {
+    tls: { key: await readFile(keyPath), cert: await readFile(certPath) },
+    keyPath,
+    certPath,
+    directory,
+    cleanup: () => rm(directory, { recursive: true, force: true }),
+  }
 }
 
 async function waitFor(predicate, message, timeoutMs = 2_000) {
@@ -56,12 +106,63 @@ test('serves loopback health and protects versioned routes with owner auth', asy
     assert.equal(new URL(`http://127.0.0.1:${gateway.port}`).hostname, '127.0.0.1')
     const health = await request(gateway, '/v1/health')
     assert.equal(health.status, 200)
-    assert.equal((await health.json()).scope, 'loopback-only')
+    assert.deepEqual(await health.json(), {
+      service: 'jarvis-gateway', status: 'ok', scope: 'loopback-only', transport: 'http',
+    })
     const unauthorized = await request(gateway, '/v1/pairing/requests', { method: 'POST' })
     assert.equal(unauthorized.status, 401)
     assert.match(unauthorized.headers.get('x-correlation-id') ?? '', /^[0-9a-f-]{36}$/)
   } finally {
     await service.stop()
+  }
+})
+
+test('rejects public, wildcard, named, and plaintext private-network bindings', () => {
+  assert.throws(() => createJarvisGateway({ ownerToken, bindHost: '0.0.0.0' }), /specific loopback/)
+  assert.throws(() => createJarvisGateway({ ownerToken, bindHost: '8.8.8.8' }), /specific loopback/)
+  assert.throws(() => createJarvisGateway({ ownerToken, bindHost: 'gateway.local' }), /specific loopback/)
+  assert.throws(() => createJarvisGateway({ ownerToken, bindHost: '100.64.0.10' }), /TLS is required/)
+  assert.doesNotThrow(() => createJarvisGateway({
+    ownerToken,
+    bindHost: '100.64.0.10',
+    tls: { key: 'configured-key', cert: 'configured-cert' },
+  }))
+})
+
+test('gateway entrypoint rejects incomplete TLS and permissive private-key files', async () => {
+  const material = await createTlsMaterial()
+  const environment = Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => !name.startsWith('JARVIS_GATEWAY_TLS_')),
+  )
+  try {
+    const incomplete = spawnSync(process.execPath, ['dist/gateway-main.js'], {
+      encoding: 'utf8',
+      env: {
+        ...environment,
+        JARVIS_OWNER_TOKEN: ownerToken,
+        JARVIS_GATEWAY_PORT: '0',
+        JARVIS_GATEWAY_TLS_KEY: material.keyPath,
+      },
+    })
+    assert.notEqual(incomplete.status, 0)
+    assert.match(incomplete.stderr, /must be configured together/)
+
+    await chmod(material.keyPath, 0o644)
+    const permissive = spawnSync(process.execPath, ['dist/gateway-main.js'], {
+      encoding: 'utf8',
+      env: {
+        ...environment,
+        JARVIS_OWNER_TOKEN: ownerToken,
+        JARVIS_GATEWAY_PORT: '0',
+        JARVIS_GATEWAY_TLS_KEY: material.keyPath,
+        JARVIS_GATEWAY_TLS_CERT: material.certPath,
+        JARVIS_DATA_DIR: material.directory,
+      },
+    })
+    assert.notEqual(permissive.status, 0)
+    assert.match(permissive.stderr, /mode 0600 or stricter/)
+  } finally {
+    await material.cleanup()
   }
 })
 
@@ -148,13 +249,14 @@ test('isolates the node WebSocket path and requires authentication as the first 
   }
 })
 
-test('authenticates a real node, preserves idempotency across reconnect, and revokes active access', async () => {
+test('authenticates a real node over WSS, preserves idempotency across reconnect, and revokes active access', async () => {
   const authority = new PairingAuthority()
   const credential = issueCredential(authority)
-  const service = createJarvisGateway({ ownerToken, authority })
+  const material = await createTlsMaterial()
+  const service = createJarvisGateway({ ownerToken, authority, tls: material.tls })
   let gateway = await service.start()
   let executions = 0
-  const socketFactory = () => new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/node`)
+  const socketFactory = endpoint => new WebSocket(endpoint, { rejectUnauthorized: false })
   const agent = new NodeAgent(nodeAgentConfig(
     `wss://127.0.0.1:${gateway.port}/v1/node`,
     credential,
@@ -175,6 +277,10 @@ test('authenticates a real node, preserves idempotency across reconnect, and rev
   }
   let rejectedAgent
   try {
+    assert.equal(gateway.secure, true)
+    assert.match(gateway.origin, /^https:\/\/127\.0\.0\.1:/)
+    const health = await request(gateway, '/v1/health')
+    assert.equal((await health.json()).transport, 'https')
     await agent.start()
     await waitFor(() => agent.state === 'ready', 'node did not become ready')
     assert.deepEqual(service.connectedNodeIds(), ['node-1'])
@@ -214,5 +320,6 @@ test('authenticates a real node, preserves idempotency across reconnect, and rev
     rejectedAgent?.stop()
     agent.stop()
     await service.stop()
+    await material.cleanup()
   }
 })


### PR DESCRIPTION
## Summary
- add HTTPS/WSS serving with TLS 1.2 minimum and explicit runtime origin metadata
- permit only specific loopback, RFC 1918, Tailscale CGNAT, or IPv6 ULA bind addresses
- reject wildcard, named, public, and plaintext non-loopback bindings
- load TLS key/certificate paths at startup and reject incomplete configuration or private-key modes wider than 0600
- upgrade the Gateway + NodeAgent integration test to a real WSS transport
- rebuild Gateway sources on every start and document private-overlay configuration boundaries

## Verification
- `npm run verify` (52/52 tests)
- `npm run verify:runtime`
- real `npm run start:gateway` HTTPS process smoke with temporary certificate
- temporary TLS material removed after tests
- `git diff --check`

Progresses #10