### PR TITLE
Add retained Gateway conversation events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ DEEPSEEK_API_KEY=replace-with-your-key
 # JARVIS_GATEWAY_TLS_KEY=/absolute/path/to/private/tls-key.pem
 # JARVIS_GATEWAY_TLS_CERT=/absolute/path/to/tls-certificate-chain.pem
 # JARVIS_SESSION_STATE=/absolute/path/to/private/session-state.json
+# JARVIS_EVENT_STATE=/absolute/path/to/private/event-state.json

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - 已实现私网受限的 `v1` Gateway 控制面原型：Owner/Device 认证、配对确认、轮换、撤销、请求 correlation ID、按连接来源和认证身份隔离的有界限流，以及 `/v1/node` WebSocket 的认证、能力注册和在线连接管理；默认 loopback，可启用私网 TLS，但禁止公网绑定。
 - Gateway 可由设备凭据签发短期访问会话；refresh 每次轮换，旧 refresh 复用、Owner 登出或设备撤销都会使会话族失效。
 - Gateway 通过固定 allowlist bridge 访问 loopback Harness；远程会话 API 只返回归一化的标题和最终用户/助手文本，不透传本机路径、内部事件、tool 或 reasoning 数据。
+- Gateway 已提供认证的 `/v1/events` WebSocket：只推送归一化会话事件，支持有界持久化游标重放；重启、游标过期或 Harness 事件中断时明确要求客户端全量刷新。
 
 ## 环境要求
 
@@ -75,9 +76,9 @@ Gateway 原型单独启动，必须通过环境变量提供 Owner Token：
 JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:gateway
 ```
 
-默认模式只监听 `127.0.0.1:3090`，并只连接 `http://127.0.0.1:3080` 的 Harness。可用 `JARVIS_HARNESS_URL` 指向其他 `127.0.0.1` 端口，`JARVIS_HARNESS_TIMEOUT_MS` 默认 10000；非 loopback Harness 地址会在启动前被拒绝。配对状态原子写入未纳入 Git 的 `data/pairing-state.json`。节点 WebSocket 只接受 `/v1/node`，并限制消息大小、握手时间和连接数。
+默认模式只监听 `127.0.0.1:3090`，并只连接 `http://127.0.0.1:3080` 的 Harness。可用 `JARVIS_HARNESS_URL` 指向其他 `127.0.0.1` 端口，`JARVIS_HARNESS_TIMEOUT_MS` 默认 10000；非 loopback Harness 地址会在启动前被拒绝。配对状态原子写入未纳入 Git 的 `data/pairing-state.json`。节点和客户端 WebSocket 分别只接受 `/v1/node` 与 `/v1/events`，并各自限制消息大小、握手时间和连接数。
 
-短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages` 和 `POST /v1/conversations/:id/cancel`。消息只接受最多 16 KiB 的纯文本；远程 slash command 被拒绝。当前响应提供已提交的历史，实时事件与 retained cursor 属于下一片。
+短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages` 和 `POST /v1/conversations/:id/cancel`。消息只接受最多 16 KiB 的纯文本；远程 slash command 被拒绝。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会要求先重新读取会话快照。
 
 Gateway 默认允许每个连接来源突发 60 次请求并每秒恢复 1 次额度；每个已认证 Owner、设备或 Session 可突发 120 次并每秒恢复 2 次额度。它只使用直接连接地址，不信任客户端提供的转发来源头；HTTP `429` 会返回 `Retry-After`、限额余量和 correlation ID。
 
