### PR TITLE
Add rotating device-bound Gateway sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ DEEPSEEK_API_KEY=replace-with-your-key
 # JARVIS_GATEWAY_HOST=127.0.0.1
 # JARVIS_GATEWAY_TLS_KEY=/absolute/path/to/private/tls-key.pem
 # JARVIS_GATEWAY_TLS_CERT=/absolute/path/to/tls-certificate-chain.pem
+# JARVIS_SESSION_STATE=/absolute/path/to/private/session-state.json

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
 - Ed25519 设备私钥同样只保存在 macOS Keychain；读取时会验证公私钥匹配和指纹，已有身份不会被静默覆盖。
 - Node Agent 支持异步凭据提供器；每次启动读取当前凭据，停止时清除内存副本。
 - 已实现配对协议核心及 Gateway API：Ed25519 设备身份、短期单次验证码、凭据轮换、撤销和原子状态持久化。
-- 已实现 loopback-only `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销、请求 correlation ID，以及 `/v1/node` WebSocket 的认证、能力注册和在线连接管理；未绑定公网。
+- 已实现私网受限的 `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销、请求 correlation ID，以及 `/v1/node` WebSocket 的认证、能力注册和在线连接管理；默认 loopback，可启用私网 TLS，但禁止公网绑定。
+- Gateway 可由设备凭据签发短期访问会话；refresh 每次轮换，旧 refresh 复用、Owner 登出或设备撤销都会使会话族失效。
 
 ## 环境要求
 
