### PR TITLE
Add owner-approved PWA pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ JARVIS_OWNER_TOKEN='use-a-local-secret-of-at-least-16-characters' npm run start:
 
 Gateway 启动后可从 `http://127.0.0.1:3090/app/` 打开移动端应用外壳。默认资源目录为项目内 `web/`，部署时可通过 `JARVIS_PWA_ROOT` 指向同一组受审计资源；Gateway 只服务固定清单中的文件，未知 `/app/*` 路径不会访问文件系统。
 
+在 PWA 的“设置”中开始配对，手机会生成同源私有设备身份并显示 6 位确认码。在运行 Gateway 的 Mac 上批准该代码：
+
+```bash
+JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:approve -- --code 123456
+```
+
+Owner Token 只提交给 loopback Gateway，不进入手机。Gateway 只持久化一次性领取密钥和设备凭据的 SHA-256 摘要；设备凭据通过领取密钥派生的 AES-256-GCM 密钥加密返回，重复领取返回同一密文。浏览器将不可导出的 P-256 私钥、设备凭据和短期 Session 保存在同源 IndexedDB；离线时只显示本地身份为非当前状态。清除站点数据会移除本地访问材料，但不会替代服务端设备撤销。
+
 短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages` 和 `POST /v1/conversations/:id/cancel`。消息只接受最多 16 KiB 的纯文本；远程 slash command 被拒绝。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会要求先重新读取会话快照。
 
 Gateway 默认允许每个连接来源突发 60 次请求并每秒恢复 1 次额度；每个已认证 Owner、设备或 Session 可突发 120 次并每秒恢复 2 次额度。它只使用直接连接地址，不信任客户端提供的转发来源头；HTTP `429` 会返回 `Retry-After`、限额余量和 correlation ID。
@@ -148,7 +156,7 @@ npm run restore -- --archive backups/jarvis-backup.jarvis
 - API Key：存放在未纳入 Git 的 `.env` 或 Harness 本机凭据存储，均不进入备份归档
 - 网络：Harness 始终只限本机回环；Gateway 仅可绑定明确的回环、私网或 overlay IP，非回环强制 TLS，禁止直接暴露到互联网
 
-这是单用户文字版 MVP；手机端目前只有可安装的离线应用外壳，尚未接入设备配对、移动对话、审批、通知，也不包含语音、智能家居、任意终端、文件操作和消息发送。Gateway 已提供认证、设备身份、受控会话 API 和可恢复的实时事件；客户端不得直接暴露或调用 Harness Web 服务。
+这是单用户文字版 MVP；手机端已有可安装的离线应用外壳、Owner 批准的设备配对和短期 Session，尚未接入移动对话、审批、通知，也不包含语音、智能家居、任意终端、文件操作和消息发送。Gateway 已提供认证、设备身份、受控会话 API 和可恢复的实时事件；客户端不得直接暴露或调用 Harness Web 服务。
 
 ## 上游边界
 

--- a/docs/plan/04-stage-3-mobile-remote.md
+++ b/docs/plan/04-stage-3-mobile-remote.md
@@ -14,7 +14,7 @@ Allow the owner to converse with Jarvis, observe status, and approve actions fro
 - Native mobile development remains deferred until a required capability fails the PWA gate.
 - Background always-listening voice is explicitly outside this stage.
 
-The first platform-independent increment is tracked in [#42](https://github.com/gh503/jarvis/issues/42). It serves a scoped, responsive PWA shell from the Gateway, caches only public application assets for offline startup, and clearly marks all account data unavailable until pairing. Physical installation remains unqualified until the owner names the first iPhone or Android device.
+The platform-independent increments tracked in [#42](https://github.com/gh503/jarvis/issues/42) and [#44](https://github.com/gh503/jarvis/issues/44) serve a scoped responsive PWA shell and an owner-approved browser pairing flow. The browser keeps an origin-bound private key, claims an encrypted device credential without receiving the Owner Token, and obtains a short-lived Gateway session. Offline startup clearly marks the saved identity as non-current. Physical installation remains unqualified until the owner names the first iPhone or Android device.
 
 ## Modules
 

--- a/docs/plan/architecture.md
+++ b/docs/plan/architecture.md
@@ -268,11 +268,11 @@ Required invariants:
 
 ### Device pairing
 
-1. Authenticated owner creates a short-lived pairing request.
-2. New device generates a local key pair.
-3. Owner verifies a displayed code on an existing trusted client.
-4. Gateway issues a revocable device credential bound to the public key.
-5. Device opens an outbound authenticated connection.
+1. New device generates a local key pair and creates a bounded short-lived claimable request.
+2. Gateway returns a six-digit verification code and a high-entropy claim secret only to that device.
+3. Owner approves the displayed code through an authenticated trusted loopback client.
+4. Gateway issues a revocable credential bound to the public key, persists only credential and claim-secret digests, and stores an AES-GCM claim envelope for safe retry.
+5. Device decrypts the envelope with a key derived from its claim secret and exchanges the credential for a rotating short-lived session.
 
 ## 7. Delivery Stages
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "backup": "npm run build --silent && node dist/backup-main.js backup",
     "restore": "npm run build --silent && node dist/backup-main.js restore",
     "pair:node": "npm run build --silent && node dist/node-pairing-main.js",
+    "pair:approve": "npm run build --silent && node dist/pairing-approval-main.js",
     "verify": "npm run typecheck && npm test",
     "verify:runtime": "./scripts/verify-local-runtime.sh",
     "verify:release": "./scripts/verify-release-macos.sh",

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -616,6 +616,33 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         return
       }
       if (pwa?.serve(request, response, correlationId) === true) return
+      if (request.method === 'POST' && parts.length === 4 && parts[0] === 'v1'
+        && parts[1] === 'pairing' && parts[2] === 'requests' && parts[3] === 'browser') {
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || !exactFields(body, ['nodeId', 'publicKey', 'displayName', 'platform'])
+          || typeof body.nodeId !== 'string' || typeof body.publicKey !== 'string'
+          || typeof body.displayName !== 'string' || body.platform !== 'pwa') {
+          throw new Error('browser pairing request body is invalid')
+        }
+        sendJson(response, 201, correlationId, authority.createClaimableRequest({
+          nodeId: body.nodeId,
+          publicKey: body.publicKey,
+          displayName: body.displayName,
+          platform: 'pwa',
+        }))
+        return
+      }
+      if (request.method === 'POST' && parts.length === 4 && parts[0] === 'v1'
+        && parts[1] === 'pairing' && parts[2] === 'requests' && parts[3] === 'claim') {
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || !exactFields(body, ['requestId', 'claimToken'])
+          || typeof body.requestId !== 'string' || typeof body.claimToken !== 'string') {
+          throw new Error('browser pairing claim body is invalid')
+        }
+        const claim = authority.claim(body.requestId, body.claimToken)
+        sendJson(response, claim === undefined ? 202 : 200, correlationId, claim ?? { status: 'pending' })
+        return
+      }
       const ownerAuthenticated = sameSecret(options.ownerToken, bearerToken(request, 'Bearer'))
       const deviceCredential = bearerToken(request, 'Device')
       const deviceNodeId = deviceCredential === undefined ? undefined : authority.identify(deviceCredential)
@@ -799,6 +826,18 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         sendJson(response, 200, correlationId, authority.confirm(body.requestId, body.verificationCode))
         return
       }
+      if (request.method === 'POST' && parts.length === 4 && parts[1] === 'pairing' && parts[2] === 'requests' && parts[3] === 'approve') {
+        if (!ownerAuthenticated) {
+          sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
+          return
+        }
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || !exactFields(body, ['verificationCode']) || typeof body.verificationCode !== 'string') {
+          throw new Error('pairing approval body is invalid')
+        }
+        sendJson(response, 200, correlationId, authority.approveClaimable(body.verificationCode))
+        return
+      }
       if (parts.length === 3 && parts[1] === 'devices' && typeof parts[2] === 'string') {
         const nodeId = parts[2]
         if (request.method === 'POST' && parts.length === 3 && parts[2] === nodeId) {
@@ -835,6 +874,24 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         return
       }
       const message = error instanceof Error ? error.message : 'request failed'
+      if (message === 'pairing claim rejected' || message === 'paired device is revoked') {
+        sendJson(response, 401, correlationId, {
+          error: 'pairing claim rejected', code: 'pairing_claim_rejected', correlationId,
+        })
+        return
+      }
+      if (message === 'pairing request has expired') {
+        sendJson(response, 410, correlationId, {
+          error: 'pairing request expired', code: 'pairing_expired', correlationId,
+        })
+        return
+      }
+      if (message === 'pairing request capacity has been reached') {
+        sendJson(response, 503, correlationId, {
+          error: 'pairing service is at capacity', code: 'pairing_capacity', correlationId,
+        })
+        return
+      }
       const status = message.includes('too large') ? 413 : 400
       sendJson(response, status, correlationId, { error: message, correlationId })
     }

--- a/src/pairing-approval-main.ts
+++ b/src/pairing-approval-main.ts
@@ -1,0 +1,57 @@
+import { stdin, stdout } from 'node:process'
+import { createInterface } from 'node:readline/promises'
+import { parseArgs } from 'node:util'
+import { BrowserPairingApprovalCoordinator } from './pairing-approval.js'
+
+function usage(): string {
+  return [
+    'Usage: npm run pair:approve -- [--code <six-digit-code>]',
+    '',
+    'Required environment:',
+    '  JARVIS_OWNER_TOKEN   Gateway owner token',
+    '',
+    'Optional environment:',
+    '  JARVIS_GATEWAY_URL   Loopback Gateway origin (default http://127.0.0.1:3090)',
+  ].join('\n')
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      help: { type: 'boolean', default: false },
+      code: { type: 'string' },
+    },
+    strict: true,
+    allowPositionals: false,
+  })
+  if (values.help) {
+    stdout.write(`${usage()}\n`)
+    return
+  }
+  const ownerToken = process.env.JARVIS_OWNER_TOKEN
+  if (ownerToken === undefined) throw new Error('JARVIS_OWNER_TOKEN is required')
+  let verificationCode = values.code?.trim()
+  if (verificationCode === undefined) {
+    if (!stdin.isTTY || !stdout.isTTY) throw new Error('pairing approval requires --code or an interactive terminal')
+    const prompt = createInterface({ input: stdin, output: stdout })
+    try {
+      verificationCode = (await prompt.question('Enter the six-digit code shown on the phone: ')).trim()
+    } finally {
+      prompt.close()
+    }
+  }
+  const coordinator = new BrowserPairingApprovalCoordinator(
+    process.env.JARVIS_GATEWAY_URL ?? 'http://127.0.0.1:3090',
+    ownerToken,
+  )
+  const approved = await coordinator.approve(verificationCode)
+  stdout.write(`Approved ${approved.displayName} (${approved.nodeId}) until ${new Date(approved.expiresAt).toISOString()}.\n`)
+}
+
+try {
+  await main()
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'pairing approval failed'
+  process.stderr.write(`Pairing approval failed: ${message}\n`)
+  process.exitCode = 1
+}

--- a/src/pairing-approval.ts
+++ b/src/pairing-approval.ts
@@ -1,0 +1,87 @@
+const MAX_RESPONSE_BYTES = 32 * 1024
+
+export interface ApprovedBrowserDevice {
+  requestId: string
+  nodeId: string
+  displayName: string
+  platform: 'pwa'
+  approvedAt: number
+  expiresAt: number
+}
+
+function loopbackOrigin(value: string): string {
+  const url = new URL(value)
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:')
+    || url.hostname !== '127.0.0.1'
+    || url.username !== ''
+    || url.password !== ''
+    || (url.pathname !== '' && url.pathname !== '/')
+    || url.search !== ''
+    || url.hash !== '') {
+    throw new Error('pairing approval gateway must be an HTTP(S) 127.0.0.1 origin')
+  }
+  return url.origin
+}
+
+function validateOwnerToken(value: string): string {
+  if (value.length < 16 || value.length > 4_096 || /[\r\n]/.test(value)) {
+    throw new TypeError('ownerToken must be 16 to 4096 characters without line breaks')
+  }
+  return value
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseApproval(value: unknown): ApprovedBrowserDevice {
+  if (!record(value)
+    || typeof value.requestId !== 'string' || !/^[A-Za-z0-9_-]{16,64}$/.test(value.requestId)
+    || typeof value.nodeId !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value.nodeId)
+    || typeof value.displayName !== 'string' || value.displayName.length < 1 || value.displayName.length > 128
+    || /[\u0000-\u001f\u007f]/.test(value.displayName)
+    || value.platform !== 'pwa'
+    || typeof value.approvedAt !== 'number' || !Number.isFinite(value.approvedAt)
+    || typeof value.expiresAt !== 'number' || !Number.isFinite(value.expiresAt)) {
+    throw new Error('Gateway returned an invalid pairing approval')
+  }
+  return {
+    requestId: value.requestId,
+    nodeId: value.nodeId,
+    displayName: value.displayName,
+    platform: 'pwa',
+    approvedAt: value.approvedAt,
+    expiresAt: value.expiresAt,
+  }
+}
+
+export class BrowserPairingApprovalCoordinator {
+  private readonly origin: string
+  private readonly ownerToken: string
+
+  constructor(gatewayUrl: string, ownerToken: string, private readonly fetchValue: typeof fetch = fetch) {
+    this.origin = loopbackOrigin(gatewayUrl)
+    this.ownerToken = validateOwnerToken(ownerToken)
+  }
+
+  async approve(verificationCode: string): Promise<ApprovedBrowserDevice> {
+    if (!/^\d{6}$/.test(verificationCode)) throw new Error('verification code must contain exactly six digits')
+    const response = await this.fetchValue(new URL('/v1/pairing/requests/approve', this.origin), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${this.ownerToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ verificationCode }),
+    })
+    const body = await response.text()
+    if (Buffer.byteLength(body) > MAX_RESPONSE_BYTES) throw new Error('Gateway response is too large')
+    if (!response.ok) throw new Error(`Gateway pairing approval failed with status ${response.status}`)
+    try {
+      return parseApproval(JSON.parse(body))
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new Error('Gateway returned invalid JSON')
+      throw error
+    }
+  }
+}

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -1,8 +1,9 @@
-import { createHash, generateKeyPairSync, randomBytes, randomInt, timingSafeEqual } from 'node:crypto'
+import { createCipheriv, createHash, generateKeyPairSync, randomBytes, randomInt, timingSafeEqual } from 'node:crypto'
 import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 
 export const DEFAULT_PAIRING_TTL_MS = 5 * 60_000
+export const DEFAULT_MAX_PENDING_PAIRINGS = 256
 
 export interface DeviceIdentity {
   publicKey: string
@@ -14,7 +15,7 @@ export interface PairingRequestInput {
   nodeId: string
   publicKey: string
   displayName: string
-  platform: 'macos'
+  platform: 'macos' | 'pwa'
 }
 
 export interface PairingRequest extends PairingRequestInput {
@@ -31,9 +32,37 @@ export interface IssuedCredential {
   issuedAt: number
 }
 
-export interface PairingStateSnapshot {
+export interface BrowserPairingChallenge extends PairingRequest {
+  claimToken: string
+}
+
+export interface EncryptedCredential {
+  algorithm: 'A256GCM'
+  iv: string
+  ciphertext: string
+}
+
+export interface BrowserPairingClaim {
+  requestId: string
+  nodeId: string
+  publicKey: string
+  generation: number
+  issuedAt: number
+  encryptedCredential: EncryptedCredential
+}
+
+export interface PairingApproval {
+  requestId: string
+  nodeId: string
+  displayName: string
+  platform: 'pwa'
+  approvedAt: number
+  expiresAt: number
+}
+
+interface PairingStateSnapshotV1 {
   version: 1
-  requests: Array<PairingRequest & { used: boolean }>
+  requests: Array<PairingRequest & { platform: 'macos', used: boolean }>
   devices: Array<{
     nodeId: string
     publicKey: string
@@ -44,14 +73,39 @@ export interface PairingStateSnapshot {
   }>
 }
 
+export interface PairingStateSnapshotV2 {
+  version: 2
+  requests: Array<PairingRequest & {
+    used: boolean
+    flow: 'direct' | 'claimable'
+    approvedAt?: number
+    claimTokenDigest?: string
+    claim?: BrowserPairingClaim
+  }>
+  devices: Array<{
+    nodeId: string
+    publicKey: string
+    displayName: string
+    platform: 'macos' | 'pwa'
+    credentialDigest: string
+    generation: number
+    issuedAt: number
+    revoked: boolean
+  }>
+}
+
+export type PairingStateSnapshot = PairingStateSnapshotV1 | PairingStateSnapshotV2
+
 export interface PairingStateStore {
   load(): PairingStateSnapshot | undefined
-  save(snapshot: PairingStateSnapshot): void
+  save(snapshot: PairingStateSnapshotV2): void
 }
 
 interface CredentialRecord {
   nodeId: string
   publicKey: string
+  displayName: string
+  platform: 'macos' | 'pwa'
   credentialDigest: Buffer
   generation: number
   issuedAt: number
@@ -60,6 +114,10 @@ interface CredentialRecord {
 
 interface PendingPairing extends PairingRequest {
   used: boolean
+  flow: 'direct' | 'claimable'
+  approvedAt?: number
+  claimTokenDigest?: Buffer
+  claim?: BrowserPairingClaim
 }
 
 export class FilePairingStateStore implements PairingStateStore {
@@ -74,7 +132,7 @@ export class FilePairingStateStore implements PairingStateStore {
     }
   }
 
-  save(snapshot: PairingStateSnapshot): void {
+  save(snapshot: PairingStateSnapshotV2): void {
     mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 })
     const temporary = `${this.path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
     writeFileSync(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
@@ -107,8 +165,42 @@ function credentialDigest(credential: string): Buffer {
   return createHash('sha256').update(credential, 'utf8').digest()
 }
 
+function validatePlatform(value: string): 'macos' | 'pwa' {
+  if (value !== 'macos' && value !== 'pwa') throw new Error('pairing platform is unsupported')
+  return value
+}
+
+function validateClaimToken(value: string): string {
+  if (!/^[A-Za-z0-9_-]{43}$/.test(value)) throw new Error('pairing claim rejected')
+  return value
+}
+
+function encryptCredential(credential: string, claimToken: string): EncryptedCredential {
+  const key = createHash('sha256').update('jarvis-pairing-claim-v1\0').update(claimToken, 'utf8').digest()
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const ciphertext = Buffer.concat([cipher.update(credential, 'utf8'), cipher.final(), cipher.getAuthTag()])
+  return {
+    algorithm: 'A256GCM',
+    iv: iv.toString('base64url'),
+    ciphertext: ciphertext.toString('base64url'),
+  }
+}
+
 function sameDigest(left: Buffer, right: Buffer): boolean {
   return left.length === right.length && timingSafeEqual(left, right)
+}
+
+function publicRequest(request: PendingPairing): PairingRequest {
+  return {
+    requestId: request.requestId,
+    nodeId: request.nodeId,
+    publicKey: request.publicKey,
+    displayName: request.displayName,
+    platform: request.platform,
+    verificationCode: request.verificationCode,
+    expiresAt: request.expiresAt,
+  }
 }
 
 export function createDeviceIdentity(): DeviceIdentity {
@@ -133,36 +225,34 @@ export class PairingAuthority {
     private readonly now: () => number = Date.now,
     private readonly pairingTtlMs = DEFAULT_PAIRING_TTL_MS,
     private readonly store?: PairingStateStore,
+    private readonly maxPendingPairings = DEFAULT_MAX_PENDING_PAIRINGS,
   ) {
     if (!Number.isInteger(pairingTtlMs) || pairingTtlMs < 1_000) {
       throw new RangeError('pairingTtlMs must be at least one second')
+    }
+    if (!Number.isInteger(maxPendingPairings) || maxPendingPairings < 1) {
+      throw new RangeError('maxPendingPairings must be a positive integer')
     }
     this.restore(this.store?.load())
   }
 
   createRequest(input: PairingRequestInput): PairingRequest {
-    const nodeId = validateIdentifier(input.nodeId, 'nodeId')
-    const publicKey = validatePublicKey(input.publicKey)
-    const displayName = validateText(input.displayName, 'displayName')
-    if (input.platform !== 'macos') throw new Error('pairing platform must be macos')
-    const request: PendingPairing = {
-      requestId: randomBytes(16).toString('base64url'),
-      nodeId,
-      publicKey,
-      displayName,
-      platform: 'macos',
-      verificationCode: randomInt(0, 1_000_000).toString().padStart(6, '0'),
-      expiresAt: this.now() + this.pairingTtlMs,
-      used: false,
-    }
-    this.requests.set(request.requestId, request)
-    this.persist()
-    return { ...request }
+    if (input.platform !== 'macos') throw new Error('direct pairing platform must be macos')
+    const request = this.createPending(input, 'direct')
+    return publicRequest(request)
+  }
+
+  createClaimableRequest(input: PairingRequestInput): BrowserPairingChallenge {
+    if (input.platform !== 'pwa') throw new Error('claimable pairing platform must be pwa')
+    const claimToken = randomBytes(32).toString('base64url')
+    const request = this.createPending(input, 'claimable', credentialDigest(claimToken))
+    return { ...publicRequest(request), claimToken }
   }
 
   confirm(requestId: string, verificationCode: string): IssuedCredential {
     const request = this.requests.get(requestId)
     if (request === undefined) throw new Error('pairing request not found')
+    if (request.flow !== 'direct') throw new Error('pairing request requires owner approval and device claim')
     if (request.used) throw new Error('pairing request has already been used')
     if (request.expiresAt <= this.now()) throw new Error('pairing request has expired')
     if (!/^\d{6}$/.test(verificationCode) || verificationCode !== request.verificationCode) {
@@ -171,7 +261,89 @@ export class PairingAuthority {
     const existing = this.devices.get(request.nodeId)
     if (existing !== undefined && !existing.revoked) throw new Error('device is already paired')
     request.used = true
-    return this.issue(request.nodeId, request.publicKey, 1)
+    try {
+      return this.issue(request.nodeId, request.publicKey, request.displayName, request.platform, 1)
+    } catch (error) {
+      request.used = false
+      throw error
+    }
+  }
+
+  approveClaimable(verificationCode: string): PairingApproval {
+    if (!/^\d{6}$/.test(verificationCode)) throw new Error('pairing verification code is incorrect')
+    const matches = [...this.requests.values()].filter(request => request.flow === 'claimable'
+      && request.verificationCode === verificationCode && request.expiresAt > this.now())
+    if (matches.length !== 1) throw new Error('pairing verification code is incorrect or ambiguous')
+    const request = matches[0] as PendingPairing
+    const existing = this.devices.get(request.nodeId)
+    if (request.claim === undefined && existing !== undefined && !existing.revoked) throw new Error('device is already paired')
+    if (request.approvedAt === undefined) {
+      request.approvedAt = this.now()
+      try {
+        this.persist()
+      } catch (error) {
+        delete request.approvedAt
+        throw error
+      }
+    }
+    return {
+      requestId: request.requestId,
+      nodeId: request.nodeId,
+      displayName: request.displayName,
+      platform: 'pwa',
+      approvedAt: request.approvedAt,
+      expiresAt: request.expiresAt,
+    }
+  }
+
+  claim(requestId: string, claimToken: string): BrowserPairingClaim | undefined {
+    const request = this.requests.get(requestId)
+    if (request === undefined || request.flow !== 'claimable' || request.claimTokenDigest === undefined) {
+      throw new Error('pairing claim rejected')
+    }
+    if (request.expiresAt <= this.now()) throw new Error('pairing request has expired')
+    const token = validateClaimToken(claimToken)
+    if (!sameDigest(request.claimTokenDigest, credentialDigest(token))) throw new Error('pairing claim rejected')
+    if (request.approvedAt === undefined) return undefined
+    if (request.claim !== undefined) {
+      if (!this.isActive(request.nodeId)) throw new Error('paired device is revoked')
+      return { ...request.claim, encryptedCredential: { ...request.claim.encryptedCredential } }
+    }
+    const existing = this.devices.get(request.nodeId)
+    if (existing !== undefined && !existing.revoked) throw new Error('device is already paired')
+    const credential = randomBytes(32).toString('base64url')
+    const issuedAt = this.now()
+    const generation = 1
+    const claim: BrowserPairingClaim = {
+      requestId: request.requestId,
+      nodeId: request.nodeId,
+      publicKey: request.publicKey,
+      generation,
+      issuedAt,
+      encryptedCredential: encryptCredential(credential, token),
+    }
+    this.devices.set(request.nodeId, {
+      nodeId: request.nodeId,
+      publicKey: request.publicKey,
+      displayName: request.displayName,
+      platform: request.platform,
+      credentialDigest: credentialDigest(credential),
+      generation,
+      issuedAt,
+      revoked: false,
+    })
+    request.used = true
+    request.claim = claim
+    try {
+      this.persist()
+    } catch (error) {
+      if (existing === undefined) this.devices.delete(request.nodeId)
+      else this.devices.set(request.nodeId, existing)
+      request.used = false
+      delete request.claim
+      throw error
+    }
+    return { ...claim, encryptedCredential: { ...claim.encryptedCredential } }
   }
 
   authenticate(nodeId: string, credential: string): boolean {
@@ -195,24 +367,65 @@ export class PairingAuthority {
 
   rotate(nodeId: string, currentCredential: string): IssuedCredential {
     const record = this.requireAuthenticated(nodeId, currentCredential)
-    return this.issue(record.nodeId, record.publicKey, record.generation + 1)
+    return this.issue(record.nodeId, record.publicKey, record.displayName, record.platform, record.generation + 1)
   }
 
   revoke(nodeId: string): boolean {
     const record = this.devices.get(nodeId)
     if (record === undefined || record.revoked) return false
     record.revoked = true
-    this.persist()
+    try {
+      this.persist()
+    } catch (error) {
+      record.revoked = false
+      throw error
+    }
     return true
+  }
+
+  private createPending(input: PairingRequestInput, flow: 'direct' | 'claimable', claimTokenDigest?: Buffer): PendingPairing {
+    for (const [requestId, request] of this.requests) {
+      if (request.expiresAt <= this.now()) this.requests.delete(requestId)
+    }
+    if (this.requests.size >= this.maxPendingPairings) throw new Error('pairing request capacity has been reached')
+    const request: PendingPairing = {
+      requestId: randomBytes(16).toString('base64url'),
+      nodeId: validateIdentifier(input.nodeId, 'nodeId'),
+      publicKey: validatePublicKey(input.publicKey),
+      displayName: validateText(input.displayName, 'displayName'),
+      platform: validatePlatform(input.platform),
+      verificationCode: randomInt(0, 1_000_000).toString().padStart(6, '0'),
+      expiresAt: this.now() + this.pairingTtlMs,
+      used: false,
+      flow,
+      ...(claimTokenDigest === undefined ? {} : { claimTokenDigest }),
+    }
+    this.requests.set(request.requestId, request)
+    try {
+      this.persist()
+    } catch (error) {
+      this.requests.delete(request.requestId)
+      throw error
+    }
+    return request
   }
 
   private persist(): void {
     this.store?.save({
-      version: 1,
-      requests: [...this.requests.values()].map(request => ({ ...request })),
+      version: 2,
+      requests: [...this.requests.values()].map(request => ({
+        ...publicRequest(request),
+        used: request.used,
+        flow: request.flow,
+        ...(request.approvedAt === undefined ? {} : { approvedAt: request.approvedAt }),
+        ...(request.claimTokenDigest === undefined ? {} : { claimTokenDigest: request.claimTokenDigest.toString('base64url') }),
+        ...(request.claim === undefined ? {} : { claim: request.claim }),
+      })),
       devices: [...this.devices.values()].map(device => ({
         nodeId: device.nodeId,
         publicKey: device.publicKey,
+        displayName: device.displayName,
+        platform: device.platform,
         credentialDigest: device.credentialDigest.toString('base64url'),
         generation: device.generation,
         issuedAt: device.issuedAt,
@@ -223,29 +436,69 @@ export class PairingAuthority {
 
   private restore(snapshot: PairingStateSnapshot | undefined): void {
     if (snapshot === undefined) return
-    if (snapshot.version !== 1 || !Array.isArray(snapshot.requests) || !Array.isArray(snapshot.devices)) {
+    if ((snapshot.version !== 1 && snapshot.version !== 2)
+      || !Array.isArray(snapshot.requests) || !Array.isArray(snapshot.devices)) {
       throw new Error('pairing state has an unsupported format')
     }
     for (const request of snapshot.requests) {
+      const requestV2 = snapshot.version === 2
+        ? request as PairingStateSnapshotV2['requests'][number]
+        : undefined
       if (typeof request.requestId !== 'string' || !/^[A-Za-z0-9_-]{16,64}$/.test(request.requestId)
         || typeof request.verificationCode !== 'string' || !/^\d{6}$/.test(request.verificationCode)
         || typeof request.expiresAt !== 'number' || !Number.isFinite(request.expiresAt)
         || typeof request.used !== 'boolean') throw new Error('pairing state contains an invalid request')
+      const platform = validatePlatform(request.platform)
+      const flow = requestV2 === undefined ? 'direct' : requestV2.flow
+      if (flow !== 'direct' && flow !== 'claimable') throw new Error('pairing state contains an invalid request flow')
+      const approvedAt = requestV2?.approvedAt
+      if (approvedAt !== undefined && (typeof approvedAt !== 'number' || !Number.isFinite(approvedAt))) {
+        throw new Error('pairing state contains an invalid approval')
+      }
+      const claimTokenDigest = requestV2?.claimTokenDigest !== undefined
+        ? Buffer.from(requestV2.claimTokenDigest, 'base64url')
+        : undefined
+      if (claimTokenDigest !== undefined && claimTokenDigest.length !== 32) {
+        throw new Error('pairing state contains an invalid claim digest')
+      }
+      const claim = requestV2?.claim
+      if (claim !== undefined) {
+        if (claim.requestId !== request.requestId || claim.nodeId !== request.nodeId || claim.publicKey !== request.publicKey
+          || !Number.isInteger(claim.generation) || claim.generation < 1
+          || typeof claim.issuedAt !== 'number' || !Number.isFinite(claim.issuedAt)
+          || claim.encryptedCredential?.algorithm !== 'A256GCM'
+          || typeof claim.encryptedCredential.iv !== 'string' || Buffer.from(claim.encryptedCredential.iv, 'base64url').length !== 12
+          || typeof claim.encryptedCredential.ciphertext !== 'string'
+          || Buffer.from(claim.encryptedCredential.ciphertext, 'base64url').length < 17) {
+          throw new Error('pairing state contains an invalid encrypted claim')
+        }
+      }
       const restored: PendingPairing = {
         requestId: request.requestId,
         nodeId: validateIdentifier(request.nodeId, 'nodeId'),
         publicKey: validatePublicKey(request.publicKey),
         displayName: validateText(request.displayName, 'displayName'),
-        platform: request.platform,
+        platform,
         verificationCode: request.verificationCode,
         expiresAt: request.expiresAt,
         used: request.used,
+        flow,
+        ...(approvedAt === undefined ? {} : { approvedAt }),
+        ...(claimTokenDigest === undefined ? {} : { claimTokenDigest }),
+        ...(claim === undefined ? {} : { claim: { ...claim, encryptedCredential: { ...claim.encryptedCredential } } }),
       }
-      if (restored.platform !== 'macos') throw new Error('pairing state contains an unsupported platform')
+      if ((flow === 'direct' && (platform !== 'macos' || claimTokenDigest !== undefined || approvedAt !== undefined || claim !== undefined))
+        || (flow === 'claimable' && (platform !== 'pwa' || claimTokenDigest === undefined))
+        || (claim !== undefined && (!restored.used || approvedAt === undefined))) {
+        throw new Error('pairing state contains inconsistent request state')
+      }
       if (this.requests.has(restored.requestId)) throw new Error('pairing state contains duplicate requests')
       this.requests.set(restored.requestId, restored)
     }
     for (const device of snapshot.devices) {
+      const deviceV2 = snapshot.version === 2
+        ? device as PairingStateSnapshotV2['devices'][number]
+        : undefined
       if (typeof device.credentialDigest !== 'string' || typeof device.generation !== 'number'
         || !Number.isInteger(device.generation) || device.generation < 1
         || typeof device.issuedAt !== 'number' || !Number.isFinite(device.issuedAt)
@@ -254,6 +507,8 @@ export class PairingAuthority {
       const restored: CredentialRecord = {
         nodeId: validateIdentifier(device.nodeId, 'nodeId'),
         publicKey: validatePublicKey(device.publicKey),
+        displayName: deviceV2 === undefined ? validateIdentifier(device.nodeId, 'nodeId') : validateText(deviceV2.displayName, 'displayName'),
+        platform: deviceV2 === undefined ? 'macos' : validatePlatform(deviceV2.platform),
         credentialDigest: digest,
         generation: device.generation,
         issuedAt: device.issuedAt,
@@ -261,6 +516,27 @@ export class PairingAuthority {
       }
       if (digest.length !== 32 || this.devices.has(restored.nodeId)) throw new Error('pairing state contains duplicate or invalid devices')
       this.devices.set(restored.nodeId, restored)
+    }
+    for (const request of this.requests.values()) {
+      const device = this.devices.get(request.nodeId)
+      const matchingDevice = device !== undefined
+        && device.publicKey === request.publicKey
+        && device.displayName === request.displayName
+        && device.platform === request.platform
+      if (request.flow === 'direct' && request.used && !matchingDevice) {
+        throw new Error('pairing state contains inconsistent request state')
+      }
+      if (request.flow === 'claimable') {
+        if (request.used !== (request.claim !== undefined) || (request.claim !== undefined && !matchingDevice)) {
+          throw new Error('pairing state contains inconsistent request state')
+        }
+        if (request.claim !== undefined && device !== undefined
+          && (device.generation < request.claim.generation
+            || (device.generation === request.claim.generation && device.issuedAt !== request.claim.issuedAt)
+            || (device.generation > request.claim.generation && device.issuedAt < request.claim.issuedAt))) {
+          throw new Error('pairing state contains inconsistent request state')
+        }
+      }
     }
   }
 
@@ -272,18 +548,33 @@ export class PairingAuthority {
     return record
   }
 
-  private issue(nodeId: string, publicKey: string, generation: number): IssuedCredential {
+  private issue(
+    nodeId: string,
+    publicKey: string,
+    displayName: string,
+    platform: 'macos' | 'pwa',
+    generation: number,
+  ): IssuedCredential {
     const credential = randomBytes(32).toString('base64url')
     const issuedAt = this.now()
+    const previous = this.devices.get(nodeId)
     this.devices.set(nodeId, {
       nodeId,
       publicKey,
+      displayName,
+      platform,
       credentialDigest: credentialDigest(credential),
       generation,
       issuedAt,
       revoked: false,
     })
-    this.persist()
+    try {
+      this.persist()
+    } catch (error) {
+      if (previous === undefined) this.devices.delete(nodeId)
+      else this.devices.set(nodeId, previous)
+      throw error
+    }
     return { nodeId, publicKey, credential, generation, issuedAt }
   }
 }

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -17,6 +17,7 @@ const ASSET_DEFINITIONS = new Map<string, PwaAssetDefinition>([
   ['/app/index.html', { file: 'index.html', contentType: 'text/html; charset=utf-8' }],
   ['/app/app.css', { file: 'app.css', contentType: 'text/css; charset=utf-8' }],
   ['/app/app.js', { file: 'app.js', contentType: 'text/javascript; charset=utf-8' }],
+  ['/app/pairing.js', { file: 'pairing.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/manifest.webmanifest', { file: 'manifest.webmanifest', contentType: 'application/manifest+json; charset=utf-8' }],
   ['/app/sw.js', { file: 'sw.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/icon.svg', { file: 'icon.svg', contentType: 'image/svg+xml' }],

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFileSync, spawnSync } from 'node:child_process'
+import { createDecipheriv, createHash } from 'node:crypto'
 import { chmod, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { request as httpsRequest } from 'node:https'
 import { tmpdir } from 'node:os'
@@ -83,6 +84,14 @@ function issueCredential(authority, nodeId = 'node-1') {
     platform: 'macos',
   })
   return authority.confirm(pairing.requestId, pairing.verificationCode).credential
+}
+
+function decryptBrowserClaim(claim, claimToken) {
+  const key = createHash('sha256').update('jarvis-pairing-claim-v1\0').update(claimToken, 'utf8').digest()
+  const encrypted = Buffer.from(claim.encryptedCredential.ciphertext, 'base64url')
+  const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(claim.encryptedCredential.iv, 'base64url'))
+  decipher.setAuthTag(encrypted.subarray(-16))
+  return Buffer.concat([decipher.update(encrypted.subarray(0, -16)), decipher.final()]).toString('utf8')
 }
 
 function nodeAgentConfig(endpoint, credential, socketFactory, execute) {
@@ -294,6 +303,99 @@ test('runs authenticated pairing, device rotation, and owner revocation over ver
       method: 'POST', headers: { authorization: `Device ${second.credential}` },
     })
     assert.equal(rejectedRotation.status, 401)
+  } finally {
+    await service.stop()
+  }
+})
+
+test('pairs a browser through owner approval and an encrypted idempotent claim', async () => {
+  const authority = new PairingAuthority(() => 1_000, 60_000)
+  const identity = createDeviceIdentity()
+  const service = createJarvisGateway({ ownerToken, authority })
+  const gateway = await service.start()
+  try {
+    const created = await request(gateway, '/v1/pairing/requests/browser', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        nodeId: 'pwa-phone', publicKey: identity.publicKey, displayName: 'Owner Phone', platform: 'pwa',
+      }),
+    })
+    assert.equal(created.status, 201)
+    const challenge = await created.json()
+    assert.match(challenge.verificationCode, /^\d{6}$/)
+    assert.match(challenge.claimToken, /^[A-Za-z0-9_-]{43}$/)
+
+    const pending = await request(gateway, '/v1/pairing/requests/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ requestId: challenge.requestId, claimToken: challenge.claimToken }),
+    })
+    assert.equal(pending.status, 202)
+    assert.deepEqual(await pending.json(), { status: 'pending' })
+
+    const badClaim = await request(gateway, '/v1/pairing/requests/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ requestId: challenge.requestId, claimToken: 'A'.repeat(43) }),
+    })
+    assert.equal(badClaim.status, 401)
+    assert.equal((await badClaim.json()).code, 'pairing_claim_rejected')
+
+    const unauthorizedApproval = await request(gateway, '/v1/pairing/requests/approve', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ verificationCode: challenge.verificationCode }),
+    })
+    assert.equal(unauthorizedApproval.status, 401)
+    const approved = await request(gateway, '/v1/pairing/requests/approve', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${ownerToken}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ verificationCode: challenge.verificationCode }),
+    })
+    assert.equal(approved.status, 200)
+    assert.equal((await approved.json()).nodeId, 'pwa-phone')
+
+    const claimRequest = () => request(gateway, '/v1/pairing/requests/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ requestId: challenge.requestId, claimToken: challenge.claimToken }),
+    })
+    const claimed = await claimRequest()
+    assert.equal(claimed.status, 200)
+    const claim = await claimed.json()
+    const retry = await claimRequest()
+    assert.equal(retry.status, 200)
+    assert.deepEqual(await retry.json(), claim)
+
+    const credential = decryptBrowserClaim(claim, challenge.claimToken)
+    const session = await request(gateway, '/v1/sessions', {
+      method: 'POST',
+      headers: { authorization: `Device ${credential}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ nodeId: challenge.nodeId }),
+    })
+    assert.equal(session.status, 201)
+    assert.match((await session.json()).accessToken, /^[A-Za-z0-9_-]{43}$/)
+  } finally {
+    await service.stop()
+  }
+})
+
+test('reports browser pairing capacity as temporarily unavailable', async () => {
+  const authority = new PairingAuthority(() => 1_000, 60_000, undefined, 1)
+  const identity = createDeviceIdentity()
+  const service = createJarvisGateway({ ownerToken, authority })
+  const gateway = await service.start()
+  try {
+    const createRequest = nodeId => request(gateway, '/v1/pairing/requests/browser', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ nodeId, publicKey: identity.publicKey, displayName: 'Owner Phone', platform: 'pwa' }),
+    })
+    assert.equal((await createRequest('pwa-first')).status, 201)
+    const capacity = await createRequest('pwa-second')
+    assert.equal(capacity.status, 503)
+    assert.equal((await capacity.json()).code, 'pairing_capacity')
   } finally {
     await service.stop()
   }

--- a/test/pairing-approval.test.js
+++ b/test/pairing-approval.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BrowserPairingApprovalCoordinator } from '../dist/pairing-approval.js'
+
+const ownerToken = 'owner-token-for-approval-tests'
+
+test('submits one six-digit approval to a loopback Gateway', async () => {
+  const calls = []
+  const coordinator = new BrowserPairingApprovalCoordinator('http://127.0.0.1:3090', ownerToken, async (url, init) => {
+    calls.push({ url: url.toString(), init })
+    return new Response(JSON.stringify({
+      requestId: 'request-id-valid-1234',
+      nodeId: 'pwa-phone',
+      displayName: 'Owner Phone',
+      platform: 'pwa',
+      approvedAt: 1_000,
+      expiresAt: 61_000,
+    }), { status: 200 })
+  })
+  const approved = await coordinator.approve('123456')
+  assert.equal(approved.nodeId, 'pwa-phone')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'http://127.0.0.1:3090/v1/pairing/requests/approve')
+  assert.equal(calls[0].init.headers.authorization, `Bearer ${ownerToken}`)
+  assert.deepEqual(JSON.parse(calls[0].init.body), { verificationCode: '123456' })
+})
+
+test('rejects remote origins, malformed codes, and invalid Gateway responses', async () => {
+  assert.throws(() => new BrowserPairingApprovalCoordinator('https://gateway.example', ownerToken), /127\.0\.0\.1/)
+  const coordinator = new BrowserPairingApprovalCoordinator(
+    'http://127.0.0.1:3090', ownerToken, async () => new Response('{}', { status: 200 }),
+  )
+  await assert.rejects(coordinator.approve('12345'), /six digits/)
+  await assert.rejects(coordinator.approve('123456'), /invalid pairing approval/)
+})

--- a/test/pairing.test.js
+++ b/test/pairing.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { createDecipheriv, createHash } from 'node:crypto'
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -12,6 +13,14 @@ const requestInput = (identity, overrides = {}) => ({
   platform: 'macos',
   ...overrides,
 })
+
+function decryptClaim(claim, claimToken) {
+  const key = createHash('sha256').update('jarvis-pairing-claim-v1\0').update(claimToken, 'utf8').digest()
+  const encrypted = Buffer.from(claim.encryptedCredential.ciphertext, 'base64url')
+  const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(claim.encryptedCredential.iv, 'base64url'))
+  decipher.setAuthTag(encrypted.subarray(-16))
+  return Buffer.concat([decipher.update(encrypted.subarray(0, -16)), decipher.final()]).toString('utf8')
+}
 
 test('generates an Ed25519 identity with a stable public-key fingerprint', () => {
   const first = createDeviceIdentity()
@@ -35,6 +44,58 @@ test('confirms a short-lived pairing request exactly once', () => {
   assert.throws(() => authority.confirm(request.requestId, request.verificationCode), /already been used/)
   now = 100_000
   assert.equal(authority.authenticate('node-1', issued.credential), true)
+})
+
+test('approves and idempotently claims an encrypted PWA credential without the owner token', () => {
+  const identity = createDeviceIdentity()
+  const authority = new PairingAuthority(() => 1_000, 60_000)
+  const challenge = authority.createClaimableRequest(requestInput(identity, {
+    nodeId: 'pwa-one', displayName: 'Owner Phone', platform: 'pwa',
+  }))
+  assert.match(challenge.claimToken, /^[A-Za-z0-9_-]{43}$/)
+  assert.equal(authority.claim(challenge.requestId, challenge.claimToken), undefined)
+  assert.throws(() => authority.claim(challenge.requestId, 'A'.repeat(43)), /rejected/)
+  assert.throws(() => authority.confirm(challenge.requestId, challenge.verificationCode), /requires owner approval/)
+
+  const approval = authority.approveClaimable(challenge.verificationCode)
+  assert.equal(approval.nodeId, 'pwa-one')
+  assert.equal(authority.approveClaimable(challenge.verificationCode).approvedAt, approval.approvedAt)
+  const firstClaim = authority.claim(challenge.requestId, challenge.claimToken)
+  const secondClaim = authority.claim(challenge.requestId, challenge.claimToken)
+  assert.deepEqual(secondClaim, firstClaim)
+  const credential = decryptClaim(firstClaim, challenge.claimToken)
+  assert.match(credential, /^[A-Za-z0-9_-]{43}$/)
+  assert.equal(authority.authenticate('pwa-one', credential), true)
+  assert.equal(authority.revoke('pwa-one'), true)
+  assert.throws(() => authority.claim(challenge.requestId, challenge.claimToken), /revoked/)
+})
+
+test('expires an unclaimed PWA request before approval or claim', () => {
+  let now = 1_000
+  const identity = createDeviceIdentity()
+  const authority = new PairingAuthority(() => now, 60_000)
+  const challenge = authority.createClaimableRequest(requestInput(identity, {
+    nodeId: 'pwa-expired', displayName: 'Expired Phone', platform: 'pwa',
+  }))
+  now = 61_000
+  assert.throws(() => authority.approveClaimable(challenge.verificationCode), /incorrect or ambiguous/)
+  assert.throws(() => authority.claim(challenge.requestId, challenge.claimToken), /expired/)
+})
+
+test('bounds pending requests and prunes expired entries before admission', () => {
+  let now = 1_000
+  const identity = createDeviceIdentity()
+  const authority = new PairingAuthority(() => now, 60_000, undefined, 1)
+  authority.createClaimableRequest(requestInput(identity, {
+    nodeId: 'pwa-first', displayName: 'First Phone', platform: 'pwa',
+  }))
+  assert.throws(() => authority.createClaimableRequest(requestInput(identity, {
+    nodeId: 'pwa-second', displayName: 'Second Phone', platform: 'pwa',
+  })), /capacity/)
+  now = 61_000
+  assert.doesNotThrow(() => authority.createClaimableRequest(requestInput(identity, {
+    nodeId: 'pwa-second', displayName: 'Second Phone', platform: 'pwa',
+  })))
 })
 
 test('wrong verification code does not issue a credential', () => {
@@ -117,11 +178,110 @@ test('persists credential digests and revocation across authority restart', asyn
   }
 })
 
+test('persists claimable pairing across restart without plaintext claim or device credentials', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-pwa-pairing-'))
+  try {
+    const path = join(directory, 'pairing-state.json')
+    const identity = createDeviceIdentity()
+    let authority = new PairingAuthority(() => 1_000, 60_000, new FilePairingStateStore(path))
+    const challenge = authority.createClaimableRequest(requestInput(identity, {
+      nodeId: 'pwa-restart', displayName: 'Restart Phone', platform: 'pwa',
+    }))
+    assert.doesNotMatch(await readFile(path, 'utf8'), new RegExp(challenge.claimToken))
+
+    authority = new PairingAuthority(() => 1_000, 60_000, new FilePairingStateStore(path))
+    authority.approveClaimable(challenge.verificationCode)
+    const claim = authority.claim(challenge.requestId, challenge.claimToken)
+    const credential = decryptClaim(claim, challenge.claimToken)
+    const stored = await readFile(path, 'utf8')
+    assert.doesNotMatch(stored, new RegExp(challenge.claimToken))
+    assert.doesNotMatch(stored, new RegExp(credential))
+
+    authority = new PairingAuthority(() => 1_000, 60_000, new FilePairingStateStore(path))
+    assert.deepEqual(authority.claim(challenge.requestId, challenge.claimToken), claim)
+    assert.equal(authority.authenticate('pwa-restart', credential), true)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('rolls back an issued credential when persistence fails', () => {
+  const identity = createDeviceIdentity()
+  let failNextSave = false
+  let snapshot
+  const store = {
+    load: () => snapshot,
+    save: value => {
+      if (failNextSave) {
+        failNextSave = false
+        throw new Error('disk unavailable')
+      }
+      snapshot = structuredClone(value)
+    },
+  }
+  const authority = new PairingAuthority(() => 1_000, 60_000, store)
+  const request = authority.createRequest(requestInput(identity))
+  failNextSave = true
+  assert.throws(() => authority.confirm(request.requestId, request.verificationCode), /disk unavailable/)
+  const issued = authority.confirm(request.requestId, request.verificationCode)
+  assert.equal(authority.authenticate(request.nodeId, issued.credential), true)
+})
+
+test('rejects inconsistent version two pairing snapshots', () => {
+  const identity = createDeviceIdentity()
+  let snapshot
+  const store = {
+    load: () => snapshot,
+    save: value => { snapshot = structuredClone(value) },
+  }
+  const authority = new PairingAuthority(() => 1_000, 60_000, store)
+  const challenge = authority.createClaimableRequest(requestInput(identity, {
+    nodeId: 'pwa-corrupt', displayName: 'Corrupt Phone', platform: 'pwa',
+  }))
+  authority.approveClaimable(challenge.verificationCode)
+  authority.claim(challenge.requestId, challenge.claimToken)
+  const validSnapshot = structuredClone(snapshot)
+
+  snapshot.devices = []
+  assert.throws(() => new PairingAuthority(() => 1_000, 60_000, store), /inconsistent request state/)
+
+  snapshot = structuredClone(validSnapshot)
+  snapshot.requests[0].claim = undefined
+  assert.throws(() => new PairingAuthority(() => 1_000, 60_000, store), /inconsistent request state/)
+})
+
+test('restores version one pairing state and migrates it on the next write', () => {
+  const identity = createDeviceIdentity()
+  const credential = 'A'.repeat(43)
+  let saved
+  const store = {
+    load: () => ({
+      version: 1,
+      requests: [],
+      devices: [{
+        nodeId: 'legacy-node',
+        publicKey: identity.publicKey,
+        credentialDigest: createHash('sha256').update(credential).digest('base64url'),
+        generation: 1,
+        issuedAt: 1_000,
+        revoked: false,
+      }],
+    }),
+    save: snapshot => { saved = snapshot },
+  }
+  const authority = new PairingAuthority(() => 2_000, 60_000, store)
+  assert.equal(authority.authenticate('legacy-node', credential), true)
+  authority.rotate('legacy-node', credential)
+  assert.equal(saved.version, 2)
+  assert.equal(saved.devices[0].platform, 'macos')
+})
+
 test('rejects unsafe pairing data and unsupported platforms', () => {
   const identity = createDeviceIdentity()
   const authority = new PairingAuthority(() => 1_000, 60_000)
   assert.throws(() => authority.createRequest(requestInput(identity, { nodeId: 'node/1' })), /nodeId/)
   assert.throws(() => authority.createRequest(requestInput(identity, { platform: 'linux' })), /platform/)
+  assert.throws(() => authority.createClaimableRequest(requestInput(identity)), /platform/)
   assert.throws(() => authority.createRequest(requestInput(identity, { publicKey: 'short' })), /publicKey/)
   assert.throws(() => authority.createRequest(requestInput(identity, { displayName: 'Fake\u001b[2JMac' })), /control characters/)
 })

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import test from 'node:test'
+import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
+import { decryptPairingCredential } from '../web/pairing.js'
 
 const webRoot = join(process.cwd(), 'web')
 
@@ -20,10 +22,10 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js', '/app/apple-touch-icon.png', '/app/icon.svg',
+    '/app/', '/app/app.css', '/app/app.js?v=4', '/app/pairing.js?v=4', '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {
-    assert.match(serviceWorker, new RegExp(`['"]${path.replaceAll('/', '\\/')}['"]`))
+    assert.ok(serviceWorker.includes(`'${path}'`), `${path} must be pre-cached`)
   }
   assert.match(serviceWorker, /event\.request\.mode === 'navigate'/)
   assert.match(serviceWorker, /caches\.match\('\/app\/'\)/)
@@ -39,8 +41,26 @@ test('ships valid standard and Apple PNG icon dimensions', async () => {
 })
 
 test('keeps the browser client on the public Gateway contract', async () => {
-  const source = await readFile(join(webRoot, 'app.js'), 'utf8')
-  assert.match(source, /fetch\('\.\.\/v1\/health'/)
-  assert.doesNotMatch(source, /@deepseek-ai|dsh|Harness|\/api\//i)
-  assert.doesNotMatch(source, /localStorage|sessionStorage|indexedDB/)
+  const appSource = await readFile(join(webRoot, 'app.js'), 'utf8')
+  const pairingSource = await readFile(join(webRoot, 'pairing.js'), 'utf8')
+  const htmlSource = await readFile(join(webRoot, 'index.html'), 'utf8')
+  assert.match(appSource, /fetch\('\.\.\/v1\/health'/)
+  assert.match(appSource, /handlePairingState\(\{ phase: 'loading' \}\)/)
+  assert.match(pairingSource, /indexedDB\.open/)
+  assert.match(pairingSource, /await this\.initialize\(\)/)
+  assert.match(htmlSource, /id="pair-button"[^>]+disabled/)
+  assert.doesNotMatch(`${appSource}\n${pairingSource}`, /@deepseek-ai|dsh|Harness|\/api\//i)
+  assert.doesNotMatch(`${appSource}\n${pairingSource}`, /localStorage|sessionStorage/)
+})
+
+test('decrypts the Gateway claim envelope with the browser claim secret', async () => {
+  const authority = new PairingAuthority(() => 1_000, 60_000)
+  const identity = createDeviceIdentity()
+  const challenge = authority.createClaimableRequest({
+    nodeId: 'pwa-browser', publicKey: identity.publicKey, displayName: 'Browser', platform: 'pwa',
+  })
+  authority.approveClaimable(challenge.verificationCode)
+  const claim = authority.claim(challenge.requestId, challenge.claimToken)
+  const credential = await decryptPairingCredential(claim.encryptedCredential, challenge.claimToken)
+  assert.equal(authority.authenticate('pwa-browser', credential), true)
 })

--- a/web/app.css
+++ b/web/app.css
@@ -30,11 +30,11 @@ body {
   font-size: 15px;
 }
 
-button, textarea { font: inherit; letter-spacing: 0; }
+button, input, textarea { font: inherit; letter-spacing: 0; }
 button { cursor: pointer; }
 button:disabled { cursor: not-allowed; opacity: .48; }
 
-button:focus-visible, textarea:focus-visible, a:focus-visible {
+button:focus-visible, input:focus-visible, textarea:focus-visible, a:focus-visible {
   outline: 3px solid color-mix(in srgb, var(--focus) 40%, transparent);
   outline-offset: 2px;
 }
@@ -241,6 +241,47 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
 .settings-row h2 { margin: 0 0 5px; font-size: 15px; }
 .settings-row p { margin: 0; color: var(--text-muted); line-height: 1.45; }
 
+.pairing-setup {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(280px, 1.4fr);
+  gap: 24px;
+  padding: 22px 0;
+  border-bottom: 1px solid var(--border);
+}
+.pairing-setup[hidden] { display: none; }
+.pairing-setup h2 { margin: 0 0 5px; font-size: 15px; }
+.pairing-setup p { margin: 0; color: var(--text-muted); line-height: 1.45; }
+.pairing-form { display: grid; gap: 7px; }
+.pairing-form[hidden] { display: none; }
+.pairing-form label { color: var(--text-muted); font-size: 12px; font-weight: 650; }
+.pairing-form-controls { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; }
+.pairing-form input {
+  min-width: 0;
+  height: 40px;
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+}
+.pairing-challenge {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px 14px;
+}
+.pairing-challenge[hidden] { display: none; }
+.pairing-challenge > span { color: var(--text-muted); font-size: 12px; font-weight: 650; }
+.pairing-challenge output {
+  grid-row: span 2;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 28px;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+}
+.pairing-challenge small { color: var(--text-muted); }
+.pairing-challenge button { grid-column: 1 / -1; width: fit-content; margin-top: 8px; }
+
 .mobile-nav { display: none; }
 
 @media (max-width: 760px) {
@@ -256,6 +297,7 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
   .composer { margin-top: 10px; }
   .settings-row { grid-template-columns: minmax(0, 1fr) auto; gap: 12px; min-height: 88px; }
   .settings-row p { font-size: 13px; }
+  .pairing-setup { grid-template-columns: 1fr; gap: 16px; }
   .mobile-nav {
     position: fixed;
     z-index: 5;
@@ -290,6 +332,8 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
   .view-header { gap: 8px; }
   .view-header h1 { font-size: 19px; }
   .settings-row { align-items: start; }
+  .pairing-form-controls { grid-template-columns: 1fr; }
+  .pairing-form-controls button { width: 100%; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web/app.js
+++ b/web/app.js
@@ -1,3 +1,5 @@
+import { BrowserPairing } from './pairing.js?v=4'
+
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')
 const gatewayValue = document.querySelector('#gateway-value')
@@ -6,16 +8,101 @@ const sidebarStatus = document.querySelector('#sidebar-status')
 const refreshButton = document.querySelector('#refresh-button')
 const installButton = document.querySelector('#install-button')
 const installDetail = document.querySelector('#install-detail')
+const deviceDetail = document.querySelector('#device-detail')
+const deviceValue = document.querySelector('#device-value')
+const pairingSetup = document.querySelector('#pairing-setup')
+const pairingForm = document.querySelector('#pairing-form')
+const pairingChallenge = document.querySelector('#pairing-challenge')
+const pairingMessage = document.querySelector('#pairing-message')
+const pairingCode = document.querySelector('#pairing-code')
+const pairingExpiry = document.querySelector('#pairing-expiry')
+const pairButton = document.querySelector('#pair-button')
+const cancelPairingButton = document.querySelector('#cancel-pairing-button')
+const deviceName = document.querySelector('#device-name')
+const sidebarDeviceState = document.querySelector('#sidebar-device-state')
+const chatStateTitle = document.querySelector('#chat-state-title')
+const chatStateDetail = document.querySelector('#chat-state-detail')
+const messageInput = document.querySelector('#message-input')
 let installPrompt
 let probeInProgress = false
+let pairingPhase = 'loading'
+let pairingExpiresAt
+
+function updateDeviceSummary() {
+  const connected = pairingPhase === 'paired'
+  const hasIdentity = connected || pairingPhase === 'paired-offline' || pairingPhase === 'paired-error'
+  sidebarDeviceState.textContent = hasIdentity ? '已配对' : '未配对'
+  sidebarStatus.textContent = connected
+    ? '安全会话已建立'
+    : pairingPhase === 'paired-offline'
+      ? 'Gateway 未连接'
+      : pairingPhase === 'paired-error'
+        ? '会话不可用'
+        : '无同步数据'
+}
 
 function setConnection(state, label, detail) {
   document.body.dataset.connection = state
   connectionLabel.textContent = label
   gatewayValue.textContent = label
   gatewayDetail.textContent = detail
-  sidebarStatus.textContent = state === 'online' ? '等待设备配对' : '无同步数据'
+  updateDeviceSummary()
 }
+
+function setDeviceValue(label, className = 'is-muted') {
+  deviceValue.textContent = label
+  deviceValue.className = `value-label ${className}`
+}
+
+function handlePairingState(state) {
+  pairingPhase = state.phase
+  pairingExpiresAt = state.expiresAt
+  pairButton.disabled = state.phase === 'loading' || state.phase === 'starting'
+  pairingSetup.hidden = state.phase === 'paired' || state.phase === 'paired-offline' || state.phase === 'paired-error'
+  pairingForm.hidden = state.phase === 'pending'
+  pairingChallenge.hidden = state.phase !== 'pending'
+  if (state.phase === 'pending') {
+    pairingCode.textContent = state.verificationCode
+    pairingMessage.textContent = state.message ?? '等待 Mac 确认'
+    setDeviceValue('待确认', 'is-warning')
+    deviceDetail.textContent = state.displayName
+  } else if (state.phase === 'paired') {
+    setDeviceValue('已配对', '')
+    deviceDetail.textContent = `${state.displayName} · 安全会话可用`
+    chatStateTitle.textContent = '安全会话已建立'
+    chatStateDetail.textContent = '此设备已通过 Jarvis Gateway 认证。'
+    messageInput.placeholder = '等待对话同步'
+  } else if (state.phase === 'paired-offline') {
+    setDeviceValue('未连接', 'is-warning')
+    deviceDetail.textContent = `${state.displayName} · 本地凭据非当前状态`
+    chatStateTitle.textContent = '等待 Gateway'
+    chatStateDetail.textContent = '已保存设备身份，但当前无法验证会话。'
+    messageInput.placeholder = 'Gateway 未连接'
+  } else if (state.phase === 'paired-error') {
+    setDeviceValue('需检查', 'is-warning')
+    deviceDetail.textContent = `${state.displayName} · ${state.message}`
+    chatStateTitle.textContent = '会话不可用'
+    chatStateDetail.textContent = 'Gateway 返回的会话状态未通过验证。'
+    messageInput.placeholder = '会话不可用'
+  } else {
+    setDeviceValue(state.phase === 'revoked' ? '已撤销' : '未配对', state.phase === 'revoked' ? 'is-warning' : 'is-muted')
+    deviceDetail.textContent = state.phase === 'revoked' ? '此设备凭据已被撤销' : '尚未向此浏览器签发凭据'
+    pairingMessage.textContent = state.phase === 'error'
+      ? state.message
+      : state.phase === 'expired'
+        ? '配对请求已过期，可重新开始'
+        : state.phase === 'starting'
+          ? '正在创建私有设备身份'
+          : '创建此浏览器的私有设备身份'
+    chatStateTitle.textContent = '连接到 Jarvis'
+    chatStateDetail.textContent = '此设备完成配对后，对话会安全地显示在这里。'
+    messageInput.placeholder = '配对后即可发送消息'
+  }
+  updateDeviceSummary()
+}
+
+const pairing = new BrowserPairing(handlePairingState)
+handlePairingState({ phase: 'loading' })
 
 async function probeGateway() {
   if (probeInProgress) return
@@ -66,6 +153,14 @@ for (const button of document.querySelectorAll('[data-view-target]')) {
 }
 
 document.querySelector('#open-settings-button').addEventListener('click', () => showView('settings'))
+pairButton.addEventListener('click', async () => {
+  try {
+    await pairing.begin(deviceName.value)
+  } catch (error) {
+    handlePairingState({ phase: 'error', message: error instanceof Error ? error.message : '无法开始配对' })
+  }
+})
+cancelPairingButton.addEventListener('click', () => { void pairing.cancel() })
 refreshButton.addEventListener('click', () => { void probeGateway() })
 window.addEventListener('online', () => { void probeGateway() })
 window.addEventListener('offline', () => setConnection('offline', '离线', '设备当前没有网络连接'))
@@ -99,4 +194,12 @@ if ('serviceWorker' in navigator) {
 }
 
 void probeGateway()
+void pairing.initialize()
 window.setInterval(() => { void probeGateway() }, 30_000)
+window.setInterval(() => {
+  if (pairingPhase !== 'pending' || pairingExpiresAt === undefined) return
+  const remainingSeconds = Math.max(0, Math.ceil((pairingExpiresAt - Date.now()) / 1_000))
+  const minutes = Math.floor(remainingSeconds / 60)
+  const seconds = String(remainingSeconds % 60).padStart(2, '0')
+  pairingExpiry.textContent = `剩余 ${minutes}:${seconds}`
+}, 1_000)

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js" defer></script>
+    <script src="./app.js?v=4" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>
@@ -51,7 +51,7 @@
           <p class="empty-list">配对后显示对话</p>
         </div>
         <div class="sidebar-footer">
-          <span class="freshness-label">未配对</span>
+          <span id="sidebar-device-state" class="freshness-label">未配对</span>
           <small id="sidebar-status">无同步数据</small>
         </div>
       </aside>
@@ -63,16 +63,16 @@
               <p class="eyebrow">移动工作区</p>
               <h1 id="chat-title">新对话</h1>
             </div>
-            <span class="freshness-label">未同步</span>
+            <span id="chat-freshness" class="freshness-label">未同步</span>
           </header>
           <div class="conversation-empty">
             <div class="empty-symbol" aria-hidden="true">J</div>
-            <h2>连接到 Jarvis</h2>
-            <p>此设备完成配对后，对话会安全地显示在这里。</p>
+            <h2 id="chat-state-title">连接到 Jarvis</h2>
+            <p id="chat-state-detail">此设备完成配对后，对话会安全地显示在这里。</p>
             <button id="open-settings-button" class="primary-button" type="button">查看连接状态</button>
           </div>
           <form class="composer" aria-label="消息输入">
-            <textarea rows="1" placeholder="配对后即可发送消息" aria-label="消息" disabled></textarea>
+            <textarea id="message-input" rows="1" placeholder="配对后即可发送消息" aria-label="消息" disabled></textarea>
             <button class="send-button" type="submit" aria-label="发送消息" title="发送消息" disabled>↑</button>
           </form>
         </section>
@@ -109,9 +109,28 @@
             <section class="settings-row" aria-labelledby="device-heading">
               <div>
                 <h2 id="device-heading">设备身份</h2>
-                <p>尚未向此浏览器签发凭据</p>
+                <p id="device-detail">尚未向此浏览器签发凭据</p>
               </div>
-              <span class="value-label is-muted">未配对</span>
+              <span id="device-value" class="value-label is-muted">未配对</span>
+            </section>
+            <section id="pairing-setup" class="pairing-setup" aria-labelledby="pairing-setup-heading">
+              <div>
+                <h2 id="pairing-setup-heading">配对此设备</h2>
+                <p id="pairing-message" role="status" aria-live="polite">创建此浏览器的私有设备身份</p>
+              </div>
+              <div id="pairing-form" class="pairing-form">
+                <label for="device-name">设备名称</label>
+                <div class="pairing-form-controls">
+                  <input id="device-name" name="device-name" maxlength="64" value="我的手机" autocomplete="off">
+                  <button id="pair-button" class="primary-button" type="button" disabled>开始配对</button>
+                </div>
+              </div>
+              <div id="pairing-challenge" class="pairing-challenge" hidden>
+                <span>Mac 确认码</span>
+                <output id="pairing-code" aria-live="polite">------</output>
+                <small id="pairing-expiry">等待确认</small>
+                <button id="cancel-pairing-button" class="secondary-button" type="button">取消</button>
+              </div>
             </section>
             <section class="settings-row" aria-labelledby="sync-heading">
               <div>

--- a/web/pairing.js
+++ b/web/pairing.js
@@ -1,0 +1,357 @@
+const DATABASE_NAME = 'jarvis-device-v1'
+const STORE_NAME = 'private-state'
+const MAX_RESPONSE_CHARS = 32 * 1024
+
+class GatewayUnavailableError extends Error {}
+
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, 1)
+    request.onupgradeneeded = () => request.result.createObjectStore(STORE_NAME)
+    request.onerror = () => reject(new Error('device storage is unavailable'))
+    request.onsuccess = () => resolve(request.result)
+  })
+}
+
+async function readState(key) {
+  const database = await openDatabase()
+  try {
+    return await new Promise((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, 'readonly')
+      const request = transaction.objectStore(STORE_NAME).get(key)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(new Error('device storage could not be read'))
+    })
+  } finally {
+    database.close()
+  }
+}
+
+async function writeState(key, value) {
+  const database = await openDatabase()
+  try {
+    await new Promise((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, 'readwrite')
+      transaction.objectStore(STORE_NAME).put(value, key)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(new Error('device storage could not be written'))
+    })
+  } finally {
+    database.close()
+  }
+}
+
+async function deleteState(key) {
+  const database = await openDatabase()
+  try {
+    await new Promise((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, 'readwrite')
+      transaction.objectStore(STORE_NAME).delete(key)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(new Error('device storage could not be updated'))
+    })
+  } finally {
+    database.close()
+  }
+}
+
+export function encodeBase64Url(value) {
+  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')
+}
+
+export function decodeBase64Url(value) {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]+$/.test(value)) throw new Error('encoded data is invalid')
+  const padded = value.replaceAll('-', '+').replaceAll('_', '/') + '='.repeat((4 - value.length % 4) % 4)
+  const binary = atob(padded)
+  return Uint8Array.from(binary, character => character.charCodeAt(0))
+}
+
+export async function decryptPairingCredential(envelope, claimToken) {
+  if (envelope?.algorithm !== 'A256GCM' || typeof envelope.iv !== 'string' || typeof envelope.ciphertext !== 'string') {
+    throw new Error('encrypted device credential is invalid')
+  }
+  const material = new TextEncoder().encode(`jarvis-pairing-claim-v1\0${claimToken}`)
+  const digest = await crypto.subtle.digest('SHA-256', material)
+  const key = await crypto.subtle.importKey('raw', digest, { name: 'AES-GCM' }, false, ['decrypt'])
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: decodeBase64Url(envelope.iv) },
+    key,
+    decodeBase64Url(envelope.ciphertext),
+  )
+  const credential = new TextDecoder().decode(plaintext)
+  if (!/^[A-Za-z0-9_-]{43}$/.test(credential)) throw new Error('device credential is invalid')
+  return credential
+}
+
+function validIdentifier(value) {
+  return typeof value === 'string' && /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)
+}
+
+function validToken(value) {
+  return typeof value === 'string' && /^[A-Za-z0-9_-]{43}$/.test(value)
+}
+
+function parseSession(value, nodeId) {
+  if (value?.nodeId !== nodeId || typeof value.sessionId !== 'string' || !/^[A-Za-z0-9_-]{16,64}$/.test(value.sessionId)
+    || typeof value.familyId !== 'string' || !/^[A-Za-z0-9_-]{16,64}$/.test(value.familyId)
+    || !validToken(value.accessToken) || !validToken(value.refreshToken)
+    || !Number.isFinite(value.accessExpiresAt) || !Number.isFinite(value.refreshExpiresAt)) {
+    throw new Error('Gateway returned an invalid session')
+  }
+  return value
+}
+
+async function createIdentity(displayName) {
+  const generated = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify'],
+  )
+  const publicKey = encodeBase64Url(await crypto.subtle.exportKey('spki', generated.publicKey))
+  const exportedPrivateKey = await crypto.subtle.exportKey('pkcs8', generated.privateKey)
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8', exportedPrivateKey, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign'],
+  )
+  new Uint8Array(exportedPrivateKey).fill(0)
+  return {
+    nodeId: `pwa-${crypto.randomUUID()}`,
+    displayName,
+    publicKey,
+    privateKey,
+  }
+}
+
+export class BrowserPairing {
+  constructor(onState, fetchValue = (...requestArguments) => fetch(...requestArguments)) {
+    this.onState = onState
+    this.fetchValue = fetchValue
+    this.pollTimer = undefined
+    this.initializationPromise = undefined
+  }
+
+  initialize() {
+    this.initializationPromise ??= this.initializeState()
+    return this.initializationPromise
+  }
+
+  async initializeState() {
+    try {
+      const identity = await readState('identity')
+      const credential = await readState('credential')
+      const pending = await readState('pending')
+      if (identity !== undefined && credential !== undefined) {
+        await this.ensureSession(identity, credential)
+        return
+      }
+      if (identity !== undefined && pending !== undefined && pending.expiresAt > Date.now()) {
+        this.emitPending(pending)
+        void this.poll(identity, pending)
+        return
+      }
+      if (pending !== undefined) await deleteState('pending')
+      this.onState({ phase: 'unpaired' })
+    } catch (error) {
+      this.onState({ phase: 'error', message: error instanceof Error ? error.message : 'pairing initialization failed' })
+    }
+  }
+
+  async begin(displayName) {
+    await this.initialize()
+    const normalizedName = displayName.trim()
+    if (normalizedName.length < 1 || normalizedName.length > 64 || /[\u0000-\u001f\u007f]/.test(normalizedName)) {
+      throw new Error('设备名称应为 1 至 64 个字符')
+    }
+    this.clearPoll()
+    this.onState({ phase: 'starting' })
+    let identity = await readState('identity')
+    if (identity === undefined) {
+      identity = await createIdentity(normalizedName)
+      await writeState('identity', identity)
+    } else if (identity.displayName !== normalizedName) {
+      identity = { ...identity, displayName: normalizedName }
+      await writeState('identity', identity)
+    }
+    const response = await this.request('/v1/pairing/requests/browser', {
+      method: 'POST',
+      body: JSON.stringify({
+        nodeId: identity.nodeId,
+        publicKey: identity.publicKey,
+        displayName: normalizedName,
+        platform: 'pwa',
+      }),
+    })
+    if (!response.ok) throw new Error(`无法创建配对请求 (${response.status})`)
+    const challenge = response.value
+    if (challenge?.nodeId !== identity.nodeId || challenge?.publicKey !== identity.publicKey
+      || !validIdentifier(challenge.requestId) || !/^\d{6}$/.test(challenge.verificationCode)
+      || !validToken(challenge.claimToken) || !Number.isFinite(challenge.expiresAt)) {
+      throw new Error('Gateway 返回了无效配对请求')
+    }
+    const pending = {
+      requestId: challenge.requestId,
+      claimToken: challenge.claimToken,
+      verificationCode: challenge.verificationCode,
+      expiresAt: challenge.expiresAt,
+      displayName: normalizedName,
+    }
+    await writeState('pending', pending)
+    this.emitPending(pending)
+    void this.poll(identity, pending)
+  }
+
+  async cancel() {
+    this.clearPoll()
+    await deleteState('pending')
+    this.onState({ phase: 'unpaired' })
+  }
+
+  clearPoll() {
+    if (this.pollTimer !== undefined) window.clearTimeout(this.pollTimer)
+    this.pollTimer = undefined
+  }
+
+  emitPending(pending, message) {
+    this.onState({
+      phase: 'pending',
+      verificationCode: pending.verificationCode,
+      expiresAt: pending.expiresAt,
+      displayName: pending.displayName,
+      ...(message === undefined ? {} : { message }),
+    })
+  }
+
+  schedulePoll(identity, pending, delay = 2_000) {
+    this.clearPoll()
+    this.pollTimer = window.setTimeout(() => { void this.poll(identity, pending) }, delay)
+  }
+
+  async poll(identity, pending) {
+    if (pending.expiresAt <= Date.now()) {
+      await deleteState('pending')
+      this.onState({ phase: 'expired' })
+      return
+    }
+    try {
+      const response = await this.request('/v1/pairing/requests/claim', {
+        method: 'POST',
+        body: JSON.stringify({ requestId: pending.requestId, claimToken: pending.claimToken }),
+      })
+      if (response.status === 202) {
+        this.emitPending(pending)
+        this.schedulePoll(identity, pending)
+        return
+      }
+      if (response.status === 410) {
+        await deleteState('pending')
+        this.onState({ phase: 'expired' })
+        return
+      }
+      if (!response.ok) {
+        await deleteState('pending')
+        this.onState({ phase: 'error', message: `配对领取失败 (${response.status})` })
+        return
+      }
+      const claim = response.value
+      if (claim?.requestId !== pending.requestId || claim?.nodeId !== identity.nodeId
+        || claim?.publicKey !== identity.publicKey || !Number.isInteger(claim.generation)
+        || claim.generation < 1 || !Number.isFinite(claim.issuedAt)) {
+        throw new Error('Gateway 返回了无效配对凭据')
+      }
+      const credentialValue = await decryptPairingCredential(claim.encryptedCredential, pending.claimToken)
+      const credential = {
+        nodeId: identity.nodeId,
+        credential: credentialValue,
+        generation: claim.generation,
+        issuedAt: claim.issuedAt,
+      }
+      await writeState('credential', credential)
+      await deleteState('pending')
+      await this.ensureSession(identity, credential)
+    } catch (error) {
+      if (error instanceof GatewayUnavailableError) {
+        this.emitPending(pending, 'Gateway 暂时不可用')
+        this.schedulePoll(identity, pending, 5_000)
+        return
+      }
+      await deleteState('pending')
+      this.onState({ phase: 'error', message: error instanceof Error ? error.message : '配对响应无效' })
+    }
+  }
+
+  async ensureSession(identity, credential) {
+    try {
+      const storedSession = await readState('session')
+      if (storedSession !== undefined && storedSession.accessExpiresAt > Date.now()) {
+        const current = await this.request('/v1/sessions/current', {
+          headers: { authorization: `Session ${storedSession.accessToken}` },
+        })
+        if (current.ok) {
+          this.onState({ phase: 'paired', displayName: identity.displayName, nodeId: identity.nodeId })
+          return
+        }
+      }
+      if (storedSession !== undefined && storedSession.refreshExpiresAt > Date.now()) {
+        const refreshed = await this.request('/v1/sessions/refresh', {
+          method: 'POST',
+          body: JSON.stringify({ refreshToken: storedSession.refreshToken }),
+        })
+        if (refreshed.ok) {
+          await writeState('session', parseSession(refreshed.value, identity.nodeId))
+          this.onState({ phase: 'paired', displayName: identity.displayName, nodeId: identity.nodeId })
+          return
+        }
+      }
+      const issued = await this.request('/v1/sessions', {
+        method: 'POST',
+        headers: { authorization: `Device ${credential.credential}` },
+        body: JSON.stringify({ nodeId: identity.nodeId }),
+      })
+      if (issued.status === 401) {
+        await deleteState('credential')
+        await deleteState('session')
+        this.onState({ phase: 'revoked' })
+        return
+      }
+      if (!issued.ok) throw new Error(`Gateway 会话创建失败 (${issued.status})`)
+      await writeState('session', parseSession(issued.value, identity.nodeId))
+      this.onState({ phase: 'paired', displayName: identity.displayName, nodeId: identity.nodeId })
+    } catch (error) {
+      if (error instanceof GatewayUnavailableError) {
+        this.onState({ phase: 'paired-offline', displayName: identity.displayName, nodeId: identity.nodeId })
+        return
+      }
+      this.onState({
+        phase: 'paired-error',
+        displayName: identity.displayName,
+        nodeId: identity.nodeId,
+        message: error instanceof Error ? error.message : 'Gateway 会话响应无效',
+      })
+    }
+  }
+
+  async request(path, init = {}) {
+    let response
+    try {
+      response = await this.fetchValue(path, {
+        ...init,
+        headers: {
+          accept: 'application/json',
+          ...(init.body === undefined ? {} : { 'content-type': 'application/json' }),
+          ...init.headers,
+        },
+      })
+    } catch {
+      throw new GatewayUnavailableError('Gateway 暂时不可用')
+    }
+    const text = await response.text()
+    if (text.length > MAX_RESPONSE_CHARS) throw new Error('Gateway response is too large')
+    let value
+    try {
+      value = text === '' ? undefined : JSON.parse(text)
+    } catch {
+      throw new Error('Gateway returned invalid JSON')
+    }
+    return { ok: response.ok, status: response.status, value }
+  }
+}

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,8 +1,9 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v1'
+const CACHE_NAME = 'jarvis-pwa-shell-v4'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js',
+  '/app/app.js?v=4',
+  '/app/pairing.js?v=4',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',
@@ -32,8 +33,8 @@ self.addEventListener('fetch', event => {
       .catch(() => caches.match('/app/')))
     return
   }
-  event.respondWith(caches.match(event.request).then(cached => cached ?? fetch(event.request).then(response => {
+  event.respondWith(fetch(event.request).then(response => {
     if (response.ok) void caches.open(CACHE_NAME).then(cache => cache.put(event.request, response.clone()))
     return response
-  })))
+  }).catch(() => caches.match(event.request)))
 })


### PR DESCRIPTION
## Summary
- add claimable browser pairing with loopback owner approval
- encrypt device credentials for one-time browser claim and persist digest-only secrets
- store browser identity in IndexedDB and exchange device credentials for short-lived sessions
- show pending, paired, offline, error, expiry, and revocation states in the installable PWA
- validate and atomically persist pairing state with bounded pending requests

## Verification
- `npm run verify` (103/103)
- `npm run verify:runtime`
- real mobile-sized browser pairing, reload, offline, and revocation flow
- `git diff --check`
- changed-file credential scan

Closes #44
Tracks #16