### PR TITLE
Enforce Gateway source and identity rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - Ed25519 设备私钥同样只保存在 macOS Keychain；读取时会验证公私钥匹配和指纹，已有身份不会被静默覆盖。
 - Node Agent 支持异步凭据提供器；每次启动读取当前凭据，停止时清除内存副本。
 - 已实现配对协议核心及 Gateway API：Ed25519 设备身份、短期单次验证码、凭据轮换、撤销和原子状态持久化。
-- 已实现私网受限的 `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销、请求 correlation ID，以及 `/v1/node` WebSocket 的认证、能力注册和在线连接管理；默认 loopback，可启用私网 TLS，但禁止公网绑定。
+- 已实现私网受限的 `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销、请求 correlation ID、按连接来源和认证身份隔离的有界限流，以及 `/v1/node` WebSocket 的认证、能力注册和在线连接管理；默认 loopback，可启用私网 TLS，但禁止公网绑定。
 - Gateway 可由设备凭据签发短期访问会话；refresh 每次轮换，旧 refresh 复用、Owner 登出或设备撤销都会使会话族失效。
 
 ## 环境要求
@@ -76,6 +76,8 @@ JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:
 
 默认模式只监听 `127.0.0.1:3090`，配对状态原子写入未纳入 Git 的 `data/pairing-state.json`。节点 WebSocket 只接受 `/v1/node`，并限制消息大小、握手时间和连接数。
 
+Gateway 默认允许每个连接来源突发 60 次请求并每秒恢复 1 次额度；每个已认证 Owner、设备或 Session 可突发 120 次并每秒恢复 2 次额度。它只使用直接连接地址，不信任客户端提供的转发来源头；HTTP `429` 会返回 `Retry-After`、限额余量和 correlation ID。
+
 Gateway 也支持绑定到明确的 RFC 1918、Tailscale CGNAT 或 IPv6 ULA 地址。非 loopback 模式强制 HTTPS/WSS，拒绝公网地址、主机名和通配地址；TLS 私钥文件权限必须为 `0600` 或更严格：
 
 ```bash
@@ -86,7 +88,7 @@ JARVIS_GATEWAY_TLS_CERT='/private/path/gateway-certificate-chain.pem' \
 npm run start:gateway
 ```
 
-证书必须由连接设备信任并覆盖客户端使用的 Gateway 名称。该配置不会安装或管理 Tailscale，也不能直接暴露到互联网；手机访问仍需速率限制、Harness bridge 和可从游标恢复的事件同步。
+证书必须由连接设备信任并覆盖客户端使用的 Gateway 名称。该配置不会安装或管理 Tailscale，也不能直接暴露到互联网；手机访问仍需 Harness bridge 和可从游标恢复的事件同步。
 
 Gateway 运行后，可以在另一个终端为当前 Mac 创建身份并完成人工验证码确认：
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -6,12 +6,15 @@ import { WebSocket, WebSocketServer, type RawData } from 'ws'
 import { NODE_PROTOCOL_VERSION, parseNodeRegistration, type NodeRegistration } from './node-capabilities.js'
 import type { NodeCommand } from './node-command.js'
 import { FilePairingStateStore, PairingAuthority } from './pairing.js'
+import { TokenBucketRateLimiter, type RateLimitDecision, type TokenBucketRateLimiterOptions } from './rate-limit.js'
 import { FileSessionStateStore, SessionAuthenticationError, SessionAuthority, type SessionPrincipal } from './sessions.js'
 
 const MAX_BODY_BYTES = 32 * 1024
 const NODE_PATH = '/v1/node'
 const NODE_HANDSHAKE_TIMEOUT_MS = 10_000
 const MAX_NODE_CONNECTIONS = 128
+const DEFAULT_SOURCE_RATE_LIMIT = { capacity: 60, refillPerSecond: 1, maxKeys: 4_096 }
+const DEFAULT_IDENTITY_RATE_LIMIT = { capacity: 120, refillPerSecond: 2, maxKeys: 1_024 }
 const ALLOWED_BIND_ADDRESSES = new BlockList()
 ALLOWED_BIND_ADDRESSES.addAddress('127.0.0.1', 'ipv4')
 ALLOWED_BIND_ADDRESSES.addAddress('::1', 'ipv6')