@@ -85,7 +86,7 @@ JARVIS_GATEWAY_TLS_CERT='/private/path/gateway-certificate-chain.pem' \
 npm run start:gateway
 ```
 
-证书必须由连接设备信任并覆盖客户端使用的 Gateway 名称。该配置不会安装或管理 Tailscale，也不能直接暴露到互联网；手机访问仍需短期用户会话、速率限制、Harness bridge 和可从游标恢复的事件同步。
+证书必须由连接设备信任并覆盖客户端使用的 Gateway 名称。该配置不会安装或管理 Tailscale，也不能直接暴露到互联网；手机访问仍需速率限制、Harness bridge 和可从游标恢复的事件同步。
 
 Gateway 运行后，可以在另一个终端为当前 Mac 创建身份并完成人工验证码确认：
 
@@ -114,6 +115,7 @@ JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:node -- \
 - Harness 会话：`.dsh/sessions/`
 - Jarvis 提醒：`data/reminders.json`
 - Jarvis 审计：`data/audit.jsonl`
+- Gateway 配对与会话摘要：`data/pairing-state.json`、`data/session-state.json`
 - API Key：仅存放在未纳入 Git 的 `.env`
 - 网络：仅限本机回环地址，不要通过端口转发直接暴露到局域网或互联网
 

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -10,8 +10,9 @@ if (!Number.isInteger(configuredPort) || configuredPort < 0 || configuredPort > 
   throw new Error('JARVIS_GATEWAY_PORT must be an integer from 0 to 65535')
 }
 
-const statePath = process.env.JARVIS_PAIRING_STATE
-  ?? join(process.env.JARVIS_DATA_DIR ?? join(process.cwd(), 'data'), 'pairing-state.json')
+const dataPath = process.env.JARVIS_DATA_DIR ?? join(process.cwd(), 'data')
+const statePath = process.env.JARVIS_PAIRING_STATE ?? join(dataPath, 'pairing-state.json')
+const sessionStatePath = process.env.JARVIS_SESSION_STATE ?? join(dataPath, 'session-state.json')
 const bindHost = process.env.JARVIS_GATEWAY_HOST ?? '127.0.0.1'
 const tlsKeyPath = process.env.JARVIS_GATEWAY_TLS_KEY
 const tlsCertPath = process.env.JARVIS_GATEWAY_TLS_CERT
@@ -29,8 +30,8 @@ if (tlsKeyPath !== undefined && tlsCertPath !== undefined) {
 }
 
 const gateway = tls === undefined
-  ? createJarvisGateway({ ownerToken, pairingStatePath: statePath, bindHost })
-  : createJarvisGateway({ ownerToken, pairingStatePath: statePath, bindHost, tls })
+  ? createJarvisGateway({ ownerToken, pairingStatePath: statePath, sessionStatePath, bindHost })
+  : createJarvisGateway({ ownerToken, pairingStatePath: statePath, sessionStatePath, bindHost, tls })
 const running = await gateway.start(configuredPort)
 console.log(`Jarvis Gateway listening on ${running.origin}`)
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -6,6 +6,7 @@ import { WebSocket, WebSocketServer, type RawData } from 'ws'
 import { NODE_PROTOCOL_VERSION, parseNodeRegistration, type NodeRegistration } from './node-capabilities.js'
 import type { NodeCommand } from './node-command.js'
 import { FilePairingStateStore, PairingAuthority } from './pairing.js'
+import { FileSessionStateStore, SessionAuthenticationError, SessionAuthority, type SessionPrincipal } from './sessions.js'
 
 const MAX_BODY_BYTES = 32 * 1024
 const NODE_PATH = '/v1/node'
@@ -37,6 +38,8 @@ export interface JarvisGatewayOptions {
   maxNodeConnections?: number
   bindHost?: string
   tls?: GatewayTlsOptions
+  sessions?: SessionAuthority
+  sessionStatePath?: string
 }
 
 export interface RunningGateway {
@@ -77,7 +80,7 @@ function requestCorrelationId(request: IncomingMessage): string {
 
 function sendJson(response: ServerResponse, status: number, correlationId: string, value: unknown): void {
   if (status === 204) {
-    response.writeHead(status, { 'x-correlation-id': correlationId })
+    response.writeHead(status, { 'cache-control': 'no-store', 'x-correlation-id': correlationId })
     response.end()
     return
   }
@@ -85,12 +88,13 @@ function sendJson(response: ServerResponse, status: number, correlationId: strin
   response.writeHead(status, {
     'content-type': 'application/json; charset=utf-8',
     'content-length': Buffer.byteLength(body),
+    'cache-control': 'no-store',
     'x-correlation-id': correlationId,
   })
   response.end(body)
 }
 
-function bearerToken(request: IncomingMessage, scheme: 'Bearer' | 'Device'): string | undefined {
+function bearerToken(request: IncomingMessage, scheme: 'Bearer' | 'Device' | 'Session'): string | undefined {
   const value = request.headers.authorization
   const prefix = `${scheme} `
   return typeof value === 'string' && value.startsWith(prefix) ? value.slice(prefix.length) : undefined
@@ -167,6 +171,12 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
     undefined,
     options.pairingStatePath === undefined ? undefined : new FilePairingStateStore(options.pairingStatePath),
   )
+  const sessions = options.sessions ?? new SessionAuthority(
+    options.sessionStatePath === undefined ? {} : { store: new FileSessionStateStore(options.sessionStatePath) },
+  )
+  for (const nodeId of new Set(sessions.list().map(session => session.nodeId))) {
+    if (!authority.isActive(nodeId)) sessions.revokeDevice(nodeId)
+  }
   const maxBodyBytes = options.maxBodyBytes ?? MAX_BODY_BYTES
   if (!Number.isInteger(maxBodyBytes) || maxBodyBytes < 1) throw new RangeError('maxBodyBytes must be positive')
   const nodeHandshakeTimeoutMs = options.nodeHandshakeTimeoutMs ?? NODE_HANDSHAKE_TIMEOUT_MS
@@ -290,8 +300,76 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
       }
       const ownerAuthenticated = sameSecret(options.ownerToken, bearerToken(request, 'Bearer'))
       const deviceCredential = bearerToken(request, 'Device')
-      if (parts[0] !== 'v1' || (!ownerAuthenticated && deviceCredential === undefined)) {
+      const sessionToken = bearerToken(request, 'Session')
+      let sessionPrincipal: SessionPrincipal | undefined = sessionToken === undefined
+        ? undefined
+        : sessions.authenticate(sessionToken)
+      if (sessionPrincipal !== undefined && !authority.isActive(sessionPrincipal.nodeId)) {
+        sessions.revokeDevice(sessionPrincipal.nodeId)
+        sessionPrincipal = undefined
+      }
+      if (request.method === 'POST' && parts.length === 3 && parts[0] === 'v1' && parts[1] === 'sessions' && parts[2] === 'refresh') {
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || typeof body.refreshToken !== 'string') throw new Error('session refresh body is invalid')
+        try {
+          const refreshed = sessions.refresh(body.refreshToken)
+          if (!authority.isActive(refreshed.nodeId)) {
+            sessions.revokeDevice(refreshed.nodeId)
+            sendJson(response, 401, correlationId, { error: 'session device is revoked', code: 'device_revoked', correlationId })
+            return
+          }
+          sendJson(response, 200, correlationId, refreshed)
+        } catch (error) {
+          if (!(error instanceof SessionAuthenticationError)) throw error
+          const code = error.code === 'reuse' ? 'refresh_reuse_detected' : `refresh_${error.code}`
+          sendJson(response, 401, correlationId, { error: 'session refresh rejected', code, correlationId })
+        }
+        return
+      }
+      if (request.method === 'POST' && parts.length === 2 && parts[0] === 'v1' && parts[1] === 'sessions') {
+        if (deviceCredential === undefined) {
+          sendJson(response, 401, correlationId, { error: 'device authentication required', correlationId })
+          return
+        }
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || typeof body.nodeId !== 'string') throw new Error('session request body is invalid')
+        if (!authority.authenticate(body.nodeId, deviceCredential)) {
+          sendJson(response, 401, correlationId, { error: 'device credential is invalid or revoked', correlationId })
+          return
+        }
+        sendJson(response, 201, correlationId, sessions.issue(body.nodeId))
+        return
+      }
+      if (request.method === 'GET' && parts.length === 3 && parts[0] === 'v1' && parts[1] === 'sessions' && parts[2] === 'current') {
+        if (sessionPrincipal === undefined) {
+          sendJson(response, 401, correlationId, { error: 'session authentication required', correlationId })
+          return
+        }
+        sendJson(response, 200, correlationId, sessions.get(sessionPrincipal.sessionId))
+        return
+      }
+      if (parts[0] !== 'v1' || (!ownerAuthenticated && deviceCredential === undefined && sessionPrincipal === undefined)) {
         sendJson(response, 401, correlationId, { error: 'authentication required', correlationId })
+        return
+      }
+      if (request.method === 'GET' && parts.length === 2 && parts[1] === 'sessions') {
+        if (!ownerAuthenticated) {
+          sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
+          return
+        }
+        sendJson(response, 200, correlationId, { sessions: sessions.list() })
+        return
+      }
+      if (request.method === 'DELETE' && parts.length === 3 && parts[1] === 'sessions') {
+        if (!ownerAuthenticated) {
+          sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
+          return
+        }
+        if (!sessions.revokeSession(parts[2] as string)) {
+          sendJson(response, 404, correlationId, { error: 'session not found or already revoked', correlationId })
+          return
+        }
+        sendJson(response, 204, correlationId, {})
         return
       }
       if (request.method === 'POST' && parts.length === 3 && parts[1] === 'pairing' && parts[2] === 'requests') {
@@ -339,10 +417,12 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
             sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
             return
           }
-          if (!authority.revoke(nodeId)) {
+          if (!authority.isActive(nodeId)) {
             sendJson(response, 404, correlationId, { error: 'device not found or already revoked', correlationId })
             return
           }
+          sessions.revokeDevice(nodeId)
+          if (!authority.revoke(nodeId)) throw new Error('device revocation failed')
           sendJson(response, 204, correlationId, {})
           disconnectNode(nodeId, 'device access revoked')
           return

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -180,6 +180,11 @@ export class PairingAuthority {
     return sameDigest(record.credentialDigest, credentialDigest(credential))
   }
 
+  isActive(nodeId: string): boolean {
+    const record = this.devices.get(nodeId)
+    return record !== undefined && !record.revoked
+  }
+
   rotate(nodeId: string, currentCredential: string): IssuedCredential {
     const record = this.requireAuthenticated(nodeId, currentCredential)
     return this.issue(record.nodeId, record.publicKey, record.generation + 1)

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,0 +1,379 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+export const DEFAULT_ACCESS_TTL_MS = 15 * 60_000
+export const DEFAULT_REFRESH_TTL_MS = 30 * 24 * 60 * 60_000
+
+const DEFAULT_MAX_SESSIONS = 256
+const DEFAULT_MAX_SESSIONS_PER_DEVICE = 8
+const DEFAULT_MAX_REFRESH_ROTATIONS = 128
+const REVOKED_RETENTION_MS = 7 * 24 * 60 * 60_000
+
+export type SessionRevokeReason = 'owner' | 'device' | 'refresh-reuse' | 'refresh-expired' | 'rotation-limit'
+
+export interface SessionPrincipal {
+  sessionId: string
+  familyId: string
+  nodeId: string
+}
+
+export interface SessionTokens extends SessionPrincipal {
+  accessToken: string
+  refreshToken: string
+  accessExpiresAt: number
+  refreshExpiresAt: number
+}
+
+export interface SessionView extends SessionPrincipal {
+  issuedAt: number
+  refreshedAt: number
+  accessExpiresAt: number
+  refreshExpiresAt: number
+  rotation: number
+  revokedAt: number | null
+  revokeReason: SessionRevokeReason | null
+}
+
+export interface SessionStateSnapshot {
+  version: 1
+  sessions: Array<SessionView & {
+    accessDigest: string
+    refreshDigest: string
+    usedRefreshDigests: string[]
+  }>
+}
+
+export interface SessionStateStore {
+  load(): SessionStateSnapshot | undefined
+  save(snapshot: SessionStateSnapshot): void
+}
+
+export interface SessionAuthorityOptions {
+  now?: () => number
+  accessTtlMs?: number
+  refreshTtlMs?: number
+  maxSessions?: number
+  maxSessionsPerDevice?: number
+  maxRefreshRotations?: number
+  store?: SessionStateStore
+}
+
+interface SessionRecord extends SessionView {
+  accessDigest: Buffer
+  refreshDigest: Buffer
+  usedRefreshDigests: Buffer[]
+}
+
+export class SessionAuthenticationError extends Error {
+  constructor(readonly code: 'invalid' | 'expired' | 'reuse') {
+    super(code === 'reuse' ? 'refresh token reuse detected' : `session token is ${code}`)
+  }
+}
+
+export class FileSessionStateStore implements SessionStateStore {
+  constructor(readonly path: string) {}
+
+  load(): SessionStateSnapshot | undefined {
+    try {
+      return JSON.parse(readFileSync(this.path, 'utf8')) as SessionStateSnapshot
+    } catch (error: unknown) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return undefined
+      throw new Error('session state could not be read')
+    }
+  }
+
+  save(snapshot: SessionStateSnapshot): void {
+    mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 })
+    const temporary = `${this.path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
+    writeFileSync(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    chmodSync(temporary, 0o600)
+    renameSync(temporary, this.path)
+    chmodSync(this.path, 0o600)
+  }
+}
+
+function positiveInteger(value: number, field: string, minimum = 1): number {
+  if (!Number.isInteger(value) || value < minimum) throw new RangeError(`${field} must be an integer of at least ${minimum}`)
+  return value
+}
+
+function validateIdentifier(value: string, field: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) {
+    throw new TypeError(`${field} contains unsupported characters`)
+  }
+  return value
+}
+
+function opaqueToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+function tokenDigest(token: string): Buffer {
+  return createHash('sha256').update(token, 'utf8').digest()
+}
+
+function validToken(token: string): boolean {
+  return /^[A-Za-z0-9_-]{43}$/.test(token)
+}
+
+function sameDigest(left: Buffer, right: Buffer): boolean {
+  return left.length === right.length && timingSafeEqual(left, right)
+}
+
+function decodeDigest(value: unknown): Buffer {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(value)) {
+    throw new Error('session state contains an invalid token digest')
+  }
+  const digest = Buffer.from(value, 'base64url')
+  if (digest.length !== 32 || digest.toString('base64url') !== value) {
+    throw new Error('session state contains an invalid token digest')
+  }
+  return digest
+}
+
+function view(record: SessionRecord): SessionView {
+  return {
+    sessionId: record.sessionId,
+    familyId: record.familyId,
+    nodeId: record.nodeId,
+    issuedAt: record.issuedAt,
+    refreshedAt: record.refreshedAt,
+    accessExpiresAt: record.accessExpiresAt,
+    refreshExpiresAt: record.refreshExpiresAt,
+    rotation: record.rotation,
+    revokedAt: record.revokedAt,
+    revokeReason: record.revokeReason,
+  }
+}
+
+export class SessionAuthority {
+  private readonly now: () => number
+  private readonly accessTtlMs: number
+  private readonly refreshTtlMs: number
+  private readonly maxSessions: number
+  private readonly maxSessionsPerDevice: number
+  private readonly maxRefreshRotations: number
+  private readonly store: SessionStateStore | undefined
+  private readonly sessions = new Map<string, SessionRecord>()
+
+  constructor(options: SessionAuthorityOptions = {}) {
+    this.now = options.now ?? Date.now
+    this.accessTtlMs = positiveInteger(options.accessTtlMs ?? DEFAULT_ACCESS_TTL_MS, 'accessTtlMs', 1_000)
+    this.refreshTtlMs = positiveInteger(options.refreshTtlMs ?? DEFAULT_REFRESH_TTL_MS, 'refreshTtlMs', this.accessTtlMs + 1)
+    this.maxSessions = positiveInteger(options.maxSessions ?? DEFAULT_MAX_SESSIONS, 'maxSessions')
+    this.maxSessionsPerDevice = positiveInteger(options.maxSessionsPerDevice ?? DEFAULT_MAX_SESSIONS_PER_DEVICE, 'maxSessionsPerDevice')
+    this.maxRefreshRotations = positiveInteger(options.maxRefreshRotations ?? DEFAULT_MAX_REFRESH_ROTATIONS, 'maxRefreshRotations')
+    this.store = options.store
+    this.restore(this.store?.load())
+  }
+
+  issue(nodeIdValue: string): SessionTokens {
+    const nodeId = validateIdentifier(nodeIdValue, 'nodeId')
+    this.prune()
+    const activeForDevice = [...this.sessions.values()].filter(record => record.nodeId === nodeId && !this.inactive(record))
+    if (this.sessions.size >= this.maxSessions) throw new Error('session capacity has been reached')
+    if (activeForDevice.length >= this.maxSessionsPerDevice) throw new Error('device session capacity has been reached')
+    const now = this.now()
+    const accessToken = opaqueToken()
+    const refreshToken = opaqueToken()
+    const record: SessionRecord = {
+      sessionId: randomBytes(16).toString('base64url'),
+      familyId: randomBytes(16).toString('base64url'),
+      nodeId,
+      accessDigest: tokenDigest(accessToken),
+      refreshDigest: tokenDigest(refreshToken),
+      usedRefreshDigests: [],
+      issuedAt: now,
+      refreshedAt: now,
+      accessExpiresAt: now + this.accessTtlMs,
+      refreshExpiresAt: now + this.refreshTtlMs,
+      rotation: 0,
+      revokedAt: null,
+      revokeReason: null,
+    }
+    this.sessions.set(record.sessionId, record)
+    this.persist()
+    return { ...this.principal(record), accessToken, refreshToken, accessExpiresAt: record.accessExpiresAt, refreshExpiresAt: record.refreshExpiresAt }
+  }
+
+  authenticate(accessToken: string): SessionPrincipal | undefined {
+    if (!validToken(accessToken)) return undefined
+    const digest = tokenDigest(accessToken)
+    const record = [...this.sessions.values()].find(candidate => sameDigest(candidate.accessDigest, digest))
+    if (record === undefined || record.revokedAt !== null || record.accessExpiresAt <= this.now()) return undefined
+    return this.principal(record)
+  }
+
+  refresh(refreshTokenValue: string): SessionTokens {
+    if (!validToken(refreshTokenValue)) throw new SessionAuthenticationError('invalid')
+    const digest = tokenDigest(refreshTokenValue)
+    for (const record of this.sessions.values()) {
+      if (record.usedRefreshDigests.some(used => sameDigest(used, digest))) {
+        this.revoke(record, 'refresh-reuse')
+        this.persist()
+        throw new SessionAuthenticationError('reuse')
+      }
+    }
+    const record = [...this.sessions.values()].find(candidate => sameDigest(candidate.refreshDigest, digest))
+    if (record === undefined || record.revokedAt !== null) throw new SessionAuthenticationError('invalid')
+    const now = this.now()
+    if (record.refreshExpiresAt <= now) {
+      this.revoke(record, 'refresh-expired')
+      this.persist()
+      throw new SessionAuthenticationError('expired')
+    }
+    if (record.rotation >= this.maxRefreshRotations) {
+      this.revoke(record, 'rotation-limit')
+      this.persist()
+      throw new SessionAuthenticationError('invalid')
+    }
+    const accessToken = opaqueToken()
+    const refreshToken = opaqueToken()
+    record.usedRefreshDigests.push(record.refreshDigest)
+    record.accessDigest = tokenDigest(accessToken)
+    record.refreshDigest = tokenDigest(refreshToken)
+    record.refreshedAt = now
+    record.accessExpiresAt = now + this.accessTtlMs
+    record.rotation += 1
+    this.persist()
+    return { ...this.principal(record), accessToken, refreshToken, accessExpiresAt: record.accessExpiresAt, refreshExpiresAt: record.refreshExpiresAt }
+  }
+
+  list(): readonly SessionView[] {
+    return [...this.sessions.values()].map(view).sort((left, right) => right.issuedAt - left.issuedAt)
+  }
+
+  get(sessionId: string): SessionView | undefined {
+    const record = this.sessions.get(sessionId)
+    return record === undefined ? undefined : view(record)
+  }
+
+  revokeSession(sessionId: string): boolean {
+    const record = this.sessions.get(sessionId)
+    if (record === undefined || record.revokedAt !== null) return false
+    this.revoke(record, 'owner')
+    this.persist()
+    return true
+  }
+
+  revokeDevice(nodeId: string): number {
+    let revoked = 0
+    for (const record of this.sessions.values()) {
+      if (record.nodeId === nodeId && record.revokedAt === null) {
+        this.revoke(record, 'device')
+        revoked += 1
+      }
+    }
+    if (revoked > 0) this.persist()
+    return revoked
+  }
+
+  private principal(record: SessionRecord): SessionPrincipal {
+    return { sessionId: record.sessionId, familyId: record.familyId, nodeId: record.nodeId }
+  }
+
+  private inactive(record: SessionRecord): boolean {
+    return record.revokedAt !== null || record.refreshExpiresAt <= this.now()
+  }
+
+  private revoke(record: SessionRecord, reason: SessionRevokeReason): void {
+    if (record.revokedAt !== null) return
+    record.revokedAt = this.now()
+    record.revokeReason = reason
+  }
+
+  private prune(): void {
+    const cutoff = this.now() - REVOKED_RETENTION_MS
+    let changed = false
+    for (const [sessionId, record] of this.sessions) {
+      if ((record.revokedAt !== null && record.revokedAt <= cutoff) || record.refreshExpiresAt <= cutoff) {
+        this.sessions.delete(sessionId)
+        changed = true
+      }
+    }
+    if (this.sessions.size >= this.maxSessions) {
+      const inactive = [...this.sessions.values()]
+        .filter(record => this.inactive(record))
+        .sort((left, right) => (left.revokedAt ?? left.refreshExpiresAt) - (right.revokedAt ?? right.refreshExpiresAt))
+      for (const record of inactive) {
+        if (this.sessions.size < this.maxSessions) break
+        this.sessions.delete(record.sessionId)
+        changed = true
+      }
+    }
+    if (changed) this.persist()
+  }
+
+  private persist(): void {
+    this.store?.save({
+      version: 1,
+      sessions: [...this.sessions.values()].map(record => ({
+        ...view(record),
+        accessDigest: record.accessDigest.toString('base64url'),
+        refreshDigest: record.refreshDigest.toString('base64url'),
+        usedRefreshDigests: record.usedRefreshDigests.map(digest => digest.toString('base64url')),
+      })),
+    })
+  }
+
+  private restore(snapshot: SessionStateSnapshot | undefined): void {
+    if (snapshot === undefined) return
+    if (snapshot.version !== 1 || !Array.isArray(snapshot.sessions) || snapshot.sessions.length > this.maxSessions) {
+      throw new Error('session state has an unsupported format')
+    }
+    const tokenDigests = new Set<string>()
+    const familyIds = new Set<string>()
+    for (const item of snapshot.sessions) {
+      if (typeof item !== 'object' || item === null || Array.isArray(item)
+        || typeof item.sessionId !== 'string'
+        || !/^[A-Za-z0-9_-]{22}$/.test(item.sessionId)
+        || typeof item.familyId !== 'string'
+        || !/^[A-Za-z0-9_-]{22}$/.test(item.familyId)
+        || typeof item.nodeId !== 'string'
+        || !Number.isFinite(item.issuedAt)
+        || !Number.isFinite(item.refreshedAt)
+        || !Number.isFinite(item.accessExpiresAt)
+        || !Number.isFinite(item.refreshExpiresAt)
+        || item.refreshedAt < item.issuedAt
+        || item.accessExpiresAt <= item.refreshedAt
+        || item.refreshExpiresAt <= item.issuedAt
+        || !Number.isInteger(item.rotation)
+        || item.rotation < 0
+        || item.rotation > this.maxRefreshRotations
+        || !Array.isArray(item.usedRefreshDigests)
+        || item.usedRefreshDigests.length !== item.rotation
+        || (item.revokedAt !== null && !Number.isFinite(item.revokedAt))
+        || (item.revokedAt !== null && item.revokedAt < item.issuedAt)
+        || (item.revokeReason !== null && typeof item.revokeReason !== 'string')
+        || (item.revokeReason !== null && !['owner', 'device', 'refresh-reuse', 'refresh-expired', 'rotation-limit'].includes(item.revokeReason))) {
+        throw new Error('session state contains an invalid session')
+      }
+      if ((item.revokedAt === null) !== (item.revokeReason === null)) throw new Error('session state contains an invalid revocation')
+      if (familyIds.has(item.familyId)) throw new Error('session state contains duplicate session families')
+      familyIds.add(item.familyId)
+      const digests = [item.accessDigest, item.refreshDigest, ...item.usedRefreshDigests]
+      for (const digest of digests) {
+        decodeDigest(digest)
+        if (tokenDigests.has(digest)) throw new Error('session state contains duplicate token digests')
+        tokenDigests.add(digest)
+      }
+      const record: SessionRecord = {
+        ...item,
+        nodeId: validateIdentifier(item.nodeId, 'nodeId'),
+        accessDigest: decodeDigest(item.accessDigest),
+        refreshDigest: decodeDigest(item.refreshDigest),
+        usedRefreshDigests: item.usedRefreshDigests.map(decodeDigest),
+      }
+      if (this.sessions.has(record.sessionId)) throw new Error('session state contains duplicate sessions')
+      this.sessions.set(record.sessionId, record)
+    }
+    const activeByDevice = new Map<string, number>()
+    for (const record of this.sessions.values()) {
+      if (this.inactive(record)) continue
+      const count = (activeByDevice.get(record.nodeId) ?? 0) + 1
+      if (count > this.maxSessionsPerDevice) throw new Error('session state exceeds the per-device session limit')
+      activeByDevice.set(record.nodeId, count)
+    }
+  }
+}

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -11,6 +11,7 @@ import { NodeAgent } from '../dist/node-agent.js'
 import { MAC_NODE_CAPABILITIES } from '../dist/node-capabilities.js'
 import { NodePolicy } from '../dist/node-command.js'
 import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
