### PR TITLE
Prepare v0.1.0 Mac MVP release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ data/
 .dsh/
 .jarvis-runtime/
 backups/
+release/
 .env
 *.log
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 
 ## 项目状态
 
-当前版本是 `v0.1.0` 前的 Mac MVP。项目通过 [Jarvis Roadmap](https://github.com/users/gh503/projects/6) 跟踪执行，通过 [Milestones](https://github.com/gh503/jarvis/milestones) 管理阶段出口，通过 [Issues](https://github.com/gh503/jarvis/issues) 定义可验收工作。
+当前版本是 `v0.1.0` Mac MVP。项目通过 [Jarvis Roadmap](https://github.com/users/gh503/projects/6) 跟踪执行，通过 [Milestones](https://github.com/gh503/jarvis/milestones) 管理阶段出口，通过 [Issues](https://github.com/gh503/jarvis/issues) 定义可验收工作。
 
 - [总体架构](docs/plan/architecture.md)
 - [开发旅程与里程碑](docs/plan/00-development-journey.md)
 - [完整阶段计划](docs/plan/README.md)
 - [备份与恢复](docs/operations/backup-restore.md)
+- [v0.1.0 发布说明](docs/releases/v0.1.0.md)
 - [贡献指南](CONTRIBUTING.md)
 - [安全策略](SECURITY.md)
 
@@ -51,7 +52,7 @@
 ```bash
 cp .env.example .env
 # 编辑 .env，填入 DEEPSEEK_API_KEY
-npm install
+npm ci
 npm run verify
 npm run verify:runtime
 npm start
@@ -110,6 +111,12 @@ JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:node -- \
 
 ```bash
 ./scripts/install-launch-agent.sh
+```
+
+默认后台端口是 `3080`。安装时设置 `JARVIS_PORT` 可以固定其他端口，并会写入 LaunchAgent：
+
+```bash
+JARVIS_PORT=3182 ./scripts/install-launch-agent.sh
 ```
 
 卸载后台服务但保留数据：

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,80 @@
+# Jarvis v0.1.0 - Mac MVP
+
+Release date: 2026-08-17
+
+Jarvis `v0.1.0` is the first public, local-first Mac text MVP. It packages the
+source and exact lockfile rather than a signed or notarized `.app`.
+
+## Supported environment
+
+- macOS 13 or newer on Apple Silicon or Intel.
+- Node.js 24.
+- An owner-provided DeepSeek API Key.
+- A single local owner and a local Harness Web UI.
+
+## Install and start
+
+```bash
+cp .env.example .env
+# Put DEEPSEEK_API_KEY in the untracked .env file, or configure it in the local UI.
+npm ci
+npm run verify
+npm run verify:runtime
+npm start
+```
+
+Open `http://127.0.0.1:3080`. After foreground qualification, install the
+optional LaunchAgent with `./scripts/install-launch-agent.sh`. Remove the
+background service while keeping local data with
+`./scripts/uninstall-launch-agent.sh`.
+
+## Included
+
+- Persistent DeepSeek text conversations through the Harness Web UI.
+- Read-only Mac system status.
+- Private local reminders and append-only action audit records.
+- Exact, expiring, single-use approval for allowlisted application launch.
+- An outbound-only macOS node security core with Keychain-backed identity.
+- A private-network Gateway prototype with pairing, rotating sessions, bounded
+  rate limits, normalized conversation APIs, and retained event cursors.
+- Offline, integrity-checked backup and atomic restore for Harness sessions and
+  Jarvis state.
+
+## Security boundaries
+
+- Harness listens only on loopback.
+- Gateway rejects public, wildcard, and plaintext private-network bindings.
+- The release archive contains no `.env`, local Harness state, credentials,
+  Keychain data, TLS keys, dependency cache, build output, or Git metadata.
+- Backup archives exclude credentials and use owner-only permissions, but are
+  not encrypted in this version.
+- Jarvis blocks arbitrary terminal, filesystem, URL, and non-Jarvis tool use.
+
+## Known limitations
+
+- This is a source-based developer MVP, not a signed `.app`, installer package,
+  automatic updater, or App Store build.
+- There is no mobile UI, voice interaction, wake word, smart-home adapter,
+  general file operation, or messaging integration.
+- Gateway and node components are qualified prototypes; the first installable
+  phone companion is planned for a later release.
+- Remote access requires owner-managed private networking and trusted TLS. The
+  Gateway must not be exposed directly to the public internet.
+- Backups are unencrypted and require all Harness and Gateway processes to stop.
+- DeepSeek Harness remains a pinned prerelease dependency at
+  `@deepseek-ai/dsh@0.1.0-rc.6`; upgrades require full requalification.
+
+## Qualification evidence
+
+- All v0.1 P0 issues are closed.
+- The macOS CI performs a clean checkout, `npm ci`, 87 automated tests, and
+  loopback Harness/Gateway runtime verification.
+- The owner-operated qualification verifies a real DeepSeek response, system
+  status, reminder lifecycle, declined and approved Notes launch, and restart
+  persistence without publishing private values.
+- The release rehearsal verifies a clean source checkout, dependency install,
+  LaunchAgent startup and health, retained local data, and complete uninstall.
+
+See [Mac MVP qualification](../verification/mac-mvp-qualification.md) and
+[backup and restore](../operations/backup-restore.md) for the evidence boundary
+and recovery procedure.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "restore": "npm run build --silent && node dist/backup-main.js restore",
     "pair:node": "npm run build --silent && node dist/node-pairing-main.js",
     "verify": "npm run typecheck && npm test",
-    "verify:runtime": "./scripts/verify-local-runtime.sh"
+    "verify:runtime": "./scripts/verify-local-runtime.sh",
+    "verify:release": "./scripts/verify-release-macos.sh",
+    "release:archive": "./scripts/build-release-archive.sh"
   },
   "dependencies": {
     "@deepseek-ai/cordis": "4.0.1",

--- a/scripts/build-release-archive.sh
+++ b/scripts/build-release-archive.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+REF="${2:-HEAD}"
+COMMIT="$(git rev-parse "$REF^{commit}")"
+VERSION="$(git show "$REF:package.json" | node -e 'let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => process.stdout.write(JSON.parse(input).version))')"
+OUTPUT="${1:-$ROOT/release/jarvis-mac-mvp-v$VERSION.zip}"
+CHECKSUM="$OUTPUT.sha256"
+PREFIX="jarvis-mac-mvp-v$VERSION/"
+TEMPORARY="$OUTPUT.tmp.$$"
+
+mkdir -p "$(dirname "$OUTPUT")"
+trap 'rm -f "$TEMPORARY"' EXIT
+git archive --format=zip --prefix="$PREFIX" -o "$TEMPORARY" "$REF"
+unzip -t "$TEMPORARY" >/dev/null
+
+while IFS= read -r entry; do
+  case "$entry" in
+    */.env|*/.dsh/*|*/.jarvis-runtime/*|*/backups/*|*/data/*|*/node_modules/*|*/dist/*|*/.git/*|*.pem|*.key|*.p12|*.pfx)
+      print -u2 "release archive contains forbidden path: $entry"
+      exit 1
+      ;;
+  esac
+done < <(unzip -Z1 "$TEMPORARY")
+
+if [[ "$(unzip -z "$TEMPORARY" | tail -n 1)" != "$COMMIT" ]]; then
+  print -u2 'release archive commit marker does not match the requested ref.'
+  exit 1
+fi
+
+mv -f "$TEMPORARY" "$OUTPUT"
+chmod 644 "$OUTPUT"
+(
+  cd "$(dirname "$OUTPUT")"
+  shasum -a 256 "$(basename "$OUTPUT")" > "$(basename "$CHECKSUM")"
+)
+chmod 644 "$CHECKSUM"
+echo "Release archive: $OUTPUT"
+cat "$CHECKSUM"

--- a/scripts/install-launch-agent.sh
+++ b/scripts/install-launch-agent.sh
@@ -2,35 +2,48 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-LABEL="ai.jarvis.mac-mvp"
+LABEL="${JARVIS_LAUNCH_AGENT_LABEL:-ai.jarvis.mac-mvp}"
+PORT="${JARVIS_PORT:-3080}"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 NPM_BIN="$(command -v npm)"
 PATH_VALUE="$PATH"
 
+if [[ ! "$LABEL" =~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$' ]]; then
+  print -u2 'JARVIS_LAUNCH_AGENT_LABEL is invalid.'
+  exit 1
+fi
+if [[ ! "$PORT" =~ '^[0-9]+$' ]] || (( PORT < 1 || PORT > 65535 )); then
+  print -u2 'JARVIS_PORT must be an integer from 1 to 65535.'
+  exit 1
+fi
+
 mkdir -p "$HOME/Library/LaunchAgents" "$ROOT/data"
 chmod 700 "$ROOT/data"
 
-/usr/bin/python3 - "$PLIST" "$ROOT" "$NPM_BIN" "$PATH_VALUE" <<'PY'
-import plistlib
-import sys
+TEMP_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/jarvis-launch-agent.XXXXXX")"
+trap 'rm -rf "$TEMP_DIRECTORY"' EXIT
+node --input-type=module - "$TEMP_DIRECTORY/agent.json" "$LABEL" "$PORT" "$ROOT" "$NPM_BIN" "$PATH_VALUE" <<'NODE'
+import { writeFileSync } from 'node:fs'
 
-path, root, npm_bin, path_value = sys.argv[1:]
-document = {
-    "Label": "ai.jarvis.mac-mvp",
-    "ProgramArguments": ["/bin/zsh", f"{root}/scripts/start-mac.sh"],
-    "WorkingDirectory": root,
-    "RunAtLoad": True,
-    "KeepAlive": True,
-    "EnvironmentVariables": {"NPM_BIN": npm_bin, "PATH": path_value},
-    "StandardOutPath": f"{root}/data/service.log",
-    "StandardErrorPath": f"{root}/data/service-error.log",
-    "ProcessType": "Interactive",
+const [path, label, port, root, npmBin, pathValue] = process.argv.slice(2)
+const document = {
+  Label: label,
+  ProgramArguments: ['/bin/zsh', `${root}/scripts/start-mac.sh`],
+  WorkingDirectory: root,
+  RunAtLoad: true,
+  KeepAlive: true,
+  EnvironmentVariables: { NPM_BIN: npmBin, PATH: pathValue, JARVIS_PORT: port },
+  StandardOutPath: `${root}/data/service.log`,
+  StandardErrorPath: `${root}/data/service-error.log`,
+  ProcessType: 'Interactive',
 }
-with open(path, "wb") as output:
-    plistlib.dump(document, output)
-PY
+writeFileSync(path, `${JSON.stringify(document)}\n`, { encoding: 'utf8', mode: 0o600 })
+NODE
+/usr/bin/plutil -convert xml1 -o "$TEMP_DIRECTORY/agent.plist" "$TEMP_DIRECTORY/agent.json"
+chmod 600 "$TEMP_DIRECTORY/agent.plist"
+mv "$TEMP_DIRECTORY/agent.plist" "$PLIST"
 
 launchctl bootout "gui/$UID/$LABEL" 2>/dev/null || true
 launchctl bootstrap "gui/$UID" "$PLIST"
 launchctl kickstart -k "gui/$UID/$LABEL"
-echo "Jarvis LaunchAgent installed: $PLIST"
+echo "Jarvis LaunchAgent installed: $PLIST (port $PORT)"

--- a/scripts/uninstall-launch-agent.sh
+++ b/scripts/uninstall-launch-agent.sh
@@ -1,8 +1,14 @@
 #!/bin/zsh
 set -euo pipefail
 
-LABEL="ai.jarvis.mac-mvp"
+LABEL="${JARVIS_LAUNCH_AGENT_LABEL:-ai.jarvis.mac-mvp}"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+if [[ ! "$LABEL" =~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$' ]]; then
+  print -u2 'JARVIS_LAUNCH_AGENT_LABEL is invalid.'
+  exit 1
+fi
+
 launchctl bootout "gui/$UID/$LABEL" 2>/dev/null || true
 rm -f "$PLIST"
 echo "Jarvis LaunchAgent removed. Local data was kept."

--- a/scripts/verify-release-macos.sh
+++ b/scripts/verify-release-macos.sh
@@ -1,0 +1,87 @@
+#!/bin/zsh
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  print -u2 'Release installation verification requires macOS.'
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REF="${JARVIS_RELEASE_REF:-HEAD}"
+TEMPORARY="$(mktemp -d "${TMPDIR:-/tmp}/jarvis-release.XXXXXX")"
+CHECKOUT="$TEMPORARY/jarvis"
+TEST_HOME="$TEMPORARY/home"
+LABEL="ai.jarvis.release-test.$$.${RANDOM}"
+PORT=""
+
+cleanup() {
+  if [[ -d "$CHECKOUT" ]]; then
+    HOME="$TEST_HOME" JARVIS_LAUNCH_AGENT_LABEL="$LABEL" \
+      "$CHECKOUT/scripts/uninstall-launch-agent.sh" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TEMPORARY"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$CHECKOUT" "$TEST_HOME"
+git -C "$ROOT" archive "$REF" | tar -x -C "$CHECKOUT"
+cd "$CHECKOUT"
+npm ci
+npm run verify
+npm run verify:runtime
+
+for attempt in {1..30}; do
+  candidate=$((30_000 + RANDOM % 20_000))
+  if ! lsof -nP -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
+    PORT="$candidate"
+    break
+  fi
+done
+[[ -n "$PORT" ]]
+
+env -u DEEPSEEK_API_KEY \
+  HOME="$TEST_HOME" \
+  JARVIS_LAUNCH_AGENT_LABEL="$LABEL" \
+  JARVIS_PORT="$PORT" \
+  ./scripts/install-launch-agent.sh
+
+PLIST="$TEST_HOME/Library/LaunchAgents/$LABEL.plist"
+[[ -f "$PLIST" ]]
+launchctl print "gui/$UID/$LABEL" >/dev/null
+
+HEALTH="$TEMPORARY/health.json"
+for attempt in {1..30}; do
+  if curl -fsS "http://127.0.0.1:$PORT/jarvis/health" > "$HEALTH"; then
+    break
+  fi
+  sleep 1
+done
+node --input-type=module - "$HEALTH" <<'NODE'
+import { readFileSync } from 'node:fs'
+
+const health = JSON.parse(readFileSync(process.argv[2], 'utf8'))
+if (health.service !== 'jarvis-mac-mvp' || health.status !== 'ok' || health.scope !== 'loopback-only') process.exit(1)
+NODE
+
+HOME="$TEST_HOME" JARVIS_LAUNCH_AGENT_LABEL="$LABEL" ./scripts/uninstall-launch-agent.sh
+for attempt in {1..30}; do
+  if ! lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  print -u2 'LaunchAgent port remained open after uninstall.'
+  exit 1
+fi
+if launchctl print "gui/$UID/$LABEL" >/dev/null 2>&1; then
+  print -u2 'LaunchAgent remained loaded after uninstall.'
+  exit 1
+fi
+[[ ! -e "$PLIST" ]]
+[[ -d "$CHECKOUT/data" ]]
+[[ -f "$CHECKOUT/data/reminders.json" ]]
+[[ -f "$CHECKOUT/data/audit.jsonl" ]]
+
+echo "Clean macOS install, startup, health, persistence, and uninstall verification passed on port $PORT"


### PR DESCRIPTION
## Summary
- document the supported v0.1.0 Mac MVP, install flow, security boundaries, and known limitations
- make LaunchAgent label and port configurable for isolated verification and remove the undeclared Python dependency
- add reproducible clean-checkout macOS qualification and git-archive release packaging scripts

## Verification
- all v0.1 P0 issues are closed
- current `main` macOS CI: pass
- `npm run verify` (87/87)
- `npm run verify:release` from a clean `git archive`: `npm ci`, tests, Harness/Gateway runtime, isolated LaunchAgent health, retained data, and uninstall all pass
- `npm run release:archive`: checksum, commit marker, archive integrity, and forbidden-path checks pass
- current Jarvis health remains loopback-only and the isolated test LaunchAgent was removed

The future release artifact is a source archive, not a signed or notarized `.app`. It contains no API key, local transcript, reminder, audit record, credentials, dependency cache, build output, or Git metadata.

Refs #15