@@ -40,6 +43,8 @@ export interface JarvisGatewayOptions {
   tls?: GatewayTlsOptions
   sessions?: SessionAuthority
   sessionStatePath?: string
+  sourceRateLimit?: TokenBucketRateLimiterOptions
+  identityRateLimit?: TokenBucketRateLimiterOptions
 }
 
 export interface RunningGateway {
@@ -78,9 +83,15 @@ function requestCorrelationId(request: IncomingMessage): string {
   return randomUUID()
 }
 
-function sendJson(response: ServerResponse, status: number, correlationId: string, value: unknown): void {
+function sendJson(
+  response: ServerResponse,
+  status: number,
+  correlationId: string,
+  value: unknown,
+  headers: Record<string, string | number> = {},
+): void {
   if (status === 204) {
-    response.writeHead(status, { 'cache-control': 'no-store', 'x-correlation-id': correlationId })
+    response.writeHead(status, { 'cache-control': 'no-store', 'x-correlation-id': correlationId, ...headers })
     response.end()
     return
   }
@@ -90,8 +101,25 @@ function sendJson(response: ServerResponse, status: number, correlationId: strin
     'content-length': Buffer.byteLength(body),
     'cache-control': 'no-store',
     'x-correlation-id': correlationId,
+    ...headers,
   })
   response.end(body)
+}
+
+function rateLimitHeaders(decision: RateLimitDecision): Record<string, string | number> {
+  return {
+    'retry-after': Math.max(1, Math.ceil(decision.retryAfterMs / 1_000)),
+    'x-ratelimit-limit': decision.limit,
+    'x-ratelimit-remaining': decision.remaining,
+  }
+}
+
+function sendRateLimited(response: ServerResponse, correlationId: string, decision: RateLimitDecision): void {
+  sendJson(response, 429, correlationId, {
+    error: 'rate limit exceeded',
+    code: 'rate_limited',
+    correlationId,
+  }, rateLimitHeaders(decision))
 }
 
 function bearerToken(request: IncomingMessage, scheme: 'Bearer' | 'Device' | 'Session'): string | undefined {
@@ -137,9 +165,18 @@ function sendSocket(socket: WebSocket, message: Record<string, unknown>): boolea
   return true
 }
 
-function rejectUpgrade(socket: import('node:stream').Duplex, status: 403 | 404 | 503): void {
-  const reason = status === 403 ? 'Forbidden' : status === 404 ? 'Not Found' : 'Service Unavailable'
-  socket.end(`HTTP/1.1 ${status} ${reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`)
+function rejectUpgrade(
+  socket: import('node:stream').Duplex,
+  status: 403 | 404 | 429 | 503,
+  headers: Record<string, string | number> = {},
+): void {
+  const reasons = { 403: 'Forbidden', 404: 'Not Found', 429: 'Too Many Requests', 503: 'Service Unavailable' }
+  const lines = Object.entries(headers).map(([name, value]) => `${name}: ${value}\r\n`).join('')
+  socket.end(`HTTP/1.1 ${status} ${reasons[status]}\r\n${lines}Connection: close\r\nContent-Length: 0\r\n\r\n`)
+}
+
+function sourceKey(request: IncomingMessage): string {
+  return request.socket.remoteAddress ?? 'unknown'
 }
 
 function routeParts(request: IncomingMessage): string[] {
@@ -192,6 +229,8 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
   if (!binding.loopback && tls === undefined) throw new Error('TLS is required for non-loopback Gateway binding')
   const secure = tls !== undefined
   const scope = binding.loopback ? 'loopback-only' : 'private-network-only'
+  const sourceRateLimiter = new TokenBucketRateLimiter(options.sourceRateLimit ?? DEFAULT_SOURCE_RATE_LIMIT)
+  const identityRateLimiter = new TokenBucketRateLimiter(options.identityRateLimit ?? DEFAULT_IDENTITY_RATE_LIMIT)
   let server: GatewayServer | undefined
   let socketServer: WebSocketServer | undefined
   const nodeConnections = new Map<string, WebSocket>()
@@ -233,6 +272,11 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         rejectNode(socket, 'node authentication rejected')
         return
       }
+      const identityDecision = identityRateLimiter.consume(`device:${message.nodeId}`)
+      if (!identityDecision.allowed) {
+        rejectNode(socket, 'node rate limit exceeded')
+        return
+      }
       state.nodeId = message.nodeId
       state.phase = 'register'
       sendSocket(socket, { type: 'node.authenticated', correlationId: state.correlationId })
@@ -266,10 +310,10 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
     }
   }
 