+import { SessionAuthority } from '../dist/sessions.js'
 
 const ownerToken = 'owner-token-for-gateway-tests'
 
@@ -201,6 +202,154 @@ test('runs authenticated pairing, device rotation, and owner revocation over ver
     assert.equal(rejectedRotation.status, 400)
   } finally {
     await service.stop()
+  }
+})
+
+test('issues, refreshes, inventories, and revokes device-bound access sessions', async () => {
+  let now = 10_000
+  const authority = new PairingAuthority()
+  const credential = issueCredential(authority)
+  const sessions = new SessionAuthority({
+    now: () => now,
+    accessTtlMs: 1_000,
+    refreshTtlMs: 10_000,
+  })
+  const service = createJarvisGateway({ ownerToken, authority, sessions })
+  const gateway = await service.start()
+  const deviceHeaders = { authorization: `Device ${credential}`, 'content-type': 'application/json' }
+  const ownerHeaders = { authorization: `Bearer ${ownerToken}` }
+  let lastCreateResponse
+  const createSession = async () => {
+    const response = await request(gateway, '/v1/sessions', {
+      method: 'POST', headers: deviceHeaders, body: JSON.stringify({ nodeId: 'node-1' }),
+    })
+    assert.equal(response.status, 201)
+    lastCreateResponse = response
+    return response.json()
+  }
+  try {
+    const unauthorized = await request(gateway, '/v1/sessions')
+    assert.equal(unauthorized.status, 401)
+    const badDevice = await request(gateway, '/v1/sessions', {
+      method: 'POST',
+      headers: { authorization: 'Device invalid-device-credential', 'content-type': 'application/json' },
+      body: JSON.stringify({ nodeId: 'node-1' }),
+    })
+    assert.equal(badDevice.status, 401)
+
+    const first = await createSession()
+    assert.equal(lastCreateResponse.headers.get('cache-control'), 'no-store')
+    const current = await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${first.accessToken}` },
+    })
+    assert.equal(current.status, 200)
+    assert.equal((await current.json()).nodeId, 'node-1')
+
+    const inventory = await request(gateway, '/v1/sessions', { headers: ownerHeaders })
+    assert.equal(inventory.status, 200)
+    const inventoryText = await inventory.text()
+    assert.doesNotMatch(inventoryText, new RegExp(first.accessToken))
+    assert.doesNotMatch(inventoryText, new RegExp(first.refreshToken))
+    assert.equal(JSON.parse(inventoryText).sessions[0].sessionId, first.sessionId)
+
+    now += 500
+    const refreshedResponse = await request(gateway, '/v1/sessions/refresh', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken: first.refreshToken }),
+    })
+    assert.equal(refreshedResponse.status, 200)
+    const refreshed = await refreshedResponse.json()
+    assert.equal((await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${first.accessToken}` },
+    })).status, 401)
+    assert.equal((await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${refreshed.accessToken}` },
+    })).status, 200)
+
+    const reused = await request(gateway, '/v1/sessions/refresh', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken: first.refreshToken }),
+    })
+    assert.equal(reused.status, 401)
+    assert.equal((await reused.json()).code, 'refresh_reuse_detected')
+    assert.equal((await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${refreshed.accessToken}` },
+    })).status, 401)
+
+    const ownerRevoked = await createSession()
+    assert.equal((await request(gateway, `/v1/sessions/${ownerRevoked.sessionId}`, {
+      method: 'DELETE', headers: ownerHeaders,
+    })).status, 204)
+    assert.equal((await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${ownerRevoked.accessToken}` },
+    })).status, 401)
+
+    const deviceRevoked = await createSession()
+    assert.equal((await request(gateway, '/v1/devices/node-1', {
+      method: 'DELETE', headers: ownerHeaders,
+    })).status, 204)
+    assert.equal((await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${deviceRevoked.accessToken}` },
+    })).status, 401)
+    assert.equal(sessions.get(deviceRevoked.sessionId).revokeReason, 'device')
+  } finally {
+    await service.stop()
+  }
+})
+
+test('fails closed when persisted device revocation precedes session revocation', async () => {
+  const authority = new PairingAuthority()
+  const credential = issueCredential(authority)
+  const sessions = new SessionAuthority()
+  const tokens = sessions.issue('node-1')
+  assert.equal(authority.authenticate('node-1', credential), true)
+  assert.equal(authority.revoke('node-1'), true)
+
+  const service = createJarvisGateway({ ownerToken, authority, sessions })
+  const gateway = await service.start()
+  try {
+    const response = await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${tokens.accessToken}` },
+    })
+    assert.equal(response.status, 401)
+    assert.equal(sessions.get(tokens.sessionId).revokeReason, 'device')
+  } finally {
+    await service.stop()
+  }
+})
+
+test('restores Gateway access sessions from digest-only state after restart', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-gateway-sessions-'))
+  const sessionStatePath = join(directory, 'session-state.json')
+  const authority = new PairingAuthority()
+  const credential = issueCredential(authority)
+  let service = createJarvisGateway({ ownerToken, authority, sessionStatePath })
+  let gateway = await service.start()
+  try {
+    const issuedResponse = await request(gateway, '/v1/sessions', {
+      method: 'POST',
+      headers: { authorization: `Device ${credential}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ nodeId: 'node-1' }),
+    })
+    assert.equal(issuedResponse.status, 201)
+    const issued = await issuedResponse.json()
+    await service.stop()
+
+    const stored = await readFile(sessionStatePath, 'utf8')
+    assert.doesNotMatch(stored, new RegExp(issued.accessToken))
+    assert.doesNotMatch(stored, new RegExp(issued.refreshToken))
+    service = createJarvisGateway({ ownerToken, authority, sessionStatePath })
+    gateway = await service.start()
+    const restored = await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${issued.accessToken}` },
+    })
+    assert.equal(restored.status, 200)
+    assert.equal((await restored.json()).sessionId, issued.sessionId)
+  } finally {
+    await service.stop()
+    await rm(directory, { recursive: true, force: true })
   }
 })
 

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { FileSessionStateStore, SessionAuthenticationError, SessionAuthority } from '../dist/sessions.js'
+
+function sessionError(code) {
+  return error => error instanceof SessionAuthenticationError && error.code === code
+}
+
+test('expires access, rotates refresh tokens, and revokes the family on reuse', () => {
+  let now = 1_000
+  const authority = new SessionAuthority({
+    now: () => now,
+    accessTtlMs: 1_000,
+    refreshTtlMs: 10_000,
+  })
+  const first = authority.issue('node-1')
+  assert.deepEqual(authority.authenticate(first.accessToken), {
+    sessionId: first.sessionId, familyId: first.familyId, nodeId: 'node-1',
+  })
+
+  now = first.accessExpiresAt
+  assert.equal(authority.authenticate(first.accessToken), undefined)
+  const second = authority.refresh(first.refreshToken)
+  assert.equal(second.sessionId, first.sessionId)
+  assert.equal(second.familyId, first.familyId)
+  assert.notEqual(second.accessToken, first.accessToken)
+  assert.notEqual(second.refreshToken, first.refreshToken)
+  assert.equal(authority.authenticate(first.accessToken), undefined)
+  assert.equal(authority.authenticate(second.accessToken)?.nodeId, 'node-1')
+
+  assert.throws(() => authority.refresh(first.refreshToken), sessionError('reuse'))
+  assert.equal(authority.authenticate(second.accessToken), undefined)
+  assert.equal(authority.list()[0].revokeReason, 'refresh-reuse')
+})
+
+test('fails closed for expired refresh tokens and supports owner and device sign-out', () => {
+  let now = 5_000
+  const authority = new SessionAuthority({
+    now: () => now,
+    accessTtlMs: 1_000,
+    refreshTtlMs: 3_000,
+  })
+  const expired = authority.issue('node-expired')
+  now = expired.refreshExpiresAt
+  assert.throws(() => authority.refresh(expired.refreshToken), sessionError('expired'))
+  assert.equal(authority.list().find(session => session.sessionId === expired.sessionId).revokeReason, 'refresh-expired')
+
+  const first = authority.issue('node-1')
+  const second = authority.issue('node-1')
+  const other = authority.issue('node-2')
+  assert.equal(authority.revokeSession(first.sessionId), true)
+  assert.equal(authority.revokeSession(first.sessionId), false)
+  assert.equal(authority.authenticate(first.accessToken), undefined)
+  assert.equal(authority.revokeDevice('node-1'), 1)
+  assert.equal(authority.authenticate(second.accessToken), undefined)
+  assert.equal(authority.authenticate(other.accessToken)?.nodeId, 'node-2')
+})
+
+test('enforces bounded sessions and refresh rotations', () => {
+  const authority = new SessionAuthority({
+    accessTtlMs: 1_000,
+    refreshTtlMs: 10_000,
+    maxSessions: 2,
+    maxSessionsPerDevice: 1,
+    maxRefreshRotations: 1,
+  })
+  const first = authority.issue('node-1')
+  assert.throws(() => authority.issue('node-1'), /device session capacity/)
+  authority.issue('node-2')
+  assert.throws(() => authority.issue('node-3'), /session capacity/)
+  assert.equal(authority.revokeDevice('node-2'), 1)
+  authority.issue('node-3')
+  assert.equal(authority.list().length, 2)
+  const rotated = authority.refresh(first.refreshToken)
+  assert.throws(() => authority.refresh(rotated.refreshToken), sessionError('invalid'))
+  assert.equal(authority.list().find(session => session.sessionId === first.sessionId).revokeReason, 'rotation-limit')
+})
+
+test('persists only token digests and detects refresh reuse after restart', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-sessions-'))
+  try {
+    const path = join(directory, 'session-state.json')
+    const store = new FileSessionStateStore(path)
+    const firstAuthority = new SessionAuthority({ store })
+    const first = firstAuthority.issue('node-1')
+    const second = firstAuthority.refresh(first.refreshToken)
+    const stored = await readFile(path, 'utf8')
+    assert.doesNotMatch(stored, new RegExp(first.accessToken))
+    assert.doesNotMatch(stored, new RegExp(first.refreshToken))
+    assert.doesNotMatch(stored, new RegExp(second.accessToken))
+    assert.doesNotMatch(stored, new RegExp(second.refreshToken))
+    assert.equal((await stat(path)).mode & 0o777, 0o600)
+    assert.equal((await stat(directory)).mode & 0o777, 0o700)
+
+    const restarted = new SessionAuthority({ store })
+    assert.equal(restarted.authenticate(second.accessToken)?.nodeId, 'node-1')
+    assert.throws(() => restarted.refresh(first.refreshToken), sessionError('reuse'))
+
+    const restoredAgain = new SessionAuthority({ store })
+    assert.equal(restoredAgain.authenticate(second.accessToken), undefined)
+    assert.equal(restoredAgain.list()[0].revokeReason, 'refresh-reuse')
+    assert.doesNotMatch(JSON.stringify(restoredAgain.list()), /Digest|Token/)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects malformed, duplicate-family, and over-limit persisted session state', () => {
+  let snapshot
+  const source = new SessionAuthority({
+    maxSessionsPerDevice: 2,
+    store: { load: () => undefined, save: value => { snapshot = structuredClone(value) } },
+  })
+  source.issue('node-1')
+  source.issue('node-1')
+
+  const malformed = structuredClone(snapshot)
+  malformed.sessions[0].accessExpiresAt = malformed.sessions[0].refreshedAt
+  assert.throws(
+    () => new SessionAuthority({ store: { load: () => malformed, save: () => {} } }),
+    /invalid session/,
+  )
+
+  const duplicateFamily = structuredClone(snapshot)
+  duplicateFamily.sessions[1].familyId = duplicateFamily.sessions[0].familyId
+  assert.throws(
+    () => new SessionAuthority({ maxSessionsPerDevice: 2, store: { load: () => duplicateFamily, save: () => {} } }),
+    /duplicate session families/,
+  )
+
+  assert.throws(
+    () => new SessionAuthority({ maxSessionsPerDevice: 1, store: { load: () => snapshot, save: () => {} } }),
+    /per-device session limit/,
+  )
+  assert.throws(
+    () => new SessionAuthority({ store: { load: () => ({ version: 1, sessions: [null] }), save: () => {} } }),
+    /invalid session/,
+  )
+})


### PR DESCRIPTION
## Summary
- issue 15-minute access sessions and 30-day refresh families from authenticated device credentials
- rotate access and refresh tokens together, invalidate prior access immediately, and revoke the family on old-refresh reuse
- persist only SHA-256 token digests with atomic 0600 state files
- add Owner session inventory and remote sign-out plus device-revocation propagation
- reconcile session state against revoked devices at startup and on every access/refresh
- bound sessions, per-device sessions, and refresh rotations while pruning inactive history at capacity
- mark all Gateway responses `Cache-Control: no-store`

## Verification
- `npm run verify` (60/60 tests)
- `npm run verify:runtime`
- Gateway restart restores valid sessions without persisting raw tokens
- old refresh reuse after restart revokes the current access token
- malformed and over-limit persisted state fails closed
- `git diff --check`

Progresses #10