@@ -91,7 +92,7 @@ JARVIS_GATEWAY_TLS_CERT='/private/path/gateway-certificate-chain.pem' \
 npm run start:gateway
 ```
 
-证书必须由连接设备信任并覆盖客户端使用的 Gateway 名称。该配置不会安装或管理 Tailscale，也不能直接暴露到互联网；完整手机体验仍需可从游标恢复的事件同步。
+证书必须由连接设备信任并覆盖客户端使用的 Gateway 名称。该配置不会安装或管理 Tailscale，也不能直接暴露到互联网；完整手机体验仍需 PWA、私网接入和设备端验收。
 
 Gateway 运行后，可以在另一个终端为当前 Mac 创建身份并完成人工验证码确认：
 
@@ -120,11 +121,11 @@ JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:node -- \
 - Harness 会话：`.dsh/sessions/`
 - Jarvis 提醒：`data/reminders.json`
 - Jarvis 审计：`data/audit.jsonl`
-- Gateway 配对与会话摘要：`data/pairing-state.json`、`data/session-state.json`
+- Gateway 配对、访问会话和有界归一化事件：`data/pairing-state.json`、`data/session-state.json`、`data/event-state.json`
 - API Key：仅存放在未纳入 Git 的 `.env`
 - 网络：Harness 始终只限本机回环；Gateway 仅可绑定明确的回环、私网或 overlay IP，非回环强制 TLS，禁止直接暴露到互联网
 
-这是单用户文字版 MVP，尚不包含手机 UI、实时远程事件、语音、智能家居、任意终端、文件操作和消息发送。Gateway 已提供认证、设备身份和受控会话 API；客户端不得直接暴露或调用 Harness Web 服务。
+这是单用户文字版 MVP，尚不包含手机 UI、语音、智能家居、任意终端、文件操作和消息发送。Gateway 已提供认证、设备身份、受控会话 API 和可恢复的实时事件；客户端不得直接暴露或调用 Harness Web 服务。
 
 ## 上游边界
 

--- a/docs/plan/architecture.md
+++ b/docs/plan/architecture.md
@@ -15,6 +15,8 @@ Build a local-first personal Jarvis that uses DeepSeek Harness as its agent runt
 - The plugin registered `/jarvis/health`; a live request returned HTTP 200 and an unsupported method returned HTTP 405.
 - The Gateway now reaches Harness through a loopback-only HTTP bridge with a fixed five-method session allowlist; real-process verification created, listed, and read an empty session without invoking a model.
 - Gateway conversation responses expose only normalized session metadata and append-origin user/assistant text; Harness paths, presets, projections, tools, reasoning, and raw events remain internal.
+- The authenticated `/v1/events` WebSocket projects the same public boundary, persists a bounded normalized replay log, closes on session expiry/revocation, and explicitly requires snapshot refresh after any replay gap.
+- Real-process verification observed a Harness session-created event through the Gateway and replayed that exact event after cursor reconnect without invoking a model.
 - Harness provides sessions, tools, model adapters, plugins, skills, MCP, subagents, jobs, workflows, schedules, workspaces, persistence, approvals, sandbox abstractions, Web UI, and host/client APIs.
 - The shipped Web server has no TLS, authentication, or origin policy. It must stay on loopback behind a Jarvis-owned security gateway.
 - The current SDK transport is subprocess stdio JSON-RPC. It is not a remote mobile API and lacks per-session close and prompt cancellation.
@@ -94,8 +96,8 @@ Optional later processes:
 
 ### AD-05: Internal communication
 
-- External clients: HTTPS plus versioned WebSocket events.
-- Gateway to Harness bridge: loopback HTTP/WebSocket initially; Unix domain socket is preferred when the bridge becomes independent of the Web carrier.
+- External clients: HTTPS plus authenticated versioned WebSocket events with bounded retained cursors and explicit snapshot fallback.
+- Gateway to Harness bridge: fixed-allowlist loopback HTTP plus normalized loopback WebSocket consumption; Unix domain socket is preferred when the bridge becomes independent of the Web carrier.
 - Device events: Home Assistant WebSocket API and MQTT 5.
 - Internal durable work: SQLite transactional outbox in V1. Do not add Redis, NATS, or Kafka until one-process delivery is insufficient.
 

--- a/scripts/verify-gateway-harness-runtime.mjs
+++ b/scripts/verify-gateway-harness-runtime.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import WebSocket from 'ws'
 import { createDeviceIdentity } from '../dist/pairing.js'
 
 const gateway = process.env.JARVIS_GATEWAY_URL
@@ -10,6 +11,57 @@ async function request(path, options = {}) {
   const text = await response.text()
   assert.match(response.headers.get('x-correlation-id') ?? '', /^[0-9a-f-]{36}$/)
   return { response, text, body: text.length === 0 ? undefined : JSON.parse(text) }
+}
+
+async function openEvents(accessToken, cursor) {
+  const endpoint = `${gateway.replace(/^http/, 'ws')}/v1/events`
+  const socket = new WebSocket(endpoint)
+  const queued = []
+  const waiters = []
+  socket.on('message', data => {
+    const value = JSON.parse(data.toString())
+    const waiter = waiters.shift()
+    if (waiter === undefined) queued.push(value)
+    else waiter(value)
+  })
+  await new Promise((resolve, reject) => {
+    socket.once('open', resolve)
+    socket.once('error', reject)
+  })
+  socket.send(JSON.stringify({
+    type: 'events.authenticate',
+    accessToken,
+    ...(cursor === undefined ? {} : { cursor }),
+  }))
+  return {
+    socket,
+    next(timeoutMs = 5_000) {
+      const value = queued.shift()
+      if (value !== undefined) return Promise.resolve(value)
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('timed out waiting for Gateway event')), timeoutMs)
+        waiters.push(event => {
+          clearTimeout(timer)
+          resolve(event)
+        })
+      })
+    },
+    close() {
+      if (socket.readyState === WebSocket.CLOSED) return Promise.resolve()
+      return new Promise(resolve => {
+        socket.once('close', resolve)
+        socket.close()
+      })
+    },
+  }
+}
+
+async function nextMatching(events, predicate) {
+  for (let count = 0; count < 20; count += 1) {
+    const event = await events.next()
+    if (predicate(event)) return event
+  }
+  throw new Error('expected Gateway event was not observed')
 }
 
 const identity = createDeviceIdentity()
@@ -41,9 +93,22 @@ const issued = await request('/v1/sessions', {
 assert.equal(issued.response.status, 201)
 const sessionHeaders = { authorization: `Session ${issued.body.accessToken}` }
 
+const events = await openEvents(issued.body.accessToken)
+const ready = await events.next()
+assert.equal(ready.type, 'events.ready')
+assert.match(ready.cursor, /^[A-Za-z0-9_-]{22}\.[0-9]+$/)
+if (ready.reason === 'harness_unavailable') {
+  await nextMatching(events, event => event.type === 'sync.required' && event.reason === 'gateway_restarted')
+}
+
 const created = await request('/v1/conversations', { method: 'POST', headers: sessionHeaders })
 assert.equal(created.response.status, 201)
 assert.match(created.body.conversation.id, /^session-[A-Za-z0-9-]+$/)
+const createdEvent = await nextMatching(events, event => event.type === 'conversation.created'
+  && event.conversation.id === created.body.conversation.id)
+assert.deepEqual(createdEvent.conversation, { id: created.body.conversation.id, blank: true })
+assert.doesNotMatch(JSON.stringify(createdEvent), /cwd|agentPreset|projections|reasoning|tool\//)
+events.socket.send(JSON.stringify({ type: 'events.ack', cursor: createdEvent.cursor }))
 
 const listed = await request('/v1/conversations', { headers: sessionHeaders })
 assert.equal(listed.response.status, 200)
@@ -57,4 +122,14 @@ assert.equal(history.body.hasMore, false)
 assert.equal(history.body.nextBeforeSequence, null)
 assert.doesNotMatch(history.text, /"events"|"projections"|"tool\/|"reasoning"/)
 
-console.log('Gateway-to-Harness runtime verification passed without invoking a model')
+await events.close()
+const resumedEvents = await openEvents(issued.body.accessToken, ready.cursor)
+const resumedReady = await resumedEvents.next()
+assert.equal(resumedReady.type, 'events.ready')
+assert.equal(resumedReady.requiresSnapshot, false)
+assert.equal(resumedReady.replayCount >= 1, true)
+const replayed = await nextMatching(resumedEvents, event => event.eventId === createdEvent.eventId)
+assert.deepEqual(replayed, createdEvent)
+await resumedEvents.close()
+
+console.log('Gateway-to-Harness HTTP and retained-event runtime verification passed without invoking a model')

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -1,0 +1,255 @@
+import { randomBytes, randomUUID } from 'node:crypto'
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import type { ConversationMessage } from './harness-bridge.js'
+
+const DEFAULT_MAX_EVENTS = 512
+const DEFAULT_MAX_BYTES = 8 * 1024 * 1024
+const CURSOR_PATTERN = /^([A-Za-z0-9_-]{22})\.([0-9]+)$/
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+
+export type SyncReason = 'gateway_restarted' | 'harness_disconnected'
+
+export type JarvisEventPayload =
+  | { type: 'conversation.created'; conversation: { id: string; blank: boolean } }
+  | { type: 'conversation.removed'; conversationId: string }
+  | { type: 'conversation.status'; conversationId: string; running: boolean }
+  | { type: 'conversation.message.committed'; conversationId: string; message: ConversationMessage }
+  | { type: 'conversation.error'; conversationId: string; code: 'harness_agent_error' }
+  | { type: 'sync.required'; reason: SyncReason }
+
+export type JarvisEvent = JarvisEventPayload & {
+  version: 1
+  eventId: string
+  cursor: string
+  occurredAt: number
+}
+
+export type ReplayReason = 'initial' | 'invalid_cursor' | 'gateway_restarted' | 'cursor_ahead' | 'cursor_expired'
+
+export interface EventReplay {
+  cursor: string
+  events: readonly JarvisEvent[]
+  requiresSnapshot: boolean
+  reason?: ReplayReason
+}
+
+interface EventLogSnapshot {
+  version: 1
+  epoch: string
+  nextSequence: number
+  events: JarvisEvent[]
+}
+
+export interface EventLogStore {
+  load(): EventLogSnapshot | undefined
+  save(snapshot: EventLogSnapshot): void
+}
+
+export interface RetainedEventLogOptions {
+  store?: EventLogStore
+  maxEvents?: number
+  maxBytes?: number
+  now?: () => number
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 1) throw new RangeError(`${name} must be a positive integer`)
+  return value
+}
+
+function validId(value: unknown): value is string {
+  return typeof value === 'string' && ID_PATTERN.test(value)
+}
+
+function exactFields(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  return Object.keys(value).every(key => allowed.includes(key)) && allowed.every(key => Object.hasOwn(value, key))
+}
+
+function validMessage(value: unknown): value is ConversationMessage {
+  return record(value) && exactFields(value, ['id', 'sequence', 'createdAt', 'role', 'text'])
+    && typeof value.id === 'string' && value.id.length > 0
+    && Number.isSafeInteger(value.sequence) && (value.sequence as number) >= 0
+    && typeof value.createdAt === 'number' && Number.isFinite(value.createdAt)
+    && (value.role === 'user' || value.role === 'assistant') && typeof value.text === 'string' && value.text.length > 0
+}
+
+function validPayload(value: Record<string, unknown>): boolean {
+  if (value.type === 'conversation.created') {
+    return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'conversation'])
+      && record(value.conversation) && exactFields(value.conversation, ['id', 'blank'])
+      && validId(value.conversation.id) && typeof value.conversation.blank === 'boolean'
+  }
+  if (value.type === 'conversation.removed') {
+    return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'conversationId'])
+      && validId(value.conversationId)
+  }
+  if (value.type === 'conversation.status') {
+    return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'conversationId', 'running'])
+      && validId(value.conversationId) && typeof value.running === 'boolean'
+  }
+  if (value.type === 'conversation.message.committed') {
+    return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'conversationId', 'message'])
+      && validId(value.conversationId) && validMessage(value.message)
+  }
+  if (value.type === 'conversation.error') {
+    return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'conversationId', 'code'])
+      && validId(value.conversationId) && value.code === 'harness_agent_error'
+  }
+  return value.type === 'sync.required' && exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'reason'])
+    && (value.reason === 'gateway_restarted' || value.reason === 'harness_disconnected')
+}
+
+function parseCursor(value: string): { epoch: string; sequence: number } | undefined {
+  const match = CURSOR_PATTERN.exec(value)
+  if (match === null) return undefined
+  const sequence = Number(match[2])
+  if (!Number.isSafeInteger(sequence) || sequence < 0) return undefined
+  return { epoch: match[1] as string, sequence }
+}
+
+function validEvent(value: unknown, epoch: string): value is JarvisEvent {
+  if (!record(value) || value.version !== 1 || typeof value.eventId !== 'string'
+    || !/^[0-9a-f-]{36}$/.test(value.eventId) || typeof value.cursor !== 'string'
+    || typeof value.occurredAt !== 'number' || !Number.isFinite(value.occurredAt) || !validPayload(value)) return false
+  return parseCursor(value.cursor)?.epoch === epoch
+}
+
+function eventBytes(event: JarvisEvent): number {
+  return Buffer.byteLength(JSON.stringify(event), 'utf8')
+}
+
+export class FileEventLogStore implements EventLogStore {
+  constructor(readonly path: string) {}
+
+  load(): EventLogSnapshot | undefined {
+    try {
+      return JSON.parse(readFileSync(this.path, 'utf8')) as EventLogSnapshot
+    } catch (error: unknown) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return undefined
+      throw new Error('event state could not be read')
+    }
+  }
+
+  save(snapshot: EventLogSnapshot): void {
+    mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 })
+    const temporary = `${this.path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
+    writeFileSync(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    chmodSync(temporary, 0o600)
+    renameSync(temporary, this.path)
+    chmodSync(this.path, 0o600)
+  }
+}
+
+export class RetainedEventLog {
+  private readonly store: EventLogStore | undefined
+  private readonly maxEvents: number
+  private readonly maxBytes: number
+  private readonly now: () => number
+  private readonly epoch: string
+  private nextSequence: number
+  private events: JarvisEvent[]
+  private readonly listeners = new Set<(event: JarvisEvent) => void>()
+  readonly restored: boolean
+
+  constructor(options: RetainedEventLogOptions = {}) {
+    this.store = options.store
+    this.maxEvents = positiveInteger(options.maxEvents ?? DEFAULT_MAX_EVENTS, 'maxEvents')
+    this.maxBytes = positiveInteger(options.maxBytes ?? DEFAULT_MAX_BYTES, 'maxBytes')
+    this.now = options.now ?? Date.now
+    const snapshot = this.store?.load()
+    this.restored = snapshot !== undefined
+    if (snapshot === undefined) {
+      this.epoch = randomBytes(16).toString('base64url')
+      this.nextSequence = 1
+      this.events = []
+      return
+    }
+    if (snapshot.version !== 1 || typeof snapshot.epoch !== 'string' || !/^[A-Za-z0-9_-]{22}$/.test(snapshot.epoch)
+      || !Number.isSafeInteger(snapshot.nextSequence) || snapshot.nextSequence < 1 || !Array.isArray(snapshot.events)
+      || snapshot.events.length > this.maxEvents || snapshot.events.some(event => !validEvent(event, snapshot.epoch))) {
+      throw new Error('event state contains invalid data')
+    }
+    const sequences = snapshot.events.map(event => parseCursor(event.cursor)?.sequence as number)
+    if (sequences.some((sequence, index) => sequence < 1 || (index > 0 && sequence !== (sequences[index - 1] as number) + 1))
+      || (sequences.length === 0 ? snapshot.nextSequence !== 1 : sequences.at(-1) !== snapshot.nextSequence - 1)
+      || new Set(snapshot.events.map(event => event.eventId)).size !== snapshot.events.length
+      || snapshot.events.reduce((total, event) => total + eventBytes(event), 0) > this.maxBytes) {
+      throw new Error('event state contains invalid sequence or retention data')
+    }
+    this.epoch = snapshot.epoch
+    this.nextSequence = snapshot.nextSequence
+    this.events = [...snapshot.events]
+  }
+
+  currentCursor(): string {
+    return `${this.epoch}.${this.nextSequence - 1}`
+  }
+
+  publish(payload: JarvisEventPayload): JarvisEvent {
+    const event = {
+      version: 1 as const,
+      eventId: randomUUID(),
+      cursor: `${this.epoch}.${this.nextSequence}`,
+      occurredAt: this.now(),
+      ...payload,
+    } as JarvisEvent
+    if (!validEvent(event, this.epoch)) throw new TypeError('event payload is invalid')
+    const previousNextSequence = this.nextSequence
+    const previousEvents = this.events
+    this.nextSequence += 1
+    this.events = [...this.events, event]
+    let bytes = this.events.reduce((total, item) => total + eventBytes(item), 0)
+    while (this.events.length > 1 && (this.events.length > this.maxEvents || bytes > this.maxBytes)) {
+      bytes -= eventBytes(this.events.shift() as JarvisEvent)
+    }
+    if (bytes > this.maxBytes) {
+      this.events = previousEvents
+      this.nextSequence = previousNextSequence
+      throw new RangeError('event exceeds the retention byte limit')
+    }
+    try {
+      this.persist()
+    } catch (error) {
+      this.events = previousEvents
+      this.nextSequence = previousNextSequence
+      throw error
+    }
+    for (const listener of this.listeners) listener(event)
+    return event
+  }
+
+  replay(cursor?: string): EventReplay {
+    const current = this.currentCursor()
+    if (cursor === undefined) return { cursor: current, events: [], requiresSnapshot: true, reason: 'initial' }
+    const parsed = parseCursor(cursor)
+    if (parsed === undefined) return { cursor: current, events: [], requiresSnapshot: true, reason: 'invalid_cursor' }
+    if (parsed.epoch !== this.epoch) return { cursor: current, events: [], requiresSnapshot: true, reason: 'gateway_restarted' }
+    const currentSequence = this.nextSequence - 1
+    if (parsed.sequence > currentSequence) return { cursor: current, events: [], requiresSnapshot: true, reason: 'cursor_ahead' }
+    const oldestSequence = this.events.length === 0
+      ? currentSequence + 1
+      : parseCursor((this.events[0] as JarvisEvent).cursor)?.sequence as number
+    if (parsed.sequence < oldestSequence - 1) {
+      return { cursor: current, events: [], requiresSnapshot: true, reason: 'cursor_expired' }
+    }
+    return {
+      cursor: current,
+      events: this.events.filter(event => (parseCursor(event.cursor)?.sequence as number) > parsed.sequence),
+      requiresSnapshot: false,
+    }
+  }
+
+  subscribe(listener: (event: JarvisEvent) => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private persist(): void {
+    this.store?.save({ version: 1, epoch: this.epoch, nextSequence: this.nextSequence, events: this.events })
+  }
+}

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -13,6 +13,7 @@ if (!Number.isInteger(configuredPort) || configuredPort < 0 || configuredPort > 
 const dataPath = process.env.JARVIS_DATA_DIR ?? join(process.cwd(), 'data')
 const statePath = process.env.JARVIS_PAIRING_STATE ?? join(dataPath, 'pairing-state.json')
 const sessionStatePath = process.env.JARVIS_SESSION_STATE ?? join(dataPath, 'session-state.json')
+const eventStatePath = process.env.JARVIS_EVENT_STATE ?? join(dataPath, 'event-state.json')
 const bindHost = process.env.JARVIS_GATEWAY_HOST ?? '127.0.0.1'
 const harnessOrigin = process.env.JARVIS_HARNESS_URL ?? 'http://127.0.0.1:3080'
 const harnessRequestTimeoutMs = process.env.JARVIS_HARNESS_TIMEOUT_MS === undefined
@@ -37,8 +38,8 @@ if (tlsKeyPath !== undefined && tlsCertPath !== undefined) {
 }
 
 const gateway = tls === undefined
-  ? createJarvisGateway({ ownerToken, pairingStatePath: statePath, sessionStatePath, bindHost, harnessOrigin, harnessRequestTimeoutMs })
-  : createJarvisGateway({ ownerToken, pairingStatePath: statePath, sessionStatePath, bindHost, harnessOrigin, harnessRequestTimeoutMs, tls })
+  ? createJarvisGateway({ ownerToken, pairingStatePath: statePath, sessionStatePath, eventStatePath, bindHost, harnessOrigin, harnessRequestTimeoutMs })
+  : createJarvisGateway({ ownerToken, pairingStatePath: statePath, sessionStatePath, eventStatePath, bindHost, harnessOrigin, harnessRequestTimeoutMs, tls })
 const running = await gateway.start(configuredPort)
 console.log(`Jarvis Gateway listening on ${running.origin}`)
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -3,7 +3,9 @@ import { createServer as createHttpServer, type IncomingMessage, type Server as 
 import { createServer as createHttpsServer, type Server as HttpsServer } from 'node:https'
 import { BlockList, isIP } from 'node:net'
 import { WebSocket, WebSocketServer, type RawData } from 'ws'
+import { FileEventLogStore, RetainedEventLog, type JarvisEvent } from './event-log.js'
 import { HarnessBridge, HarnessBridgeError, type HarnessClient } from './harness-bridge.js'
+import { HarnessEventBridge, type ConversationEventSource } from './harness-events.js'
 import { NODE_PROTOCOL_VERSION, parseNodeRegistration, type NodeRegistration } from './node-capabilities.js'
 import type { NodeCommand } from './node-command.js'
 import { FilePairingStateStore, PairingAuthority } from './pairing.js'
@@ -12,8 +14,11 @@ import { FileSessionStateStore, SessionAuthenticationError, SessionAuthority, ty
 
 const MAX_BODY_BYTES = 32 * 1024
 const NODE_PATH = '/v1/node'
+const EVENTS_PATH = '/v1/events'
 const NODE_HANDSHAKE_TIMEOUT_MS = 10_000
 const MAX_NODE_CONNECTIONS = 128
+const EVENT_HANDSHAKE_TIMEOUT_MS = 10_000
+const MAX_EVENT_CONNECTIONS = 128
 const DEFAULT_SOURCE_RATE_LIMIT = { capacity: 60, refillPerSecond: 1, maxKeys: 4_096 }
 const DEFAULT_IDENTITY_RATE_LIMIT = { capacity: 120, refillPerSecond: 2, maxKeys: 1_024 }
 const ALLOWED_BIND_ADDRESSES = new BlockList()
@@ -49,6 +54,11 @@ export interface JarvisGatewayOptions {
   harness?: HarnessClient
   harnessOrigin?: string
   harnessRequestTimeoutMs?: number
+  harnessEvents?: ConversationEventSource
+  eventLog?: RetainedEventLog
+  eventStatePath?: string
+  eventHandshakeTimeoutMs?: number
+  maxEventConnections?: number
 }
 
 export interface RunningGateway {
@@ -72,6 +82,18 @@ interface NodeConnectionState {
   nodeId?: string
   registration?: NodeRegistration
   handshakeTimer: ReturnType<typeof setTimeout>
+}
+
+interface EventConnectionState {
+  phase: 'authenticate' | 'ready'
+  correlationId: string
+  handshakeTimer: ReturnType<typeof setTimeout>
+  expiryTimer?: ReturnType<typeof setTimeout>
+  sessionId?: string
+  nodeId?: string
+  accessToken?: string
+  lastAcknowledgedCursor?: string
+  unsubscribe?: () => void
 }
 
 function sameSecret(expected: string, actual: string | undefined): boolean {
@@ -197,7 +219,7 @@ function parseSocketMessage(data: RawData, isBinary: boolean): Record<string, un
   }
 }
 
-function sendSocket(socket: WebSocket, message: Record<string, unknown>): boolean {
+function sendSocket(socket: WebSocket, message: unknown): boolean {
   if (socket.readyState !== WebSocket.OPEN) return false
   socket.send(JSON.stringify(message))
   return true
@@ -279,6 +301,14 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
   if (!Number.isInteger(maxNodeConnections) || maxNodeConnections < 1) {
     throw new RangeError('maxNodeConnections must be a positive integer')
   }
+  const eventHandshakeTimeoutMs = options.eventHandshakeTimeoutMs ?? EVENT_HANDSHAKE_TIMEOUT_MS
+  if (!Number.isInteger(eventHandshakeTimeoutMs) || eventHandshakeTimeoutMs < 1) {
+    throw new RangeError('eventHandshakeTimeoutMs must be a positive integer')
+  }
+  const maxEventConnections = options.maxEventConnections ?? MAX_EVENT_CONNECTIONS
+  if (!Number.isInteger(maxEventConnections) || maxEventConnections < 1) {
+    throw new RangeError('maxEventConnections must be a positive integer')
+  }
   const binding = validateBindHost(options.bindHost ?? '127.0.0.1')
   const tls = validateTls(options.tls)
   if (!binding.loopback && tls === undefined) throw new Error('TLS is required for non-loopback Gateway binding')
@@ -288,12 +318,28 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
     ...(options.harnessOrigin === undefined ? {} : { origin: options.harnessOrigin }),
     ...(options.harnessRequestTimeoutMs === undefined ? {} : { timeoutMs: options.harnessRequestTimeoutMs }),
   })
+  const eventLog = options.eventLog ?? new RetainedEventLog(
+    options.eventStatePath === undefined ? {} : { store: new FileEventLogStore(options.eventStatePath) },
+  )
+  const harnessEvents = options.harnessEvents ?? (options.harness === undefined
+    ? new HarnessEventBridge({
+        ...(options.harnessOrigin === undefined ? {} : { origin: options.harnessOrigin }),
+        listVisibleConversations: () => harness.listConversations(),
+      })
+    : {
+        start() {},
+        stop: () => Promise.resolve(),
+      })
   const sourceRateLimiter = new TokenBucketRateLimiter(options.sourceRateLimit ?? DEFAULT_SOURCE_RATE_LIMIT)
   const identityRateLimiter = new TokenBucketRateLimiter(options.identityRateLimit ?? DEFAULT_IDENTITY_RATE_LIMIT)
   let server: GatewayServer | undefined
-  let socketServer: WebSocketServer | undefined
+  let nodeSocketServer: WebSocketServer | undefined
+  let eventSocketServer: WebSocketServer | undefined
+  let harnessAvailable = false
+  let harnessWasAvailable = false
   const nodeConnections = new Map<string, WebSocket>()
   const connectionStates = new Map<WebSocket, NodeConnectionState>()
+  const eventConnectionStates = new Map<WebSocket, EventConnectionState>()
 
   const rejectNode = (socket: WebSocket, reason: string): void => {
     const state = connectionStates.get(socket)
@@ -388,6 +434,166 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
     socket.on('error', () => socket.terminate())
   }
 
+  const eventOriginAllowed = (request: IncomingMessage): boolean => {
+    const origin = request.headers.origin
+    if (origin === undefined) return true
+    if (typeof origin !== 'string' || request.headers.host === undefined) return false
+    try {
+      const parsed = new URL(origin)
+      const expected = new URL(`${secure ? 'https' : 'http'}://${request.headers.host}`)
+      return parsed.origin === expected.origin
+        && parsed.username === '' && parsed.password === '' && parsed.pathname === '/'
+        && parsed.search === '' && parsed.hash === ''
+    } catch {
+      return false
+    }
+  }
+
+  const rejectEvent = (socket: WebSocket, code: string, reason: string): void => {
+    const state = eventConnectionStates.get(socket)
+    if (state !== undefined) {
+      clearTimeout(state.handshakeTimer)
+      if (state.expiryTimer !== undefined) clearTimeout(state.expiryTimer)
+      state.unsubscribe?.()
+    }
+    if (socket.readyState !== WebSocket.OPEN) {
+      socket.terminate()
+      return
+    }
+    socket.send(JSON.stringify({
+      version: 1,
+      type: 'events.rejected',
+      code,
+      correlationId: state?.correlationId ?? randomUUID(),
+    }), () => socket.close(1008, reason))
+  }
+
+  const disconnectEventSession = (sessionId: string, reason: string): void => {
+    for (const [socket, state] of eventConnectionStates) {
+      if (state.sessionId === sessionId) rejectEvent(socket, 'session_invalid', reason)
+    }
+  }
+
+  const disconnectEventDevice = (nodeId: string, reason: string): void => {
+    for (const [socket, state] of eventConnectionStates) {
+      if (state.nodeId === nodeId) rejectEvent(socket, 'device_revoked', reason)
+    }
+  }
+
+  const revalidateEventSockets = (): void => {
+    for (const [socket, state] of eventConnectionStates) {
+      if (state.accessToken !== undefined && sessions.authenticate(state.accessToken) === undefined) {
+        rejectEvent(socket, 'session_invalid', 'session access ended')
+      } else if (state.nodeId !== undefined && !authority.isActive(state.nodeId)) {
+        rejectEvent(socket, 'device_revoked', 'device access revoked')
+      }
+    }
+  }
+
+  const handleEventMessage = (socket: WebSocket, data: RawData, isBinary: boolean): void => {
+    const state = eventConnectionStates.get(socket)
+    if (state === undefined) return
+    const message = parseSocketMessage(data, isBinary)
+    if (message === undefined || typeof message.type !== 'string') {
+      rejectEvent(socket, 'invalid_message', 'invalid event message')
+      return
+    }
+    if (state.phase === 'authenticate') {
+      if (message.type !== 'events.authenticate' || !exactFields(message, ['type', 'accessToken', 'cursor'])
+        || typeof message.accessToken !== 'string'
+        || (message.cursor !== undefined && (typeof message.cursor !== 'string' || message.cursor.length > 200))) {
+        rejectEvent(socket, 'authentication_rejected', 'event authentication rejected')
+        return
+      }
+      const principal = sessions.authenticate(message.accessToken)
+      if (principal === undefined || !authority.isActive(principal.nodeId)) {
+        if (principal !== undefined) sessions.revokeDevice(principal.nodeId)
+        rejectEvent(socket, 'authentication_rejected', 'event authentication rejected')
+        return
+      }
+      const identityDecision = identityRateLimiter.consume(`session:${principal.sessionId}`)
+      if (!identityDecision.allowed) {
+        rejectEvent(socket, 'rate_limited', 'event rate limit exceeded')
+        return
+      }
+      const view = sessions.get(principal.sessionId)
+      if (view === undefined || view.revokedAt !== null) {
+        rejectEvent(socket, 'authentication_rejected', 'event authentication rejected')
+        return
+      }
+      const replay = eventLog.replay(message.cursor as string | undefined)
+      const queued: JarvisEvent[] = []
+      let replaying = true
+      state.unsubscribe = eventLog.subscribe(event => {
+        if (replaying) queued.push(event)
+        else sendSocket(socket, event)
+      })
+      state.sessionId = principal.sessionId
+      state.nodeId = principal.nodeId
+      state.accessToken = message.accessToken
+      state.phase = 'ready'
+      clearTimeout(state.handshakeTimer)
+      const expiryTimer = setTimeout(
+        () => rejectEvent(socket, 'session_expired', 'session access expired'),
+        Math.max(1, view.accessExpiresAt - Date.now()),
+      )
+      expiryTimer.unref()
+      state.expiryTimer = expiryTimer
+      const requiresSnapshot = replay.requiresSnapshot || !harnessAvailable
+      const reason = !harnessAvailable ? 'harness_unavailable' : replay.reason
+      sendSocket(socket, {
+        version: 1,
+        type: 'events.ready',
+        cursor: replay.cursor,
+        replayCount: replay.events.length,
+        requiresSnapshot,
+        ...(reason === undefined ? {} : { reason }),
+        correlationId: state.correlationId,
+      })
+      if (!requiresSnapshot) {
+        for (const event of replay.events) sendSocket(socket, event)
+      }
+      replaying = false
+      for (const event of queued) sendSocket(socket, event)
+      return
+    }
+    if (message.type !== 'events.ack' || !exactFields(message, ['type', 'cursor']) || typeof message.cursor !== 'string'
+      || message.cursor.length > 200 || state.accessToken === undefined
+      || sessions.authenticate(state.accessToken) === undefined) {
+      rejectEvent(socket, 'invalid_message', 'invalid event acknowledgement')
+      return
+    }
+    const identityDecision = identityRateLimiter.consume(`session:${state.sessionId as string}`)
+    if (!identityDecision.allowed) {
+      rejectEvent(socket, 'rate_limited', 'event rate limit exceeded')
+      return
+    }
+    const acknowledged = eventLog.replay(message.cursor)
+    if (acknowledged.requiresSnapshot) {
+      rejectEvent(socket, 'invalid_cursor', 'event acknowledgement cursor is invalid')
+      return
+    }
+    state.lastAcknowledgedCursor = message.cursor
+  }
+
+  const handleEventConnection = (socket: WebSocket, request: IncomingMessage): void => {
+    const state: EventConnectionState = {
+      phase: 'authenticate',
+      correlationId: requestCorrelationId(request),
+      handshakeTimer: setTimeout(() => rejectEvent(socket, 'handshake_timeout', 'event handshake timed out'), eventHandshakeTimeoutMs),
+    }
+    state.handshakeTimer.unref()
+    eventConnectionStates.set(socket, state)
+    socket.on('message', (data, isBinary) => handleEventMessage(socket, data, isBinary))
+    socket.on('close', () => {
+      clearTimeout(state.handshakeTimer)
+      if (state.expiryTimer !== undefined) clearTimeout(state.expiryTimer)
+      state.unsubscribe?.()
+      eventConnectionStates.delete(socket)
+    })
+    socket.on('error', () => socket.terminate())
+  }
+
   const handle = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
     const correlationId = requestCorrelationId(request)
     try {
@@ -415,6 +621,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         : sessions.authenticate(sessionToken)
       if (sessionPrincipal !== undefined && !authority.isActive(sessionPrincipal.nodeId)) {
         sessions.revokeDevice(sessionPrincipal.nodeId)
+        disconnectEventDevice(sessionPrincipal.nodeId, 'device access revoked')
         sessionPrincipal = undefined
       }
       if (request.method === 'POST' && parts.length === 3 && parts[0] === 'v1' && parts[1] === 'sessions' && parts[2] === 'refresh') {
@@ -424,6 +631,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         if (refreshPrincipal !== undefined) {
           if (!authority.isActive(refreshPrincipal.nodeId)) {
             sessions.revokeDevice(refreshPrincipal.nodeId)
+            disconnectEventDevice(refreshPrincipal.nodeId, 'device access revoked')
             sendJson(response, 401, correlationId, { error: 'session device is revoked', code: 'device_revoked', correlationId })
             return
           }
@@ -435,14 +643,17 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         }
         try {
           const refreshed = sessions.refresh(body.refreshToken)
+          disconnectEventSession(refreshed.sessionId, 'session access refreshed')
           if (!authority.isActive(refreshed.nodeId)) {
             sessions.revokeDevice(refreshed.nodeId)
+            disconnectEventDevice(refreshed.nodeId, 'device access revoked')
             sendJson(response, 401, correlationId, { error: 'session device is revoked', code: 'device_revoked', correlationId })
             return
           }
           sendJson(response, 200, correlationId, refreshed)
         } catch (error) {
           if (!(error instanceof SessionAuthenticationError)) throw error
+          revalidateEventSockets()
           const code = error.code === 'reuse' ? 'refresh_reuse_detected' : `refresh_${error.code}`
           sendJson(response, 401, correlationId, { error: 'session refresh rejected', code, correlationId })
         }
@@ -552,6 +763,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
           sendJson(response, 404, correlationId, { error: 'session not found or already revoked', correlationId })
           return
         }
+        disconnectEventSession(parts[2] as string, 'session signed out')
         sendJson(response, 204, correlationId, {})
         return
       }
@@ -608,6 +820,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
           if (!authority.revoke(nodeId)) throw new Error('device revocation failed')
           sendJson(response, 204, correlationId, {})
           disconnectNode(nodeId, 'device access revoked')
+          disconnectEventDevice(nodeId, 'device access revoked')
           return
         }
       }
@@ -623,14 +836,29 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
     }
   }
 