-  const handleNodeConnection = (socket: WebSocket): void => {
+  const handleNodeConnection = (socket: WebSocket, request: IncomingMessage): void => {
     const state: NodeConnectionState = {
       phase: 'authenticate',
-      correlationId: randomUUID(),
+      correlationId: requestCorrelationId(request),
       handshakeTimer: setTimeout(() => rejectNode(socket, 'node handshake timed out'), nodeHandshakeTimeoutMs),
     }
     state.handshakeTimer.unref()
@@ -287,8 +331,13 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
 
   const handle = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
     const correlationId = requestCorrelationId(request)
-    const parts = routeParts(request)
     try {
+      const sourceDecision = sourceRateLimiter.consume(sourceKey(request))
+      if (!sourceDecision.allowed) {
+        sendRateLimited(response, correlationId, sourceDecision)
+        return
+      }
+      const parts = routeParts(request)
       if (request.method === 'GET' && parts.length === 2 && parts[0] === 'v1' && parts[1] === 'health') {
         sendJson(response, 200, correlationId, {
           service: 'jarvis-gateway',
@@ -300,6 +349,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
       }
       const ownerAuthenticated = sameSecret(options.ownerToken, bearerToken(request, 'Bearer'))
       const deviceCredential = bearerToken(request, 'Device')
+      const deviceNodeId = deviceCredential === undefined ? undefined : authority.identify(deviceCredential)
       const sessionToken = bearerToken(request, 'Session')
       let sessionPrincipal: SessionPrincipal | undefined = sessionToken === undefined
         ? undefined
@@ -311,6 +361,19 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
       if (request.method === 'POST' && parts.length === 3 && parts[0] === 'v1' && parts[1] === 'sessions' && parts[2] === 'refresh') {
         const body = await readJson(request, maxBodyBytes)
         if (!record(body) || typeof body.refreshToken !== 'string') throw new Error('session refresh body is invalid')
+        const refreshPrincipal = sessions.identifyRefresh(body.refreshToken)
+        if (refreshPrincipal !== undefined) {
+          if (!authority.isActive(refreshPrincipal.nodeId)) {
+            sessions.revokeDevice(refreshPrincipal.nodeId)
+            sendJson(response, 401, correlationId, { error: 'session device is revoked', code: 'device_revoked', correlationId })
+            return
+          }
+          const identityDecision = identityRateLimiter.consume(`session:${refreshPrincipal.sessionId}`)
+          if (!identityDecision.allowed) {
+            sendRateLimited(response, correlationId, identityDecision)
+            return
+          }
+        }
         try {
           const refreshed = sessions.refresh(body.refreshToken)
           if (!authority.isActive(refreshed.nodeId)) {
@@ -326,14 +389,28 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         }
         return
       }
+      const identityKey = ownerAuthenticated
+        ? 'owner'
+        : deviceNodeId !== undefined
+          ? `device:${deviceNodeId}`
+          : sessionPrincipal === undefined
+            ? undefined
+            : `session:${sessionPrincipal.sessionId}`
+      if (identityKey !== undefined) {
+        const identityDecision = identityRateLimiter.consume(identityKey)
+        if (!identityDecision.allowed) {
+          sendRateLimited(response, correlationId, identityDecision)
+          return
+        }
+      }
       if (request.method === 'POST' && parts.length === 2 && parts[0] === 'v1' && parts[1] === 'sessions') {
-        if (deviceCredential === undefined) {
+        if (deviceNodeId === undefined) {
           sendJson(response, 401, correlationId, { error: 'device authentication required', correlationId })
           return
         }
         const body = await readJson(request, maxBodyBytes)
         if (!record(body) || typeof body.nodeId !== 'string') throw new Error('session request body is invalid')
-        if (!authority.authenticate(body.nodeId, deviceCredential)) {
+        if (body.nodeId !== deviceNodeId) {
           sendJson(response, 401, correlationId, { error: 'device credential is invalid or revoked', correlationId })
           return
         }
@@ -348,7 +425,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         sendJson(response, 200, correlationId, sessions.get(sessionPrincipal.sessionId))
         return
       }
-      if (parts[0] !== 'v1' || (!ownerAuthenticated && deviceCredential === undefined && sessionPrincipal === undefined)) {
+      if (parts[0] !== 'v1' || (!ownerAuthenticated && deviceNodeId === undefined && sessionPrincipal === undefined)) {
         sendJson(response, 401, correlationId, { error: 'authentication required', correlationId })
         return
       }
@@ -403,7 +480,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
       if (parts.length === 3 && parts[1] === 'devices' && typeof parts[2] === 'string') {
         const nodeId = parts[2]
         if (request.method === 'POST' && parts.length === 3 && parts[2] === nodeId) {
-          if (deviceCredential === undefined) {
+          if (deviceNodeId === undefined || deviceCredential === undefined || deviceNodeId !== nodeId) {
             sendJson(response, 401, correlationId, { error: 'device authentication required', correlationId })
             return
           }
@@ -445,6 +522,16 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
       socketServer = new WebSocketServer({ noServer: true, maxPayload: maxBodyBytes })
       socketServer.on('connection', handleNodeConnection)
       server.on('upgrade', (request, socket, head) => {
+        const correlationId = requestCorrelationId(request)
+        const sourceDecision = sourceRateLimiter.consume(sourceKey(request))
+        if (!sourceDecision.allowed) {
+          rejectUpgrade(socket, 429, {
+            ...rateLimitHeaders(sourceDecision),
+            'cache-control': 'no-store',
+            'x-correlation-id': correlationId,
+          })
+          return
+        }
         const path = new URL(request.url ?? '/', 'http://127.0.0.1').pathname
         if (path !== NODE_PATH) {
           rejectUpgrade(socket, 404)

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -180,6 +180,14 @@ export class PairingAuthority {
     return sameDigest(record.credentialDigest, credentialDigest(credential))
   }
 
+  identify(credential: string): string | undefined {
+    const digest = credentialDigest(credential)
+    for (const record of this.devices.values()) {
+      if (!record.revoked && sameDigest(record.credentialDigest, digest)) return record.nodeId
+    }
+    return undefined
+  }
+
   isActive(nodeId: string): boolean {
     const record = this.devices.get(nodeId)
     return record !== undefined && !record.revoked

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,106 @@
+export interface TokenBucketRateLimiterOptions {
+  capacity: number
+  refillPerSecond: number
+  maxKeys: number
+  now?: () => number
+}
+
+export interface RateLimitDecision {
+  allowed: boolean
+  limit: number
+  remaining: number
+  retryAfterMs: number
+}
+
+interface Bucket {
+  tokens: number
+  updatedAt: number
+  lastSeenAt: number
+}
+
+function positive(value: number, name: string): number {
+  if (!Number.isFinite(value) || value <= 0) throw new RangeError(`${name} must be positive`)
+  return value
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 1) throw new RangeError(`${name} must be a positive integer`)
+  return value
+}
+
+export class TokenBucketRateLimiter {
+  private readonly capacity: number
+  private readonly refillPerMs: number
+  private readonly maxKeys: number
+  private readonly now: () => number
+  private readonly buckets = new Map<string, Bucket>()
+
+  constructor(options: TokenBucketRateLimiterOptions) {
+    this.capacity = positiveInteger(options.capacity, 'capacity')
+    this.refillPerMs = positive(options.refillPerSecond, 'refillPerSecond') / 1_000
+    this.maxKeys = positiveInteger(options.maxKeys, 'maxKeys')
+    this.now = options.now ?? Date.now
+  }
+
+  consume(key: string): RateLimitDecision {
+    if (key.length === 0) throw new Error('rate limit key must not be empty')
+    const now = this.now()
+    if (!Number.isFinite(now)) throw new Error('rate limit clock must be finite')
+    let bucket = this.buckets.get(key)
+    if (bucket === undefined) {
+      this.pruneRecovered(now)
+      if (this.buckets.size >= this.maxKeys) {
+        return {
+          allowed: false,
+          limit: this.capacity,
+          remaining: 0,
+          retryAfterMs: this.capacityRetryAfter(now),
+        }
+      }
+      bucket = { tokens: this.capacity, updatedAt: now, lastSeenAt: now }
+      this.buckets.set(key, bucket)
+    }
+
+    this.refill(bucket, now)
+    bucket.lastSeenAt = Math.max(bucket.lastSeenAt, now)
+    if (bucket.tokens < 1) {
+      return {
+        allowed: false,
+        limit: this.capacity,
+        remaining: 0,
+        retryAfterMs: Math.ceil((1 - bucket.tokens) / this.refillPerMs),
+      }
+    }
+    bucket.tokens -= 1
+    return {
+      allowed: true,
+      limit: this.capacity,
+      remaining: Math.floor(bucket.tokens),
+      retryAfterMs: 0,
+    }
+  }
+
+  private refill(bucket: Bucket, now: number): void {
+    const elapsed = Math.max(0, now - bucket.updatedAt)
+    if (elapsed === 0) return
+    bucket.tokens = Math.min(this.capacity, bucket.tokens + elapsed * this.refillPerMs)
+    bucket.updatedAt = now
+  }
+
+  private pruneRecovered(now: number): void {
+    for (const [key, bucket] of [...this.buckets].sort((left, right) => left[1].lastSeenAt - right[1].lastSeenAt)) {
+      this.refill(bucket, now)
+      if (bucket.tokens >= this.capacity) this.buckets.delete(key)
+    }
+  }
+
+  private capacityRetryAfter(now: number): number {
+    let retryAfterMs = Number.POSITIVE_INFINITY
+    for (const bucket of this.buckets.values()) {
+      const elapsed = Math.max(0, now - bucket.updatedAt)
+      const tokens = Math.min(this.capacity, bucket.tokens + elapsed * this.refillPerMs)
+      retryAfterMs = Math.min(retryAfterMs, Math.ceil((this.capacity - tokens) / this.refillPerMs))
+    }
+    return Number.isFinite(retryAfterMs) ? Math.max(1, retryAfterMs) : 1
+  }
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -205,6 +205,15 @@ export class SessionAuthority {
     return this.principal(record)
   }
 
+  identifyRefresh(refreshTokenValue: string): SessionPrincipal | undefined {
+    if (!validToken(refreshTokenValue)) return undefined
+    const digest = tokenDigest(refreshTokenValue)
+    const record = [...this.sessions.values()].find(candidate => sameDigest(candidate.refreshDigest, digest))
+    if (record === undefined || record.revokedAt !== null || record.refreshExpiresAt <= this.now()
+      || record.rotation >= this.maxRefreshRotations) return undefined
+    return this.principal(record)
+  }
+
   refresh(refreshTokenValue: string): SessionTokens {
     if (!validToken(refreshTokenValue)) throw new SessionAuthenticationError('invalid')
     const digest = tokenDigest(refreshTokenValue)

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -199,7 +199,7 @@ test('runs authenticated pairing, device rotation, and owner revocation over ver
     const rejectedRotation = await request(gateway, '/v1/devices/node-1', {
       method: 'POST', headers: { authorization: `Device ${second.credential}` },
     })
-    assert.equal(rejectedRotation.status, 400)
+    assert.equal(rejectedRotation.status, 401)
   } finally {
     await service.stop()
   }
@@ -369,6 +369,114 @@ test('rejects oversized and malformed requests without exposing secrets', async 
   }
 })
 
+test('limits sources before reading request bodies and returns retry metadata', async () => {
+  const service = createJarvisGateway({
+    ownerToken,
+    maxBodyBytes: 8,
+    sourceRateLimit: { capacity: 1, refillPerSecond: 0.001, maxKeys: 8 },
+  })
+  const gateway = await service.start()
+  try {
+    assert.equal((await request(gateway, '/v1/health')).status, 200)
+    const limited = await request(gateway, '/v1/pairing/requests', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ownerToken}`,
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.20',
+      },
+      body: JSON.stringify({ oversized: 'this body must never be parsed' }),
+    })
+    assert.equal(limited.status, 429)
+    assert.equal(limited.headers.get('retry-after'), '1000')
+    assert.equal(limited.headers.get('x-ratelimit-limit'), '1')
+    assert.equal(limited.headers.get('x-ratelimit-remaining'), '0')
+    assert.equal(limited.headers.get('cache-control'), 'no-store')
+    assert.match(limited.headers.get('x-correlation-id') ?? '', /^[0-9a-f-]{36}$/)
+    assert.equal((await limited.json()).code, 'rate_limited')
+  } finally {
+    await service.stop()
+  }
+})
+
+test('isolates owner, device, and session identity limits after authentication', async () => {
+  const authority = new PairingAuthority()
+  const firstCredential = issueCredential(authority, 'node-1')
+  const secondCredential = issueCredential(authority, 'node-2')
+  const service = createJarvisGateway({
+    ownerToken,
+    authority,
+    sourceRateLimit: { capacity: 100, refillPerSecond: 100, maxKeys: 8 },
+    identityRateLimit: { capacity: 1, refillPerSecond: 0.001, maxKeys: 8 },
+  })
+  const gateway = await service.start()
+  const createSession = (nodeId, credential) => request(gateway, '/v1/sessions', {
+    method: 'POST',
+    headers: { authorization: `Device ${credential}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ nodeId }),
+  })
+  try {
+    const invalid = await createSession('node-1', 'invalid-device-credential')
+    assert.equal(invalid.status, 401)
+
+    const first = await createSession('node-1', firstCredential)
+    assert.equal(first.status, 201)
+    const firstTokens = await first.json()
+    assert.equal((await createSession('node-1', firstCredential)).status, 429)
+    assert.equal((await createSession('node-2', secondCredential)).status, 201)
+
+    const sessionHeaders = { authorization: `Session ${firstTokens.accessToken}` }
+    assert.equal((await request(gateway, '/v1/sessions/current', { headers: sessionHeaders })).status, 200)
+    assert.equal((await request(gateway, '/v1/sessions/current', { headers: sessionHeaders })).status, 429)
+
+    const ownerHeaders = { authorization: `Bearer ${ownerToken}` }
+    assert.equal((await request(gateway, '/v1/sessions', { headers: ownerHeaders })).status, 200)
+    const ownerLimited = await request(gateway, '/v1/sessions', { headers: ownerHeaders })
+    assert.equal(ownerLimited.status, 429)
+    assert.equal(ownerLimited.headers.get('x-ratelimit-limit'), '1')
+  } finally {
+    await service.stop()
+  }
+})
+
+test('detects refresh reuse even after the session identity limit is exhausted', async () => {
+  const authority = new PairingAuthority()
+  issueCredential(authority)
+  const sessions = new SessionAuthority()
+  const first = sessions.issue('node-1')
+  const service = createJarvisGateway({
+    ownerToken,
+    authority,
+    sessions,
+    sourceRateLimit: { capacity: 100, refillPerSecond: 100, maxKeys: 8 },
+    identityRateLimit: { capacity: 2, refillPerSecond: 0.001, maxKeys: 8 },
+  })
+  const gateway = await service.start()
+  const refresh = token => request(gateway, '/v1/sessions/refresh', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ refreshToken: token }),
+  })
+  try {
+    const rotatedResponse = await refresh(first.refreshToken)
+    assert.equal(rotatedResponse.status, 200)
+    const rotated = await rotatedResponse.json()
+    assert.equal((await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${rotated.accessToken}` },
+    })).status, 200)
+
+    const reused = await refresh(first.refreshToken)
+    assert.equal(reused.status, 401)
+    assert.equal((await reused.json()).code, 'refresh_reuse_detected')
+    assert.equal(sessions.get(first.sessionId).revokeReason, 'refresh-reuse')
+    assert.equal((await request(gateway, '/v1/sessions/current', {
+      headers: { authorization: `Session ${rotated.accessToken}` },
+    })).status, 401)
+  } finally {
+    await service.stop()
+  }
+})
+
 test('isolates the node WebSocket path and requires authentication as the first message', async () => {
   const service = createJarvisGateway({ ownerToken })
   const gateway = await service.start()
@@ -395,6 +503,67 @@ test('isolates the node WebSocket path and requires authentication as the first 
     socket.close()
   } finally {
     await service.stop()
+  }
+})
+
+test('rate limits WebSocket upgrades by source and authenticated node identity', async () => {
+  const sourceLimitedService = createJarvisGateway({
+    ownerToken,
+    sourceRateLimit: { capacity: 1, refillPerSecond: 0.001, maxKeys: 8 },
+  })
+  const sourceGateway = await sourceLimitedService.start()
+  try {
+    assert.equal((await request(sourceGateway, '/v1/health')).status, 200)
+    await new Promise((resolve, reject) => {
+      const socket = new WebSocket(`ws://127.0.0.1:${sourceGateway.port}/v1/node`)
+      socket.once('unexpected-response', (_request, response) => {
+        try {
+          assert.equal(response.statusCode, 429)
+          assert.equal(response.headers['x-ratelimit-limit'], '1')
+          assert.match(response.headers['x-correlation-id'] ?? '', /^[0-9a-f-]{36}$/)
+          response.resume()
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      })
+      socket.once('error', reject)
+    })
+  } finally {
+    await sourceLimitedService.stop()
+  }
+
+  const authority = new PairingAuthority()
+  const credential = issueCredential(authority)
+  const identityLimitedService = createJarvisGateway({
+    ownerToken,
+    authority,
+    sourceRateLimit: { capacity: 100, refillPerSecond: 100, maxKeys: 8 },
+    identityRateLimit: { capacity: 1, refillPerSecond: 0.001, maxKeys: 8 },
+  })
+  const identityGateway = await identityLimitedService.start()
+  try {
+    const issued = await request(identityGateway, '/v1/sessions', {
+      method: 'POST',
+      headers: { authorization: `Device ${credential}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ nodeId: 'node-1' }),
+    })
+    assert.equal(issued.status, 201)
+    const rejection = await new Promise((resolve, reject) => {
+      const socket = new WebSocket(`ws://127.0.0.1:${identityGateway.port}/v1/node`)
+      socket.once('open', () => socket.send(JSON.stringify({
+        type: 'node.authenticate',
+        protocolVersion: 1,
+        nodeId: 'node-1',
+        credential,
+      })))
+      socket.once('message', data => resolve(JSON.parse(data.toString())))
+      socket.once('error', reject)
+    })
+    assert.equal(rejection.type, 'node.rejected')
+    assert.equal(rejection.reason, 'node rate limit exceeded')
+  } finally {
+    await identityLimitedService.stop()
   }
 })
 

--- a/test/pairing.test.js
+++ b/test/pairing.test.js
@@ -44,6 +44,7 @@ test('wrong verification code does not issue a credential', () => {
   assert.throws(() => authority.confirm(request.requestId, '000000'), /incorrect/)
   const issued = authority.confirm(request.requestId, request.verificationCode)
   assert.equal(authority.authenticate('node-1', issued.credential), true)
+  assert.equal(authority.identify(issued.credential), 'node-1')
 })
 
 test('expired pairing requests cannot be confirmed', () => {
@@ -74,7 +75,9 @@ test('rotation invalidates the old credential while preserving device identity',
   assert.equal(rotated.generation, 2)
   assert.equal(rotated.publicKey, first.publicKey)
   assert.equal(authority.authenticate('node-1', first.credential), false)
+  assert.equal(authority.identify(first.credential), undefined)
   assert.equal(authority.authenticate('node-1', rotated.credential), true)
+  assert.equal(authority.identify(rotated.credential), 'node-1')
   assert.throws(() => authority.rotate('node-1', first.credential), /invalid or revoked/)
 })
 
@@ -85,6 +88,7 @@ test('revocation blocks current and future authentication', () => {
   const issued = authority.confirm(request.requestId, request.verificationCode)
   assert.equal(authority.revoke('node-1'), true)
   assert.equal(authority.authenticate('node-1', issued.credential), false)
+  assert.equal(authority.identify(issued.credential), undefined)
   assert.equal(authority.revoke('node-1'), false)
   assert.throws(() => authority.rotate('node-1', issued.credential), /invalid or revoked/)
 })

--- a/test/rate-limit.test.js
+++ b/test/rate-limit.test.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TokenBucketRateLimiter } from '../dist/rate-limit.js'
+
+function limiter(overrides = {}) {
+  let now = 1_000
+  const value = new TokenBucketRateLimiter({
+    capacity: 2,
+    refillPerSecond: 1,
+    maxKeys: 2,
+    now: () => now,
+    ...overrides,
+  })
+  return { value, advance: milliseconds => { now += milliseconds }, rewind: milliseconds => { now -= milliseconds } }
+}
+
+test('consumes capacity, reports retry delay, and refills over time', () => {
+  const clock = limiter()
+  assert.deepEqual(clock.value.consume('source-a'), { allowed: true, limit: 2, remaining: 1, retryAfterMs: 0 })
+  assert.deepEqual(clock.value.consume('source-a'), { allowed: true, limit: 2, remaining: 0, retryAfterMs: 0 })
+  assert.deepEqual(clock.value.consume('source-a'), { allowed: false, limit: 2, remaining: 0, retryAfterMs: 1_000 })
+  clock.advance(500)
+  assert.deepEqual(clock.value.consume('source-a'), { allowed: false, limit: 2, remaining: 0, retryAfterMs: 500 })
+  clock.advance(500)
+  assert.deepEqual(clock.value.consume('source-a'), { allowed: true, limit: 2, remaining: 0, retryAfterMs: 0 })
+})
+
+test('isolates keys and does not refill when the clock moves backwards', () => {
+  const clock = limiter()
+  clock.value.consume('source-a')
+  clock.value.consume('source-a')
+  assert.equal(clock.value.consume('source-b').allowed, true)
+  clock.rewind(500)
+  assert.equal(clock.value.consume('source-a').allowed, false)
+  clock.advance(1_500)
+  assert.equal(clock.value.consume('source-a').allowed, true)
+})
+
+test('fails closed at key capacity and reclaims only fully recovered buckets', () => {
+  const clock = limiter()
+  clock.value.consume('source-a')
+  clock.value.consume('source-b')
+  const full = clock.value.consume('source-c')
+  assert.equal(full.allowed, false)
+  assert.equal(full.retryAfterMs, 1_000)
+  clock.advance(999)
+  assert.equal(clock.value.consume('source-c').allowed, false)
+  clock.advance(1)
+  assert.equal(clock.value.consume('source-c').allowed, true)
+})
+
+test('rejects invalid limiter configuration and keys', () => {
+  assert.throws(() => new TokenBucketRateLimiter({ capacity: 0, refillPerSecond: 1, maxKeys: 1 }), /capacity/)
+  assert.throws(() => new TokenBucketRateLimiter({ capacity: 1.5, refillPerSecond: 1, maxKeys: 1 }), /capacity/)
+  assert.throws(() => new TokenBucketRateLimiter({ capacity: 1, refillPerSecond: 0, maxKeys: 1 }), /refillPerSecond/)
+  assert.throws(() => new TokenBucketRateLimiter({ capacity: 1, refillPerSecond: 1, maxKeys: 0 }), /maxKeys/)
+  assert.throws(() => limiter().value.consume(''), /must not be empty/)
+})

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -20,6 +20,9 @@ test('expires access, rotates refresh tokens, and revokes the family on reuse', 
   assert.deepEqual(authority.authenticate(first.accessToken), {
     sessionId: first.sessionId, familyId: first.familyId, nodeId: 'node-1',
   })
+  assert.deepEqual(authority.identifyRefresh(first.refreshToken), {
+    sessionId: first.sessionId, familyId: first.familyId, nodeId: 'node-1',
+  })
 
   now = first.accessExpiresAt
   assert.equal(authority.authenticate(first.accessToken), undefined)
@@ -28,11 +31,14 @@ test('expires access, rotates refresh tokens, and revokes the family on reuse', 
   assert.equal(second.familyId, first.familyId)
   assert.notEqual(second.accessToken, first.accessToken)
   assert.notEqual(second.refreshToken, first.refreshToken)
+  assert.equal(authority.identifyRefresh(first.refreshToken), undefined)
+  assert.equal(authority.identifyRefresh(second.refreshToken)?.sessionId, first.sessionId)
   assert.equal(authority.authenticate(first.accessToken), undefined)
   assert.equal(authority.authenticate(second.accessToken)?.nodeId, 'node-1')
 
   assert.throws(() => authority.refresh(first.refreshToken), sessionError('reuse'))
   assert.equal(authority.authenticate(second.accessToken), undefined)
+  assert.equal(authority.identifyRefresh(second.refreshToken), undefined)
   assert.equal(authority.list()[0].revokeReason, 'refresh-reuse')
 })
 


### PR DESCRIPTION
## Summary
- add bounded token buckets for direct connection sources and authenticated identities
- enforce HTTP and WebSocket limits with fail-closed key capacity and standard 429 metadata
- preserve refresh-token reuse revocation even when a session identity is exhausted
- bind device credentials to their identified node before session issuance or rotation

## Verification
- `npm run verify` (68/68)
- `npm run verify:runtime`
- `git diff --check`

Progresses #10; retained session events and the Harness bridge remain separate follow-up slices.