+  const handleHarnessAvailability = (available: boolean): void => {
+    if (!available) {
+      if (harnessAvailable) eventLog.publish({ type: 'sync.required', reason: 'harness_disconnected' })
+      harnessAvailable = false
+      return
+    }
+    harnessAvailable = true
+    if (!harnessWasAvailable) {
+      eventLog.publish({ type: 'sync.required', reason: 'gateway_restarted' })
+    }
+    harnessWasAvailable = true
+  }
+
   return {
     start(port = 0) {
       if (server !== undefined) return Promise.reject(new Error('gateway is already running'))
       server = tls === undefined
         ? createHttpServer((request, response) => { void handle(request, response) })
         : createHttpsServer({ ...tls, minVersion: 'TLSv1.2' }, (request, response) => { void handle(request, response) })
-      socketServer = new WebSocketServer({ noServer: true, maxPayload: maxBodyBytes })
-      socketServer.on('connection', handleNodeConnection)
+      nodeSocketServer = new WebSocketServer({ noServer: true, maxPayload: maxBodyBytes })
+      eventSocketServer = new WebSocketServer({ noServer: true, maxPayload: maxBodyBytes })
+      nodeSocketServer.on('connection', handleNodeConnection)
+      eventSocketServer.on('connection', handleEventConnection)
       server.on('upgrade', (request, socket, head) => {
         const correlationId = requestCorrelationId(request)
         const sourceDecision = sourceRateLimiter.consume(sourceKey(request))
@@ -642,20 +870,36 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
           })
           return
         }
-        const path = new URL(request.url ?? '/', 'http://127.0.0.1').pathname
-        if (path !== NODE_PATH) {
+        const parsed = new URL(request.url ?? '/', 'http://127.0.0.1')
+        if ([...parsed.searchParams.keys()].length !== 0) {
           rejectUpgrade(socket, 404)
           return
         }
-        if (request.headers.origin !== undefined) {
-          rejectUpgrade(socket, 403)
+        if (parsed.pathname === NODE_PATH) {
+          if (request.headers.origin !== undefined) {
+            rejectUpgrade(socket, 403)
+            return
+          }
+          if (nodeSocketServer === undefined || nodeSocketServer.clients.size >= maxNodeConnections) {
+            rejectUpgrade(socket, 503)
+            return
+          }
+          nodeSocketServer.handleUpgrade(request, socket, head, upgraded => nodeSocketServer?.emit('connection', upgraded, request))
           return
         }
-        if (socketServer === undefined || socketServer.clients.size >= maxNodeConnections) {
-          rejectUpgrade(socket, 503)
+        if (parsed.pathname === EVENTS_PATH) {
+          if (!eventOriginAllowed(request)) {
+            rejectUpgrade(socket, 403)
+            return
+          }
+          if (eventSocketServer === undefined || eventSocketServer.clients.size >= maxEventConnections) {
+            rejectUpgrade(socket, 503)
+            return
+          }
+          eventSocketServer.handleUpgrade(request, socket, head, upgraded => eventSocketServer?.emit('connection', upgraded, request))
           return
         }
-        socketServer.handleUpgrade(request, socket, head, upgraded => socketServer?.emit('connection', upgraded, request))
+        rejectUpgrade(socket, 404)
       })
       return new Promise<RunningGateway>((resolve, reject) => {
         server?.once('error', reject)
@@ -667,6 +911,22 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
           }
           const host = binding.host.includes(':') ? `[${binding.host}]` : binding.host
           const protocol = secure ? 'https' : 'http'
+          try {
+            harnessEvents.start({
+              onEvent: event => { eventLog.publish(event) },
+              onAvailability: handleHarnessAvailability,
+            })
+          } catch (error) {
+            const failedServer = server
+            server = undefined
+            nodeSocketServer?.close()
+            eventSocketServer?.close()
+            nodeSocketServer = undefined
+            eventSocketServer = undefined
+            failedServer?.close()
+            reject(error)
+            return
+          }
           resolve({
             server: server as GatewayServer,
             host: binding.host,
@@ -680,15 +940,26 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
     stop() {
       if (server === undefined) return Promise.resolve()
       const current = server
-      const currentSocketServer = socketServer
+      const currentNodeSocketServer = nodeSocketServer
+      const currentEventSocketServer = eventSocketServer
       server = undefined
-      socketServer = undefined
+      nodeSocketServer = undefined
+      eventSocketServer = undefined
       for (const state of connectionStates.values()) clearTimeout(state.handshakeTimer)
-      for (const socket of currentSocketServer?.clients ?? []) socket.terminate()
+      for (const state of eventConnectionStates.values()) {
+        clearTimeout(state.handshakeTimer)
+        if (state.expiryTimer !== undefined) clearTimeout(state.expiryTimer)
+        state.unsubscribe?.()
+      }
+      for (const socket of currentNodeSocketServer?.clients ?? []) socket.terminate()
+      for (const socket of currentEventSocketServer?.clients ?? []) socket.terminate()
       nodeConnections.clear()
       connectionStates.clear()
-      currentSocketServer?.close()
-      return new Promise<void>((resolve, reject) => current.close(error => error === undefined ? resolve() : reject(error)))
+      eventConnectionStates.clear()
+      currentNodeSocketServer?.close()
+      currentEventSocketServer?.close()
+      const serverClosed = new Promise<void>((resolve, reject) => current.close(error => error === undefined ? resolve() : reject(error)))
+      return Promise.all([serverClosed, harnessEvents.stop()]).then(() => undefined)
     },
     connectedNodeIds() {
       return [...nodeConnections.keys()].sort()

--- a/src/harness-bridge.ts
+++ b/src/harness-bridge.ts
@@ -102,9 +102,9 @@ function textFromBlocks(value: unknown): string {
   return value.flatMap(block => record(block) && block.type === 'text' && typeof block.text === 'string' ? [block.text] : []).join('')
 }
 
-function messageFromEntry(value: unknown): ConversationMessage | undefined {
-  if (!record(value) || !record(value.event)) return undefined
-  const event = value.event
+export function conversationMessageFromHarnessEvent(value: unknown): ConversationMessage | undefined {
+  if (!record(value)) return undefined
+  const event = value
   if (event.surfaceOp !== 'append') return undefined
   const sequence = event.seq
   const createdAt = event.time
@@ -121,6 +121,11 @@ function messageFromEntry(value: unknown): ConversationMessage | undefined {
     return { id: message.id, sequence: sequence as number, createdAt, role: 'assistant', text }
   }
   return undefined
+}
+
+function messageFromEntry(value: unknown): ConversationMessage | undefined {
+  if (!record(value)) return undefined
+  return conversationMessageFromHarnessEvent(value.event)
 }
 
 async function readBoundedJson(response: Response, maxBytes: number): Promise<unknown> {
@@ -162,8 +167,9 @@ export class HarnessBridge implements HarnessClient {
   async listConversations(): Promise<readonly ConversationSummary[]> {
     const value = await this.call('session.list', {})
     if (!record(value) || !Array.isArray(value.items)) throw new HarnessBridgeError('protocol', 'Harness returned an invalid session list')
-    return value.items.map(item => {
-      if (!record(item) || typeof item.running !== 'boolean' || typeof item.blank !== 'boolean') {
+    return value.items.filter(item => !record(item) || item.origin !== 'subagent').map(item => {
+      if (!record(item) || typeof item.running !== 'boolean' || typeof item.blank !== 'boolean'
+        || (item.origin !== undefined && item.origin !== 'subagent')) {
         throw new HarnessBridgeError('protocol', 'Harness returned an invalid session summary')
       }
       return {

--- a/src/harness-events.ts
+++ b/src/harness-events.ts
@@ -1,0 +1,245 @@
+import { WebSocket, type RawData } from 'ws'
+import type { JarvisEventPayload } from './event-log.js'
+import {
+  conversationMessageFromHarnessEvent,
+  type ConversationSummary,
+} from './harness-bridge.js'
+
+const DEFAULT_RECONNECT_DELAY_MS = 1_000
+const DEFAULT_MAX_FRAME_BYTES = 2 * 1024 * 1024
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+
+type ChannelName = 'mux' | 'host'
+
+export interface ConversationEventSourceHandlers {
+  onEvent(event: JarvisEventPayload): void
+  onAvailability(available: boolean): void
+}
+
+export interface ConversationEventSource {
+  start(handlers: ConversationEventSourceHandlers): void
+  stop(): Promise<void>
+}
+
+export interface HarnessEventBridgeOptions {
+  origin?: string
+  reconnectDelayMs?: number
+  maxFrameBytes?: number
+  listVisibleConversations: () => Promise<readonly ConversationSummary[]>
+  socketFactory?: (url: string, maxPayload: number) => WebSocket
+}
+
+interface ChannelState {
+  socket: WebSocket | undefined
+  reconnectTimer: ReturnType<typeof setTimeout> | undefined
+  open: boolean
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 1) throw new RangeError(`${name} must be a positive integer`)
+  return value
+}
+
+function validateOrigin(value: string): URL {
+  const origin = new URL(value)
+  if (origin.protocol !== 'http:' || origin.hostname !== '127.0.0.1'
+    || origin.username !== '' || origin.password !== '' || origin.pathname !== '/'
+    || origin.search !== '' || origin.hash !== '') {
+    throw new Error('Harness event origin must be an exact http://127.0.0.1[:port] origin')
+  }
+  return origin
+}
+
+function sessionId(value: unknown): string | undefined {
+  return typeof value === 'string' && SESSION_ID_PATTERN.test(value) ? value : undefined
+}
+
+function socketUrl(origin: URL, channel: ChannelName): string {
+  const url = new URL(`/api/events.${channel}`, origin)
+  url.protocol = 'ws:'
+  return url.toString()
+}
+
+export class HarnessEventBridge implements ConversationEventSource {
+  private readonly origin: URL
+  private readonly reconnectDelayMs: number
+  private readonly maxFrameBytes: number
+  private readonly listVisibleConversations: () => Promise<readonly ConversationSummary[]>
+  private readonly socketFactory: (url: string, maxPayload: number) => WebSocket
+  private readonly channels: Record<ChannelName, ChannelState> = {
+    mux: { socket: undefined, reconnectTimer: undefined, open: false },
+    host: { socket: undefined, reconnectTimer: undefined, open: false },
+  }
+  private readonly visibleSessions = new Set<string>()
+  private handlers: ConversationEventSourceHandlers | undefined
+  private stopped = true
+  private available = false
+  private visibilityGeneration = 0
+
+  constructor(options: HarnessEventBridgeOptions) {
+    this.origin = validateOrigin(options.origin ?? 'http://127.0.0.1:3080')
+    this.reconnectDelayMs = positiveInteger(options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS, 'reconnectDelayMs')
+    this.maxFrameBytes = positiveInteger(options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES, 'maxFrameBytes')
+    this.listVisibleConversations = options.listVisibleConversations
+    this.socketFactory = options.socketFactory ?? ((url, maxPayload) => new WebSocket(url, { maxPayload }))
+  }
+
+  start(handlers: ConversationEventSourceHandlers): void {
+    if (!this.stopped) throw new Error('Harness event bridge is already running')
+    this.handlers = handlers
+    this.stopped = false
+    this.connect('mux')
+    this.connect('host')
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return
+    this.stopped = true
+    this.visibilityGeneration += 1
+    this.setAvailable(false)
+    for (const channel of Object.values(this.channels)) {
+      if (channel.reconnectTimer !== undefined) clearTimeout(channel.reconnectTimer)
+      channel.reconnectTimer = undefined
+      channel.open = false
+      channel.socket?.terminate()
+      channel.socket = undefined
+    }
+    this.handlers = undefined
+  }
+
+  private connect(name: ChannelName): void {
+    if (this.stopped) return
+    const state = this.channels[name]
+    let socket: WebSocket
+    try {
+      socket = this.socketFactory(socketUrl(this.origin, name), this.maxFrameBytes)
+    } catch {
+      this.scheduleReconnect(name)
+      return
+    }
+    state.socket = socket
+    socket.once('open', () => {
+      if (state.socket !== socket || this.stopped) return
+      state.open = true
+      this.refreshVisibility()
+    })
+    socket.on('message', (data, isBinary) => {
+      if (state.socket !== socket || this.stopped) return
+      try {
+        this.handleFrame(name, data, isBinary)
+      } catch {
+        socket.close(1002, 'invalid Harness event frame')
+      }
+    })
+    const disconnected = (): void => {
+      if (state.socket !== socket) return
+      state.socket = undefined
+      state.open = false
+      this.visibilityGeneration += 1
+      this.setAvailable(false)
+      this.scheduleReconnect(name)
+    }
+    socket.once('close', disconnected)
+    socket.once('error', disconnected)
+  }
+
+  private scheduleReconnect(name: ChannelName): void {
+    if (this.stopped || this.channels[name].reconnectTimer !== undefined) return
+    const timer = setTimeout(() => {
+      const state = this.channels[name]
+      state.reconnectTimer = undefined
+      this.connect(name)
+    }, this.reconnectDelayMs)
+    timer.unref()
+    this.channels[name].reconnectTimer = timer
+  }
+
+  private refreshVisibility(): void {
+    if (!this.channels.mux.open || !this.channels.host.open || this.stopped) return
+    const generation = ++this.visibilityGeneration
+    void this.listVisibleConversations().then(conversations => {
+      if (this.stopped || generation !== this.visibilityGeneration
+        || !this.channels.mux.open || !this.channels.host.open) return
+      this.visibleSessions.clear()
+      for (const conversation of conversations) this.visibleSessions.add(conversation.id)
+      this.setAvailable(true)
+    }).catch(() => {
+      if (generation !== this.visibilityGeneration || this.stopped) return
+      this.setAvailable(false)
+      this.channels.mux.socket?.close(1011, 'Harness visibility unavailable')
+      this.channels.host.socket?.close(1011, 'Harness visibility unavailable')
+    })
+  }
+
+  private setAvailable(value: boolean): void {
+    if (this.available === value) return
+    this.available = value
+    this.handlers?.onAvailability(value)
+  }
+
+  private handleFrame(channel: ChannelName, data: RawData, isBinary: boolean): void {
+    if (isBinary) throw new Error('binary Harness event frame')
+    let envelope: unknown
+    try {
+      envelope = JSON.parse(data.toString()) as unknown
+    } catch {
+      throw new Error('malformed Harness event frame')
+    }
+    if (!record(envelope) || envelope.type !== 'server-request' || typeof envelope.rpcId !== 'string'
+      || typeof envelope.method !== 'string' || !record(envelope.payload)
+      || envelope.method !== envelope.payload.type) throw new Error('invalid Harness event envelope')
+    if (envelope.payload.type === 'stream/error') throw new Error('Harness event stream failed')
+    if (channel === 'mux') this.handleMux(envelope.payload)
+    else this.handleHost(envelope.payload)
+  }
+
+  private handleMux(payload: Record<string, unknown>): void {
+    if (payload.type === 'session/subscribed') {
+      if (sessionId(payload.sessionId) === undefined || !Number.isInteger(payload.lastSeq) || (payload.lastSeq as number) < -1) {
+        throw new Error('invalid Harness subscription frame')
+      }
+      return
+    }
+    if (payload.type !== 'session/event') return
+    const conversationId = sessionId(payload.sessionId)
+    if (conversationId === undefined || !record(payload.event)) throw new Error('invalid Harness session event frame')
+    if (!this.available || !this.visibleSessions.has(conversationId)) return
+    const message = conversationMessageFromHarnessEvent(payload.event)
+    if (message !== undefined) {
+      this.handlers?.onEvent({ type: 'conversation.message.committed', conversationId, message })
+    }
+  }
+
+  private handleHost(payload: Record<string, unknown>): void {
+    const conversationId = sessionId(payload.sessionId)
+    if (payload.type === 'host/session-added') {
+      if (conversationId === undefined || typeof payload.blank !== 'boolean') throw new Error('invalid Harness session-added frame')
+      if (payload.origin !== undefined && payload.origin !== 'subagent') throw new Error('invalid Harness session origin')
+      if (payload.origin === 'subagent') return
+      this.visibleSessions.add(conversationId)
+      if (this.available) {
+        this.handlers?.onEvent({ type: 'conversation.created', conversation: { id: conversationId, blank: payload.blank } })
+      }
+      return
+    }
+    if (payload.type === 'host/session-removed') {
+      if (conversationId === undefined) throw new Error('invalid Harness session-removed frame')
+      if (!this.visibleSessions.delete(conversationId) || !this.available) return
+      this.handlers?.onEvent({ type: 'conversation.removed', conversationId })
+      return
+    }
+    if (payload.type === 'host/session-status') {
+      if (conversationId === undefined || typeof payload.running !== 'boolean') throw new Error('invalid Harness session-status frame')
+      if (!this.available || !this.visibleSessions.has(conversationId)) return
+      this.handlers?.onEvent({ type: 'conversation.status', conversationId, running: payload.running })
+    } else if (payload.type === 'host/agent-error') {
+      if (conversationId === undefined || typeof payload.message !== 'string') throw new Error('invalid Harness agent-error frame')
+      if (!this.available || !this.visibleSessions.has(conversationId)) return
+      this.handlers?.onEvent({ type: 'conversation.error', conversationId, code: 'harness_agent_error' })
+    }
+  }
+}

--- a/test/event-log.test.js
+++ b/test/event-log.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { FileEventLogStore, RetainedEventLog } from '../dist/event-log.js'
+
+function status(id, running) {
+  return { type: 'conversation.status', conversationId: id, running }
+}
+
+test('retains monotonic events, replays from a cursor, and reports explicit gaps', () => {
+  let now = 1_000
+  const log = new RetainedEventLog({ maxEvents: 2, now: () => now++ })
+  const initial = log.currentCursor()
+  const first = log.publish(status('session-one', true))
+  const second = log.publish(status('session-one', false))
+  const third = log.publish({ type: 'conversation.removed', conversationId: 'session-one' })
+
+  assert.equal(first.version, 1)
+  assert.equal(first.occurredAt, 1_000)
+  assert.deepEqual(log.replay(second.cursor), {
+    cursor: third.cursor, events: [third], requiresSnapshot: false,
+  })
+  assert.deepEqual(log.replay(first.cursor), {
+    cursor: third.cursor, events: [second, third], requiresSnapshot: false,
+  })
+  assert.equal(log.replay(initial).reason, 'cursor_expired')
+  assert.equal(log.replay('invalid').reason, 'invalid_cursor')
+  assert.equal(log.replay(`${third.cursor.split('.')[0]}.999`).reason, 'cursor_ahead')
+  assert.equal(log.replay().reason, 'initial')
+})
+
+test('persists only normalized retained events with private permissions', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-events-'))
+  const path = join(directory, 'event-state.json')
+  try {
+    const first = new RetainedEventLog({ store: new FileEventLogStore(path) })
+    const event = first.publish({
+      type: 'conversation.message.committed',
+      conversationId: 'session-one',
+      message: { id: 'message-one', sequence: 2, createdAt: 3, role: 'assistant', text: 'Visible answer' },
+    })
+    const restored = new RetainedEventLog({ store: new FileEventLogStore(path) })
+    assert.equal(restored.restored, true)
+    assert.equal(restored.currentCursor(), event.cursor)
+    assert.deepEqual(restored.replay(event.cursor), { cursor: event.cursor, events: [], requiresSnapshot: false })
+    assert.equal((await stat(directory)).mode & 0o777, 0o700)
+    assert.equal((await stat(path)).mode & 0o777, 0o600)
+    const stored = await readFile(path, 'utf8')
+    assert.match(stored, /Visible answer/)
+    assert.doesNotMatch(stored, /cwd|agentPreset|reasoning|tool\/result/)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects invalid payloads and oversized single events before publication', () => {
+  const log = new RetainedEventLog({ maxBytes: 256 })
+  assert.throws(() => log.publish({ type: 'conversation.status', conversationId: '../private', running: true }), /payload/)
+  assert.throws(() => log.publish({
+    type: 'conversation.status', conversationId: 'session-one', running: true, cwd: '/private/path',
+  }), /payload/)
+  assert.throws(() => log.publish({
+    type: 'conversation.message.committed',
+    conversationId: 'session-one',
+    message: { id: 'message-one', sequence: 1, createdAt: 1, role: 'assistant', text: 'x'.repeat(512) },
+  }), /retention byte limit/)
+})
+
+test('rolls back an event when durable persistence fails', () => {
+  const log = new RetainedEventLog({
+    store: { load: () => undefined, save: () => { throw new Error('disk unavailable') } },
+  })
+  const cursor = log.currentCursor()
+  assert.throws(() => log.publish(status('session-one', true)), /disk unavailable/)
+  assert.equal(log.currentCursor(), cursor)
+  assert.equal(log.replay(cursor).events.length, 0)
+})

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
 import WebSocket from 'ws'
+import { RetainedEventLog } from '../dist/event-log.js'
 import { createJarvisGateway } from '../dist/gateway.js'
 import { HarnessBridgeError } from '../dist/harness-bridge.js'
 import { NodeAgent } from '../dist/node-agent.js'
@@ -98,6 +99,40 @@ function nodeAgentConfig(endpoint, credential, socketFactory, execute) {
     },
     policy: new NodePolicy({ capabilities: { system_status: { version: 1 } } }),
     execute,
+  }
+}
+
+function socketInbox(socket) {
+  const queued = []
+  const waiters = []
+  socket.on('message', data => {
+    const value = JSON.parse(data.toString())
+    const waiter = waiters.shift()
+    if (waiter === undefined) queued.push(value)
+    else waiter.resolve(value)
+  })
+  socket.on('error', error => {
+    for (const waiter of waiters.splice(0)) waiter.reject(error)
+  })
+  return {
+    next() {
+      const value = queued.shift()
+      if (value !== undefined) return Promise.resolve(value)
+      return new Promise((resolve, reject) => waiters.push({ resolve, reject }))
+    },
+  }
+}
+
+function fakeConversationEvents() {
+  let handlers
+  return {
+    start(value) {
+      handlers = value
+      handlers.onAvailability(true)
+    },
+    async stop() { handlers = undefined },
+    emit(event) { handlers?.onEvent(event) },
+    available(value) { handlers?.onAvailability(value) },
   }
 }
 
@@ -598,6 +633,182 @@ test('maps Harness failures without exposing internal diagnostics', async () => 
     await expectFailure(new HarnessBridgeError('rejected', 'upstream-private', 'bad-request'), 400, 'harness_rejected')
     await expectFailure(new HarnessBridgeError('rejected', 'upstream-private', 'internal'), 502, 'harness_rejected')
   } finally {
+    await service.stop()
+  }
+})
+
+test('authenticates conversation events, replays retained cursors, and closes revoked sessions', async () => {
+  const authority = new PairingAuthority()
+  issueCredential(authority)
+  const sessions = new SessionAuthority()
+  const access = sessions.issue('node-1')
+  const harnessEvents = fakeConversationEvents()
+  const eventLog = new RetainedEventLog()
+  const service = createJarvisGateway({ ownerToken, authority, sessions, harnessEvents, eventLog })
+  const gateway = await service.start()
+  const endpoint = `ws://127.0.0.1:${gateway.port}/v1/events`
+  const sockets = []
+  try {
+    await assert.rejects(new Promise((resolve, reject) => {
+      const socket = new WebSocket(`${endpoint}?accessToken=forbidden`)
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    }), /Unexpected server response: 404/)
+    await assert.rejects(new Promise((resolve, reject) => {
+      const socket = new WebSocket(endpoint, { origin: 'https://untrusted.example' })
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    }), /Unexpected server response: 403/)
+
+    const unauthorized = new WebSocket(endpoint)
+    sockets.push(unauthorized)
+    const unauthorizedInbox = socketInbox(unauthorized)
+    await new Promise((resolve, reject) => {
+      unauthorized.once('open', resolve)
+      unauthorized.once('error', reject)
+    })
+    unauthorized.send(JSON.stringify({ type: 'events.authenticate', accessToken: ownerToken }))
+    assert.equal((await unauthorizedInbox.next()).type, 'events.rejected')
+
+    const first = new WebSocket(endpoint, { origin: gateway.origin })
+    sockets.push(first)
+    const firstInbox = socketInbox(first)
+    await new Promise((resolve, reject) => {
+      first.once('open', resolve)
+      first.once('error', reject)
+    })
+    first.send(JSON.stringify({ type: 'events.authenticate', accessToken: access.accessToken }))
+    const initialReady = await firstInbox.next()
+    assert.deepEqual({
+      type: initialReady.type,
+      replayCount: initialReady.replayCount,
+      requiresSnapshot: initialReady.requiresSnapshot,
+      reason: initialReady.reason,
+    }, { type: 'events.ready', replayCount: 0, requiresSnapshot: true, reason: 'initial' })
+    assert.match(initialReady.cursor, /^[A-Za-z0-9_-]{22}\.[0-9]+$/)
+
+    harnessEvents.emit({ type: 'conversation.status', conversationId: 'session-one', running: true })
+    const live = await firstInbox.next()
+    assert.equal(live.type, 'conversation.status')
+    assert.equal(live.running, true)
+    first.send(JSON.stringify({ type: 'events.ack', cursor: live.cursor }))
+    first.close()
+
+    const resumed = new WebSocket(endpoint)
+    sockets.push(resumed)
+    const resumedInbox = socketInbox(resumed)
+    await new Promise((resolve, reject) => {
+      resumed.once('open', resolve)
+      resumed.once('error', reject)
+    })
+    resumed.send(JSON.stringify({
+      type: 'events.authenticate', accessToken: access.accessToken, cursor: initialReady.cursor,
+    }))
+    const resumedReady = await resumedInbox.next()
+    assert.equal(resumedReady.type, 'events.ready')
+    assert.equal(resumedReady.requiresSnapshot, false)
+    assert.equal(resumedReady.replayCount, 1)
+    assert.deepEqual(await resumedInbox.next(), live)
+
+    const revoked = await request(gateway, `/v1/sessions/${access.sessionId}`, {
+      method: 'DELETE', headers: { authorization: `Bearer ${ownerToken}` },
+    })
+    assert.equal(revoked.status, 204)
+    const rejection = await resumedInbox.next()
+    assert.equal(rejection.type, 'events.rejected')
+    assert.equal(rejection.code, 'session_invalid')
+  } finally {
+    for (const socket of sockets) socket.terminate()
+    await service.stop()
+  }
+})
+
+test('requires event-stream resync after an upstream continuity gap', async () => {
+  const authority = new PairingAuthority()
+  issueCredential(authority)
+  const sessions = new SessionAuthority()
+  const access = sessions.issue('node-1')
+  const harnessEvents = fakeConversationEvents()
+  const service = createJarvisGateway({ ownerToken, authority, sessions, harnessEvents })
+  const gateway = await service.start()
+  const socket = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/events`)
+  const inbox = socketInbox(socket)
+  try {
+    await new Promise((resolve, reject) => {
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    })
+    socket.send(JSON.stringify({ type: 'events.authenticate', accessToken: access.accessToken }))
+    assert.equal((await inbox.next()).type, 'events.ready')
+    harnessEvents.available(false)
+    const event = await inbox.next()
+    assert.equal(event.type, 'sync.required')
+    assert.equal(event.reason, 'harness_disconnected')
+  } finally {
+    socket.terminate()
+    await service.stop()
+  }
+})
+
+test('closes an active event stream when its access token expires', async () => {
+  const authority = new PairingAuthority()
+  issueCredential(authority)
+  const sessions = new SessionAuthority({ accessTtlMs: 1_000, refreshTtlMs: 2_000 })
+  const access = sessions.issue('node-1')
+  const harnessEvents = fakeConversationEvents()
+  const service = createJarvisGateway({ ownerToken, authority, sessions, harnessEvents })
+  const gateway = await service.start()
+  const socket = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/events`)
+  const inbox = socketInbox(socket)
+  try {
+    await new Promise((resolve, reject) => {
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    })
+    socket.send(JSON.stringify({ type: 'events.authenticate', accessToken: access.accessToken }))
+    assert.equal((await inbox.next()).type, 'events.ready')
+    const rejection = await Promise.race([
+      inbox.next(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('event stream did not expire')), 2_000)),
+    ])
+    assert.equal(rejection.type, 'events.rejected')
+    assert.equal(rejection.code, 'session_expired')
+  } finally {
+    socket.terminate()
+    await service.stop()
+  }
+})
+
+test('applies the authenticated session rate limit to event acknowledgements', async () => {
+  const authority = new PairingAuthority()
+  issueCredential(authority)
+  const sessions = new SessionAuthority()
+  const access = sessions.issue('node-1')
+  const harnessEvents = fakeConversationEvents()
+  const service = createJarvisGateway({
+    ownerToken,
+    authority,
+    sessions,
+    harnessEvents,
+    identityRateLimit: { capacity: 1, refillPerSecond: 0.001, maxKeys: 16 },
+  })
+  const gateway = await service.start()
+  const socket = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/events`)
+  const inbox = socketInbox(socket)
+  try {
+    await new Promise((resolve, reject) => {
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    })
+    socket.send(JSON.stringify({ type: 'events.authenticate', accessToken: access.accessToken }))
+    const ready = await inbox.next()
+    assert.equal(ready.type, 'events.ready')
+    socket.send(JSON.stringify({ type: 'events.ack', cursor: ready.cursor }))
+    const rejection = await inbox.next()
+    assert.equal(rejection.type, 'events.rejected')
+    assert.equal(rejection.code, 'rate_limited')
+  } finally {
+    socket.terminate()
     await service.stop()
   }
 })

--- a/test/harness-events.test.js
+++ b/test/harness-events.test.js
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import test from 'node:test'
+import { WebSocketServer } from 'ws'
+import { HarnessEventBridge } from '../dist/harness-events.js'
+
+async function waitFor(predicate, message, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message)
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+async function startHarnessEvents() {
+  const server = createServer()
+  const sockets = { mux: [], host: [] }
+  const websocket = new WebSocketServer({ noServer: true })
+  server.on('upgrade', (request, socket, head) => {
+    const channel = request.url === '/api/events.mux' ? 'mux' : request.url === '/api/events.host' ? 'host' : undefined
+    if (channel === undefined) return socket.destroy()
+    websocket.handleUpgrade(request, socket, head, accepted => {
+      sockets[channel].push(accepted)
+      websocket.emit('connection', accepted, request)
+    })
+  })
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (address === null || typeof address === 'string') throw new Error('mock Harness did not bind')
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    sockets,
+    send(channel, payload) {
+      const socket = sockets[channel].at(-1)
+      if (socket === undefined) throw new Error(`${channel} stream is not connected`)
+      socket.send(JSON.stringify({ type: 'server-request', rpcId: `rpc-${Date.now()}`, method: payload.type, payload }))
+    },
+    async close() {
+      for (const socket of websocket.clients) socket.terminate()
+      await new Promise(resolve => websocket.close(resolve))
+      await new Promise((resolve, reject) => server.close(error => error === undefined ? resolve() : reject(error)))
+    },
+  }
+}
+
+test('normalizes only visible conversation events and tracks stream availability', async () => {
+  const harness = await startHarnessEvents()
+  const events = []
+  const availability = []
+  const bridge = new HarnessEventBridge({
+    origin: harness.origin,
+    reconnectDelayMs: 20,
+    listVisibleConversations: async () => [{
+      id: 'session-root', title: null, updatedAt: 1, running: false, blank: false,
+    }],
+  })
+  try {
+    bridge.start({ onEvent: event => events.push(event), onAvailability: value => availability.push(value) })
+    await waitFor(() => availability.includes(true), 'Harness event bridge did not become available')
+    harness.send('host', {
+      type: 'host/session-added', sessionId: 'session-new', blank: true,
+      cwd: '/private/path', agentPreset: 'internal',
+    })
+    harness.send('host', {
+      type: 'host/session-added', sessionId: 'session-child', blank: true, origin: 'subagent', cwd: '/private/child',
+    })
+    harness.send('host', { type: 'host/session-status', sessionId: 'session-root', running: true })
+    harness.send('host', { type: 'host/agent-error', sessionId: 'session-root', message: 'private provider failure' })
+    harness.send('mux', { type: 'session/event', sessionId: 'session-root', event: {
+      type: 'user/message', seq: 2, time: 3, surfaceOp: 'append',
+      data: { id: 'user-one', source: { kind: 'user' }, content: [{ type: 'text', text: 'Hello' }] },
+    } })
+    harness.send('mux', { type: 'session/event', sessionId: 'session-root', event: {
+      type: 'assistant/message', seq: 4, time: 5, surfaceOp: 'append',
+      data: { message: { id: 'assistant-one', content: [
+        { type: 'reasoning', text: 'hidden' }, { type: 'text', text: 'Visible' },
+      ] } },
+    } })
+    harness.send('mux', { type: 'session/event', sessionId: 'session-child', event: {
+      type: 'assistant/message', seq: 1, time: 2, surfaceOp: 'append',
+      data: { message: { id: 'child-message', content: [{ type: 'text', text: 'hidden child' }] } },
+    } })
+    harness.send('mux', { type: 'session/event', sessionId: 'session-root', event: {
+      type: 'tool/result', seq: 6, time: 7, surfaceOp: 'append',
+      data: { message: { id: 'tool-one', content: [{ type: 'text', text: 'hidden tool' }] } },
+    } })
+    await waitFor(() => events.length === 5, 'normalized Harness events were not delivered')
+
+    assert.deepEqual(events, [
+      { type: 'conversation.created', conversation: { id: 'session-new', blank: true } },
+      { type: 'conversation.status', conversationId: 'session-root', running: true },
+      { type: 'conversation.error', conversationId: 'session-root', code: 'harness_agent_error' },
+      { type: 'conversation.message.committed', conversationId: 'session-root',
+        message: { id: 'user-one', sequence: 2, createdAt: 3, role: 'user', text: 'Hello' } },
+      { type: 'conversation.message.committed', conversationId: 'session-root',
+        message: { id: 'assistant-one', sequence: 4, createdAt: 5, role: 'assistant', text: 'Visible' } },
+    ])
+    assert.doesNotMatch(JSON.stringify(events), /private|internal|reasoning|hidden|tool/)
+
+    harness.sockets.host.at(-1).terminate()
+    await waitFor(() => availability.at(-1) === false, 'Harness disconnect was not observed')
+    await waitFor(() => availability.at(-1) === true, 'Harness event bridge did not reconnect')
+  } finally {
+    await bridge.stop()
+    await harness.close()
+  }
+})
+
+test('accepts only an exact loopback HTTP Harness event origin', () => {
+  const options = { listVisibleConversations: async () => [] }
+  for (const origin of ['https://127.0.0.1:3080', 'http://localhost:3080', 'http://127.0.0.1:3080/api']) {
+    assert.throws(() => new HarnessEventBridge({ ...options, origin }), /exact http/)
+  }
+})


### PR DESCRIPTION
## Summary
- add authenticated `/v1/events` WebSocket streams using first-frame Session authentication
- consume Harness mux/host streams only over loopback and project a strict public event allowlist
- retain normalized events in a bounded private journal with monotonic opaque cursors
- replay valid cursors and explicitly require snapshots for initial, stale, restarted, or interrupted streams
- close active streams on access expiry, refresh, owner sign-out, device revocation, and refresh-family revocation
- reject URL credentials, cross-origin browser upgrades, malformed frames, oversized payloads, and rate-limit abuse

## Verification
- `npm run verify` (84/84)
- `npm run verify:runtime`
- `git diff --check`
- real Harness + Gateway runtime observed a normalized session-created event and replayed the same event after cursor reconnect without invoking a model

Closes #10.