### PR TITLE
Add authenticated PWA conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:approve -- --code 1
 
 Owner Token 只提交给 loopback Gateway，不进入手机。Gateway 只持久化一次性领取密钥和设备凭据的 SHA-256 摘要；设备凭据通过领取密钥派生的 AES-256-GCM 密钥加密返回，重复领取返回同一密文。浏览器将不可导出的 P-256 私钥、设备凭据和短期 Session 保存在同源 IndexedDB；离线时只显示本地身份为非当前状态。清除站点数据会移除本地访问材料，但不会替代服务端设备撤销。
 
-短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages` 和 `POST /v1/conversations/:id/cancel`。消息只接受最多 16 KiB 的纯文本；远程 slash command 被拒绝。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会要求先重新读取会话快照。
+短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages` 和 `POST /v1/conversations/:id/cancel`。配对后的 PWA 可列出、新建、选择和继续文字对话；消息只接受最多 16 KiB 的纯文本，发送期间会锁定重复提交，远程 slash command 被拒绝。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会先要求重新读取权威会话快照，刷新失败时不会推进游标。
+
+PWA 只在同源 IndexedDB 保存最近一次规范化对话列表、当前最多 50 条文字消息和事件游标，不缓存 API 响应或 Owner Token。Gateway 不可达时，离线壳可只读显示该快照，并明确标记为“旧数据”；所有新建和发送操作保持禁用，恢复连接并重新验证 Session 后才切回实时状态。
 
 Gateway 默认允许每个连接来源突发 60 次请求并每秒恢复 1 次额度；每个已认证 Owner、设备或 Session 可突发 120 次并每秒恢复 2 次额度。它只使用直接连接地址，不信任客户端提供的转发来源头；HTTP `429` 会返回 `Retry-After`、限额余量和 correlation ID。
 
@@ -156,7 +158,7 @@ npm run restore -- --archive backups/jarvis-backup.jarvis
 - API Key：存放在未纳入 Git 的 `.env` 或 Harness 本机凭据存储，均不进入备份归档
 - 网络：Harness 始终只限本机回环；Gateway 仅可绑定明确的回环、私网或 overlay IP，非回环强制 TLS，禁止直接暴露到互联网
 
-这是单用户文字版 MVP；手机端已有可安装的离线应用外壳、Owner 批准的设备配对和短期 Session，尚未接入移动对话、审批、通知，也不包含语音、智能家居、任意终端、文件操作和消息发送。Gateway 已提供认证、设备身份、受控会话 API 和可恢复的实时事件；客户端不得直接暴露或调用 Harness Web 服务。
+这是单用户文字版 MVP；手机端已有可安装的离线应用、Owner 批准的设备配对、短期 Session、文字对话和实时同步，尚未接入审批与通知，也不包含语音、智能家居、任意终端、文件操作和第三方消息发送。Gateway 已提供认证、设备身份、受控会话 API 和可恢复的实时事件；客户端不得直接暴露或调用 Harness Web 服务。
 
 ## 上游边界
 

--- a/docs/plan/04-stage-3-mobile-remote.md
+++ b/docs/plan/04-stage-3-mobile-remote.md
@@ -14,7 +14,7 @@ Allow the owner to converse with Jarvis, observe status, and approve actions fro
 - Native mobile development remains deferred until a required capability fails the PWA gate.
 - Background always-listening voice is explicitly outside this stage.
 
-The platform-independent increments tracked in [#42](https://github.com/gh503/jarvis/issues/42) and [#44](https://github.com/gh503/jarvis/issues/44) serve a scoped responsive PWA shell and an owner-approved browser pairing flow. The browser keeps an origin-bound private key, claims an encrypted device credential without receiving the Owner Token, and obtains a short-lived Gateway session. Offline startup clearly marks the saved identity as non-current. Physical installation remains unqualified until the owner names the first iPhone or Android device.
+The platform-independent increments tracked in [#42](https://github.com/gh503/jarvis/issues/42), [#44](https://github.com/gh503/jarvis/issues/44), and [#46](https://github.com/gh503/jarvis/issues/46) serve a scoped responsive PWA shell, owner-approved browser pairing, and authenticated text conversations with cursor-based live synchronization. The browser keeps an origin-bound private key, claims an encrypted device credential without receiving the Owner Token, and obtains a short-lived Gateway session. Offline startup renders only a bounded normalized conversation snapshot marked stale and disables mutations. Physical installation remains unqualified until the owner names the first iPhone or Android device.
 
 ## Modules
 

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -18,6 +18,8 @@ const ASSET_DEFINITIONS = new Map<string, PwaAssetDefinition>([
   ['/app/app.css', { file: 'app.css', contentType: 'text/css; charset=utf-8' }],
   ['/app/app.js', { file: 'app.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/pairing.js', { file: 'pairing.js', contentType: 'text/javascript; charset=utf-8' }],
+  ['/app/device-store.js', { file: 'device-store.js', contentType: 'text/javascript; charset=utf-8' }],
+  ['/app/conversations.js', { file: 'conversations.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/manifest.webmanifest', { file: 'manifest.webmanifest', contentType: 'application/manifest+json; charset=utf-8' }],
   ['/app/sw.js', { file: 'sw.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/icon.svg', { file: 'icon.svg', contentType: 'image/svg+xml' }],

--- a/test/conversations.test.js
+++ b/test/conversations.test.js
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ConversationsClient } from '../web/conversations.js'
+
+const cursor = `${'A'.repeat(22)}.1`
+const conversation = { id: 'session-one', title: 'Jarvis plan', updatedAt: 1_000, running: false, blank: false }
+const message = { id: 'message-one', sequence: 1, createdAt: 1_000, role: 'assistant', text: 'Ready' }
+
+function memoryStore() {
+  const values = new Map()
+  return {
+    values,
+    read: async key => structuredClone(values.get(key)),
+    write: async (key, value) => { values.set(key, structuredClone(value)) },
+    delete: async key => { values.delete(key) },
+  }
+}
+
+class FakeSocket {
+  constructor(url) {
+    this.url = url
+    this.readyState = 0
+    this.sent = []
+    this.listeners = new Map()
+  }
+
+  addEventListener(name, listener) {
+    const listeners = this.listeners.get(name) ?? []
+    listeners.push(listener)
+    this.listeners.set(name, listeners)
+  }
+
+  dispatch(name, value = {}) {
+    for (const listener of this.listeners.get(name) ?? []) listener(value)
+  }
+
+  open() {
+    this.readyState = 1
+    this.dispatch('open')
+  }
+
+  message(value) {
+    this.dispatch('message', { data: JSON.stringify(value) })
+  }
+
+  send(value) {
+    this.sent.push(JSON.parse(value))
+  }
+
+  close() {
+    if (this.readyState === 3) return
+    this.readyState = 3
+    this.dispatch('close')
+  }
+}
+
+const tick = () => new Promise(resolve => setImmediate(resolve))
+
+function gatewayPairing(calls, overrides = {}) {
+  return {
+    accessSession: async force => {
+      calls.push(['session', force])
+      return { accessToken: 'S'.repeat(43) }
+    },
+    authenticatedRequest: async (path, init = {}) => {
+      calls.push(['request', path, init.method ?? 'GET'])
+      if (overrides.request !== undefined) {
+        const result = await overrides.request(path, init)
+        if (result !== undefined) return result
+      }
+      if (path === '/v1/conversations') return { ok: true, status: 200, value: { conversations: [conversation] } }
+      if (path.startsWith('/v1/conversations/session-one?')) {
+        return { ok: true, status: 200, value: { messages: [message], hasMore: false, nextBeforeSequence: null } }
+      }
+      throw new Error(`unexpected request ${path}`)
+    },
+  }
+}
+
+test('loads an authenticated snapshot and keeps the access token out of the event URL', async () => {
+  const calls = []
+  const states = []
+  const sockets = []
+  const store = memoryStore()
+  const client = new ConversationsClient(gatewayPairing(calls), state => states.push(state), {
+    store,
+    location: { origin: 'https://jarvis.internal' },
+    socketFactory: url => {
+      const socket = new FakeSocket(url)
+      sockets.push(socket)
+      return socket
+    },
+  })
+  await client.start()
+  await tick()
+
+  assert.equal(states.at(-1).phase, 'ready')
+  assert.equal(states.at(-1).selectedId, 'session-one')
+  assert.deepEqual(states.at(-1).messages, [message])
+  assert.equal(sockets[0].url, 'wss://jarvis.internal/v1/events')
+  assert.doesNotMatch(sockets[0].url, /S{10}/)
+
+  sockets[0].open()
+  await tick()
+  assert.deepEqual(sockets[0].sent[0], { type: 'events.authenticate', accessToken: 'S'.repeat(43) })
+  sockets[0].message({ type: 'events.ready', cursor, replayCount: 0, requiresSnapshot: false })
+  await tick()
+  assert.equal(store.values.get('event-cursor'), cursor)
+})
+
+test('refreshes the authoritative snapshot when the event stream requires synchronization', async () => {
+  const calls = []
+  const sockets = []
+  const client = new ConversationsClient(gatewayPairing(calls), () => {}, {
+    store: memoryStore(),
+    location: { origin: 'http://127.0.0.1:3190' },
+    socketFactory: url => {
+      const socket = new FakeSocket(url)
+      sockets.push(socket)
+      return socket
+    },
+  })
+  await client.start()
+  await tick()
+  const initialLists = calls.filter(call => call[1] === '/v1/conversations').length
+  sockets[0].open()
+  sockets[0].message({ type: 'events.ready', cursor, replayCount: 0, requiresSnapshot: true, reason: 'initial' })
+  await tick()
+  await tick()
+  assert.equal(calls.filter(call => call[1] === '/v1/conversations').length, initialLists + 1)
+})
+
+test('shows a cached snapshot as stale while offline without contacting the Gateway', async () => {
+  const store = memoryStore()
+  await store.write('conversation-cache', {
+    version: 1, conversations: [conversation], selectedId: conversation.id, messages: [message], cachedAt: 2_000,
+  })
+  const states = []
+  const client = new ConversationsClient({
+    accessSession: async () => { throw new Error('must not authenticate offline') },
+    authenticatedRequest: async () => { throw new Error('must not request offline') },
+  }, state => states.push(state), { store, location: { origin: 'https://jarvis.internal' } })
+  client.setOnline(false)
+  await client.start()
+  assert.equal(states.at(-1).phase, 'stale')
+  assert.deepEqual(states.at(-1).messages, [message])
+})
+
+test('allows only one in-flight submission for the same draft', async () => {
+  const calls = []
+  const states = []
+  let release
+  const accepted = new Promise(resolve => { release = resolve })
+  const pairing = gatewayPairing(calls, {
+    request: async (path, init) => {
+      if (path.endsWith('/messages') && init.method === 'POST') return accepted
+      return undefined
+    },
+  })
+  const client = new ConversationsClient(pairing, state => states.push(state), {
+    store: memoryStore(), location: { origin: 'https://jarvis.internal' }, socketFactory: url => new FakeSocket(url),
+  })
+  await client.start()
+  const first = client.send('Hello Jarvis')
+  const duplicate = await client.send('Hello Jarvis')
+  assert.equal(duplicate, false)
+  assert.equal(calls.filter(call => typeof call[1] === 'string' && call[1].endsWith('/messages')).length, 1)
+  release({ ok: true, status: 202, value: { accepted: true } })
+  assert.equal(await first, true)
+  assert.equal(states.at(-1).sending, false)
+  assert.equal(states.at(-1).phase, 'ready')
+})
+
+test('keeps the composer usable after rejecting an unsafe draft locally', async () => {
+  const states = []
+  const client = new ConversationsClient(gatewayPairing([]), state => states.push(state), {
+    store: memoryStore(), location: { origin: 'https://jarvis.internal' }, socketFactory: url => new FakeSocket(url),
+  })
+  await client.start()
+  assert.equal(await client.send('/local-command'), false)
+  assert.equal(states.at(-1).phase, 'ready')
+  assert.match(states.at(-1).message, /斜杠命令/)
+})
+
+test('does not advance the event cursor when a required snapshot fails', async () => {
+  const calls = []
+  const sockets = []
+  const store = memoryStore()
+  let failSnapshot = false
+  const pairing = gatewayPairing(calls, {
+    request: async path => {
+      if (failSnapshot && path === '/v1/conversations') return { ok: false, status: 503, value: {} }
+      return undefined
+    },
+  })
+  const client = new ConversationsClient(pairing, () => {}, {
+    store,
+    location: { origin: 'https://jarvis.internal' },
+    socketFactory: url => {
+      const socket = new FakeSocket(url)
+      sockets.push(socket)
+      return socket
+    },
+    setTimeout: () => 1,
+    clearTimeout: () => {},
+  })
+  await client.start()
+  await tick()
+  sockets[0].open()
+  failSnapshot = true
+  sockets[0].message({ type: 'events.ready', cursor, replayCount: 0, requiresSnapshot: true, reason: 'cursor_expired' })
+  await tick()
+  await tick()
+  assert.equal(store.values.has('event-cursor'), false)
+  assert.equal(sockets[0].readyState, 3)
+})

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -22,7 +22,8 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js?v=4', '/app/pairing.js?v=4', '/app/apple-touch-icon.png', '/app/icon.svg',
+    '/app/', '/app/app.css', '/app/app.js?v=7', '/app/pairing.js?v=7', '/app/device-store.js?v=7',
+    '/app/conversations.js?v=7', '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {
     assert.ok(serviceWorker.includes(`'${path}'`), `${path} must be pre-cached`)
@@ -43,14 +44,18 @@ test('ships valid standard and Apple PNG icon dimensions', async () => {
 test('keeps the browser client on the public Gateway contract', async () => {
   const appSource = await readFile(join(webRoot, 'app.js'), 'utf8')
   const pairingSource = await readFile(join(webRoot, 'pairing.js'), 'utf8')
+  const conversationsSource = await readFile(join(webRoot, 'conversations.js'), 'utf8')
+  const deviceStoreSource = await readFile(join(webRoot, 'device-store.js'), 'utf8')
   const htmlSource = await readFile(join(webRoot, 'index.html'), 'utf8')
   assert.match(appSource, /fetch\('\.\.\/v1\/health'/)
   assert.match(appSource, /handlePairingState\(\{ phase: 'loading' \}\)/)
-  assert.match(pairingSource, /indexedDB\.open/)
+  assert.match(deviceStoreSource, /indexedDB\.open/)
   assert.match(pairingSource, /await this\.initialize\(\)/)
+  assert.match(conversationsSource, /events\.authenticate/)
+  assert.match(conversationsSource, /authenticatedRequest\('\/v1\/conversations'/)
   assert.match(htmlSource, /id="pair-button"[^>]+disabled/)
-  assert.doesNotMatch(`${appSource}\n${pairingSource}`, /@deepseek-ai|dsh|Harness|\/api\//i)
-  assert.doesNotMatch(`${appSource}\n${pairingSource}`, /localStorage|sessionStorage/)
+  assert.doesNotMatch(`${appSource}\n${pairingSource}\n${conversationsSource}`, /@deepseek-ai|dsh|Harness|\/api\//i)
+  assert.doesNotMatch(`${appSource}\n${pairingSource}\n${conversationsSource}`, /localStorage|sessionStorage/)
 })
 
 test('decrypts the Gateway claim envelope with the browser claim secret', async () => {

--- a/web/app.css
+++ b/web/app.css
@@ -133,10 +133,28 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
 .nav-button:hover, .nav-button.is-active { background: #29312e; color: #fff; }
 .nav-button span:first-child { width: 18px; text-align: center; }
 
-.conversation-list { min-height: 0; margin-top: 28px; }
+.conversation-list { min-height: 0; margin-top: 28px; overflow: hidden; }
 .section-heading { justify-content: space-between; color: var(--sidebar-muted); font-size: 12px; }
 .sidebar .icon-button { border-color: #3a4440; background: transparent; color: #fff; }
 .empty-list { margin: 22px 8px; color: #7f8b86; font-size: 13px; }
+.conversation-list-items { display: grid; gap: 3px; max-height: calc(100dvh - 300px); margin-top: 10px; overflow: auto; }
+.conversation-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 3px 8px;
+  width: 100%;
+  min-height: 52px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--sidebar-muted);
+  text-align: left;
+}
+.conversation-item:hover, .conversation-item.is-active { background: #29312e; color: #fff; }
+.conversation-item strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.conversation-item small { grid-column: 1 / -1; color: #8e9a95; }
+.conversation-running { color: #5ee6b1; font-size: 11px; }
 
 .sidebar-footer {
   display: grid;
@@ -164,12 +182,14 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
 .value-label.is-warning { background: #fff3cd; color: var(--warning); }
 .value-label.is-muted { color: var(--text-muted); }
 
-.main-content { min-width: 0; min-height: 0; }
+.main-content { width: 100%; height: 100%; min-width: 0; min-height: 0; }
 .view-panel { height: 100%; min-height: 0; padding: 28px clamp(20px, 4vw, 56px); overflow: auto; }
 .chat-view.is-active { display: grid; grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; }
 .view-header { justify-content: space-between; min-height: 48px; gap: 18px; }
 .view-header h1 { margin: 2px 0 0; font-size: 24px; line-height: 1.2; }
 .eyebrow { margin: 0; color: var(--text-muted); font-size: 12px; font-weight: 650; }
+.chat-header-actions { display: flex; align-items: center; gap: 10px; min-width: 0; }
+#mobile-conversation-select { display: none; }
 
 .conversation-empty, .plain-empty {
   align-self: center;
@@ -192,6 +212,50 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
 }
 .conversation-empty h2, .plain-empty h2 { margin: 0 0 8px; font-size: 20px; }
 .conversation-empty p, .plain-empty p { margin: 0 0 22px; color: var(--text-muted); line-height: 1.55; }
+.conversation-empty .primary-button + .primary-button { margin-left: 8px; }
+
+.message-list {
+  display: flex;
+  width: min(780px, 100%);
+  min-height: 0;
+  margin: 18px auto 0;
+  padding: 6px 2px 18px;
+  flex-direction: column;
+  gap: 14px;
+  overflow: auto;
+  list-style: none;
+}
+.message-list[hidden] { display: none; }
+.message { display: grid; gap: 5px; max-width: min(680px, 88%); }
+.message.is-user { align-self: end; }
+.message.is-assistant { align-self: start; }
+.message-body {
+  margin: 0;
+  padding: 11px 13px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.message.is-user .message-body { border-color: #b7dfcf; background: #e7f5ef; }
+.message-meta { color: var(--text-muted); font-size: 11px; }
+.message.is-user .message-meta { text-align: right; }
+.conversation-notice {
+  width: min(780px, 100%);
+  min-height: 28px;
+  margin: 0 auto;
+  color: var(--warning);
+  font-size: 12px;
+  text-align: center;
+}
+.conversation-notice[hidden] { display: none; }
+
+.activity-list { display: grid; margin: 24px 0 0; padding: 0; border-top: 1px solid var(--border); list-style: none; }
+.activity-list[hidden] { display: none; }
+.activity-item { display: flex; justify-content: space-between; gap: 18px; padding: 15px 0; border-bottom: 1px solid var(--border); }
+.activity-item time { flex: 0 0 auto; color: var(--text-muted); font-size: 12px; }
 
 .primary-button, .secondary-button {
   min-height: 40px;
@@ -293,7 +357,24 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
   .sidebar { display: none; }
   .view-panel { padding: 20px 16px 14px; }
   .view-header h1 { font-size: 21px; }
+  .chat-header-actions { flex: 1; justify-content: flex-end; }
+  #mobile-conversation-select {
+    display: block;
+    width: min(42vw, 180px);
+    min-width: 0;
+    height: 36px;
+    padding: 0 28px 0 9px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface);
+    color: var(--text);
+    text-overflow: ellipsis;
+  }
+  .chat-header-actions .freshness-label { display: none; }
   .conversation-empty { padding: 24px 12px; }
+  .message-list { margin-top: 10px; padding-bottom: 10px; }
+  .message { max-width: 92%; }
+  .message-body { padding: 10px 11px; }
   .composer { margin-top: 10px; }
   .settings-row { grid-template-columns: minmax(0, 1fr) auto; gap: 12px; min-height: 88px; }
   .settings-row p { font-size: 13px; }

--- a/web/app.js
+++ b/web/app.js
@@ -1,4 +1,5 @@
-import { BrowserPairing } from './pairing.js?v=4'
+import { ConversationsClient } from './conversations.js?v=7'
+import { BrowserPairing } from './pairing.js?v=7'
 
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')
@@ -22,11 +23,27 @@ const deviceName = document.querySelector('#device-name')
 const sidebarDeviceState = document.querySelector('#sidebar-device-state')
 const chatStateTitle = document.querySelector('#chat-state-title')
 const chatStateDetail = document.querySelector('#chat-state-detail')
+const conversationEmpty = document.querySelector('#conversation-empty')
+const conversationListItems = document.querySelector('#conversation-list-items')
+const messageList = document.querySelector('#message-list')
+const messageForm = document.querySelector('#message-form')
 const messageInput = document.querySelector('#message-input')
+const sendButton = document.querySelector('#send-button')
+const newConversationButton = document.querySelector('#new-conversation-button')
+const emptyNewConversationButton = document.querySelector('#empty-new-conversation-button')
+const mobileConversationSelect = document.querySelector('#mobile-conversation-select')
+const chatTitle = document.querySelector('#chat-title')
+const chatFreshness = document.querySelector('#chat-freshness')
+const conversationNotice = document.querySelector('#conversation-notice')
+const activityFreshness = document.querySelector('#activity-freshness')
+const activityEmpty = document.querySelector('#activity-empty')
+const activityList = document.querySelector('#activity-list')
+const syncValue = document.querySelector('#sync-value')
 let installPrompt
 let probeInProgress = false
 let pairingPhase = 'loading'
 let pairingExpiresAt
+let conversationsClient
 
 function updateDeviceSummary() {
   const connected = pairingPhase === 'paired'
@@ -99,10 +116,136 @@ function handlePairingState(state) {
     messageInput.placeholder = '配对后即可发送消息'
   }
   updateDeviceSummary()
+  if (conversationsClient !== undefined) {
+    if (state.phase === 'paired') {
+      conversationsClient.setOnline(navigator.onLine)
+      void conversationsClient.start()
+    } else if (state.phase === 'paired-offline') {
+      conversationsClient.setOnline(false)
+      void conversationsClient.start()
+    } else {
+      conversationsClient.stop(state.phase)
+    }
+  }
 }
 
 const pairing = new BrowserPairing(handlePairingState)
+conversationsClient = new ConversationsClient(pairing, handleConversationState)
 handlePairingState({ phase: 'loading' })
+
+function formatDate(value, includeDate = false) {
+  return new Intl.DateTimeFormat('zh-CN', includeDate
+    ? { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' }
+    : { hour: '2-digit', minute: '2-digit' }).format(new Date(value))
+}
+
+function conversationLabel(conversation) {
+  return conversation.title?.trim() || (conversation.blank ? '新对话' : '未命名对话')
+}
+
+function handleConversationState(state) {
+  const current = state.conversations.find(item => item.id === state.selectedId)
+  const mutable = state.phase === 'ready' && pairingPhase === 'paired' && navigator.onLine
+  const freshness = state.phase === 'ready'
+    ? '实时'
+    : state.phase === 'sending' || state.phase === 'refreshing' || state.phase === 'loading'
+      ? '同步中'
+      : state.phase === 'stale'
+        ? '旧数据'
+        : '不可用'
+  chatFreshness.textContent = freshness
+  activityFreshness.textContent = freshness
+  syncValue.textContent = freshness
+  syncValue.className = `value-label ${state.phase === 'ready' ? '' : 'is-warning'}`
+  if (state.cachedAt !== undefined) lastCheck.textContent = `最近同步：${formatDate(state.cachedAt, true)}`
+
+  conversationListItems.replaceChildren()
+  for (const conversation of state.conversations) {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = `conversation-item ${conversation.id === state.selectedId ? 'is-active' : ''}`
+    button.dataset.conversationId = conversation.id
+    const title = document.createElement('strong')
+    title.textContent = conversationLabel(conversation)
+    const running = document.createElement('span')
+    running.className = 'conversation-running'
+    running.textContent = conversation.running ? '回复中' : ''
+    const timestamp = document.createElement('small')
+    timestamp.textContent = formatDate(conversation.updatedAt, true)
+    button.append(title, running, timestamp)
+    conversationListItems.append(button)
+  }
+  if (state.conversations.length === 0) {
+    const empty = document.createElement('p')
+    empty.className = 'empty-list'
+    empty.textContent = pairingPhase === 'paired' ? '暂无对话' : '配对后显示对话'
+    conversationListItems.append(empty)
+  }
+
+  mobileConversationSelect.replaceChildren()
+  if (state.conversations.length === 0) {
+    const option = document.createElement('option')
+    option.textContent = '无对话'
+    mobileConversationSelect.append(option)
+  } else {
+    for (const conversation of state.conversations) {
+      const option = document.createElement('option')
+      option.value = conversation.id
+      option.textContent = conversationLabel(conversation)
+      option.selected = conversation.id === state.selectedId
+      mobileConversationSelect.append(option)
+    }
+  }
+  mobileConversationSelect.disabled = !mutable || state.conversations.length === 0
+  newConversationButton.disabled = !mutable || state.sending
+  emptyNewConversationButton.disabled = !mutable || state.sending
+
+  chatTitle.textContent = current === undefined ? '对话' : conversationLabel(current)
+  messageList.replaceChildren()
+  for (const message of state.messages) {
+    const item = document.createElement('li')
+    item.className = `message is-${message.role}`
+    const body = document.createElement('p')
+    body.className = 'message-body'
+    body.textContent = message.text
+    const meta = document.createElement('span')
+    meta.className = 'message-meta'
+    meta.textContent = `${message.role === 'assistant' ? 'Jarvis' : '你'} · ${formatDate(message.createdAt)}`
+    item.append(body, meta)
+    messageList.append(item)
+  }
+  messageList.hidden = state.messages.length === 0
+  conversationEmpty.hidden = state.messages.length > 0
+  document.querySelector('#open-settings-button').hidden = pairingPhase === 'paired'
+  emptyNewConversationButton.hidden = pairingPhase !== 'paired' || current !== undefined
+  if (pairingPhase === 'paired') {
+    chatStateTitle.textContent = current === undefined ? '开始一段对话' : '暂无消息'
+    chatStateDetail.textContent = current === undefined
+      ? '新建对话后即可向 Jarvis 发送文字。'
+      : '输入第一条消息，Jarvis 的回复会实时显示。'
+  }
+  conversationNotice.hidden = state.message === undefined && state.phase !== 'stale'
+  conversationNotice.textContent = state.message ?? (state.phase === 'stale' ? '当前显示上次同步的数据，发送功能已停用。' : '')
+  messageInput.disabled = !mutable || current === undefined || state.sending
+  sendButton.disabled = messageInput.disabled || messageInput.value.trim().length === 0
+  messageInput.placeholder = current === undefined ? '先新建或选择对话' : state.sending ? '正在发送' : '输入消息'
+
+  activityList.replaceChildren()
+  for (const activity of state.activity) {
+    const item = document.createElement('li')
+    item.className = 'activity-item'
+    const label = document.createElement('span')
+    label.textContent = activity.label
+    const time = document.createElement('time')
+    time.dateTime = new Date(activity.occurredAt).toISOString()
+    time.textContent = formatDate(activity.occurredAt)
+    item.append(label, time)
+    activityList.append(item)
+  }
+  activityEmpty.hidden = state.activity.length > 0
+  activityList.hidden = state.activity.length === 0
+  if (state.messages.length > 0) queueMicrotask(() => { messageList.scrollTop = messageList.scrollHeight })
+}
 
 async function probeGateway() {
   if (probeInProgress) return
@@ -124,7 +267,10 @@ async function probeGateway() {
     const health = await response.json()
     if (!response.ok || health.service !== 'jarvis-gateway' || health.status !== 'ok') throw new Error('invalid gateway response')
     setConnection('online', '网关可用', `安全范围：${health.scope === 'loopback-only' ? '仅本机' : '私有网络'}`)
-    lastCheck.textContent = `网关检查于 ${new Intl.DateTimeFormat('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' }).format(new Date())} 完成；账户数据仍不可用`
+    if (pairingPhase === 'paired-offline') void pairing.accessSession(true).catch(() => {})
+    if (pairingPhase !== 'paired') {
+      lastCheck.textContent = `网关检查于 ${new Intl.DateTimeFormat('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' }).format(new Date())} 完成；配对后同步数据`
+    }
   } catch {
     setConnection('unavailable', '无法连接', 'Jarvis Gateway 暂时不可用')
   } finally {
@@ -161,11 +307,50 @@ pairButton.addEventListener('click', async () => {
   }
 })
 cancelPairingButton.addEventListener('click', () => { void pairing.cancel() })
-refreshButton.addEventListener('click', () => { void probeGateway() })
-window.addEventListener('online', () => { void probeGateway() })
-window.addEventListener('offline', () => setConnection('offline', '离线', '设备当前没有网络连接'))
+conversationListItems.addEventListener('click', event => {
+  const button = event.target instanceof Element ? event.target.closest('[data-conversation-id]') : null
+  if (button !== null) void conversationsClient.select(button.dataset.conversationId)
+})
+mobileConversationSelect.addEventListener('change', () => { void conversationsClient.select(mobileConversationSelect.value) })
+newConversationButton.addEventListener('click', () => { void conversationsClient.create() })
+emptyNewConversationButton.addEventListener('click', () => { void conversationsClient.create() })
+messageInput.addEventListener('input', () => {
+  sendButton.disabled = messageInput.disabled || messageInput.value.trim().length === 0
+  messageInput.style.height = 'auto'
+  messageInput.style.height = `${Math.min(messageInput.scrollHeight, 120)}px`
+})
+messageInput.addEventListener('keydown', event => {
+  if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+    event.preventDefault()
+    messageForm.requestSubmit()
+  }
+})
+messageForm.addEventListener('submit', async event => {
+  event.preventDefault()
+  const text = messageInput.value
+  if (await conversationsClient.send(text)) {
+    messageInput.value = ''
+    messageInput.style.height = 'auto'
+    sendButton.disabled = true
+  }
+})
+refreshButton.addEventListener('click', () => {
+  void probeGateway()
+  void conversationsClient.refresh()
+})
+window.addEventListener('online', () => {
+  conversationsClient.setOnline(true)
+  void probeGateway()
+})
+window.addEventListener('offline', () => {
+  conversationsClient.setOnline(false)
+  setConnection('offline', '离线', '设备当前没有网络连接')
+})
 document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') void probeGateway()
+  if (document.visibilityState === 'visible') {
+    void probeGateway()
+    void conversationsClient.refresh()
+  }
 })
 
 window.addEventListener('beforeinstallprompt', event => {

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -1,0 +1,425 @@
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=7'
+
+const CACHE_KEY = 'conversation-cache'
+const CURSOR_KEY = 'event-cursor'
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+const CURSOR_PATTERN = /^[A-Za-z0-9_-]{22}\.[0-9]+$/
+const MAX_MESSAGES = 50
+const MAX_ACTIVITY = 30
+const MAX_EVENT_CHARS = 64 * 1024
+
+function validSummary(value) {
+  return value !== null && typeof value === 'object' && ID_PATTERN.test(value.id)
+    && (value.title === null || typeof value.title === 'string')
+    && Number.isFinite(value.updatedAt) && typeof value.running === 'boolean' && typeof value.blank === 'boolean'
+}
+
+function validMessage(value) {
+  return value !== null && typeof value === 'object' && typeof value.id === 'string' && value.id.length > 0
+    && Number.isSafeInteger(value.sequence) && value.sequence >= 0 && Number.isFinite(value.createdAt)
+    && (value.role === 'user' || value.role === 'assistant') && typeof value.text === 'string' && value.text.length > 0
+}
+
+function parseConversationList(value) {
+  if (!Array.isArray(value?.conversations) || !value.conversations.every(validSummary)) {
+    throw new Error('Gateway 返回了无效对话列表')
+  }
+  return value.conversations.slice().sort((left, right) => right.updatedAt - left.updatedAt)
+}
+
+function parseHistory(value) {
+  if (!Array.isArray(value?.messages) || !value.messages.every(validMessage)
+    || typeof value.hasMore !== 'boolean'
+    || (value.nextBeforeSequence !== null && (!Number.isSafeInteger(value.nextBeforeSequence) || value.nextBeforeSequence < 0))) {
+    throw new Error('Gateway 返回了无效对话记录')
+  }
+  const messages = value.messages.slice().sort((left, right) => left.sequence - right.sequence)
+  if (new Set(messages.map(message => message.id)).size !== messages.length) {
+    throw new Error('Gateway 返回了重复消息')
+  }
+  return { messages, hasMore: value.hasMore }
+}
+
+function parseCache(value) {
+  if (value?.version !== 1 || !Array.isArray(value.conversations) || !value.conversations.every(validSummary)
+    || (value.selectedId !== null && !ID_PATTERN.test(value.selectedId))
+    || !Array.isArray(value.messages) || !value.messages.every(validMessage) || !Number.isFinite(value.cachedAt)) return undefined
+  if (new Set(value.conversations.map(item => item.id)).size !== value.conversations.length
+    || new Set(value.messages.map(item => item.id)).size !== value.messages.length) return undefined
+  const selectedId = value.selectedId !== null && value.conversations.some(item => item.id === value.selectedId)
+    ? value.selectedId
+    : null
+  return {
+    conversations: value.conversations.slice(0, 100),
+    selectedId,
+    messages: selectedId === null ? [] : value.messages.slice(-MAX_MESSAGES),
+    cachedAt: value.cachedAt,
+  }
+}
+
+function messageForError(error, fallback) {
+  return error instanceof Error ? error.message : fallback
+}
+
+function eventDescription(event) {
+  if (event.type === 'conversation.created') return '新对话已创建'
+  if (event.type === 'conversation.removed') return '对话已移除'
+  if (event.type === 'conversation.status') return event.running ? 'Jarvis 正在回复' : 'Jarvis 已完成回复'
+  if (event.type === 'conversation.message.committed') return event.message.role === 'assistant' ? '收到 Jarvis 回复' : '消息已提交'
+  if (event.type === 'conversation.error') return '对话执行失败'
+  return '正在重新同步对话'
+}
+
+export class ConversationsClient {
+  constructor(pairing, onState, options = {}) {
+    this.pairing = pairing
+    this.onState = onState
+    this.socketFactory = options.socketFactory ?? (url => new WebSocket(url))
+    this.locationValue = options.location ?? window.location
+    this.setTimeoutValue = options.setTimeout ?? ((callback, delay) => window.setTimeout(callback, delay))
+    this.clearTimeoutValue = options.clearTimeout ?? (timer => window.clearTimeout(timer))
+    this.store = options.store ?? {
+      read: readDeviceState,
+      write: writeDeviceState,
+      delete: deleteDeviceState,
+    }
+    this.active = false
+    this.online = true
+    this.loading = false
+    this.sending = false
+    this.conversations = []
+    this.selectedId = null
+    this.messages = []
+    this.activity = []
+    this.cachedAt = undefined
+    this.socket = undefined
+    this.reconnectTimer = undefined
+    this.forceRenewSession = false
+  }
+
+  async start() {
+    if (this.active) return
+    this.active = true
+    let cached
+    try {
+      cached = parseCache(await this.store.read(CACHE_KEY))
+    } catch (error) {
+      this.active = false
+      this.emit('error', messageForError(error, '无法读取本地对话快照'))
+      return
+    }
+    if (cached !== undefined) {
+      this.conversations = cached.conversations
+      this.selectedId = cached.selectedId
+      this.messages = cached.messages
+      this.cachedAt = cached.cachedAt
+      this.emit('stale')
+    } else {
+      this.emit('loading')
+    }
+    if (!this.online) return
+    await this.refresh()
+    if (this.active) void this.connectEvents()
+  }
+
+  stop(reason = 'disabled') {
+    this.active = false
+    this.loading = false
+    this.sending = false
+    this.clearReconnect()
+    if (this.socket !== undefined) {
+      const socket = this.socket
+      this.socket = undefined
+      socket.close(1000, 'client suspended')
+    }
+    this.emit(this.conversations.length > 0 ? 'stale' : reason)
+  }
+
+  setOnline(online) {
+    this.online = online
+    if (!online) {
+      this.clearReconnect()
+      if (this.socket !== undefined) {
+        const socket = this.socket
+        this.socket = undefined
+        socket.close(1000, 'offline')
+      }
+      if (this.active) this.emit('stale')
+      return
+    }
+    if (this.active) {
+      void this.refresh().then(() => this.connectEvents())
+    }
+  }
+
+  async refresh() {
+    if (!this.active || !this.online || this.loading) return false
+    this.loading = true
+    this.emit(this.conversations.length > 0 ? 'refreshing' : 'loading')
+    try {
+      const response = await this.pairing.authenticatedRequest('/v1/conversations')
+      if (!response.ok) throw new Error(`无法读取对话 (${response.status})`)
+      this.conversations = parseConversationList(response.value)
+      if (this.selectedId === null || !this.conversations.some(item => item.id === this.selectedId)) {
+        this.selectedId = this.conversations[0]?.id ?? null
+      }
+      await this.loadSelected()
+      this.cachedAt = Date.now()
+      await this.persistCache()
+      this.emit('ready')
+      return true
+    } catch (error) {
+      this.addActivity('同步失败')
+      this.emit(this.conversations.length > 0 ? 'stale' : 'error', messageForError(error, '无法同步对话'))
+      return false
+    } finally {
+      this.loading = false
+    }
+  }
+
+  async select(conversationId) {
+    if (!ID_PATTERN.test(conversationId) || !this.conversations.some(item => item.id === conversationId)) return
+    this.selectedId = conversationId
+    this.messages = []
+    this.emit(this.online ? 'loading' : 'stale')
+    if (!this.online) return
+    try {
+      await this.loadSelected()
+      this.cachedAt = Date.now()
+      await this.persistCache()
+      this.emit('ready')
+    } catch (error) {
+      this.emit(this.conversations.length > 0 ? 'ready' : 'error', messageForError(error, '无法打开对话'))
+    }
+  }
+
+  async create() {
+    if (!this.active || !this.online || this.sending) return false
+    this.sending = true
+    this.emit('refreshing')
+    let errorMessage
+    try {
+      const response = await this.pairing.authenticatedRequest('/v1/conversations', { method: 'POST', body: '{}' })
+      if (response.status !== 201 || !ID_PATTERN.test(response.value?.conversation?.id)) {
+        throw new Error(`无法新建对话 (${response.status})`)
+      }
+      const id = response.value.conversation.id
+      this.selectedId = id
+      this.messages = []
+      await this.refresh()
+      if (!this.conversations.some(item => item.id === id)) {
+        this.conversations.unshift({ id, title: null, updatedAt: Date.now(), running: false, blank: true })
+      }
+      this.selectedId = id
+      await this.persistCache()
+      this.addActivity('新对话已创建')
+    } catch (error) {
+      errorMessage = messageForError(error, '无法新建对话')
+    } finally {
+      this.sending = false
+    }
+    const phase = !this.active || !this.online
+      ? this.conversations.length > 0 ? 'stale' : 'disabled'
+      : this.conversations.length > 0 || errorMessage === undefined ? 'ready' : 'error'
+    this.emit(phase, errorMessage)
+    return errorMessage === undefined
+  }
+
+  async send(text) {
+    if (!this.active || !this.online || this.sending || this.selectedId === null) return false
+    const bytes = new TextEncoder().encode(text).byteLength
+    if (text.trim().length === 0 || bytes > 16 * 1024 || text.includes('\0') || text.trimStart().startsWith('/')) {
+      this.emit('ready', '消息应为 1 至 16384 字节的普通文本，且不能是斜杠命令')
+      return false
+    }
+    this.sending = true
+    this.emit('sending')
+    let errorMessage
+    try {
+      const response = await this.pairing.authenticatedRequest(`/v1/conversations/${encodeURIComponent(this.selectedId)}/messages`, {
+        method: 'POST', body: JSON.stringify({ text, mode: 'queue' }),
+      })
+      if (response.status !== 202 || response.value?.accepted !== true) throw new Error(`消息未被接受 (${response.status})`)
+      this.addActivity('消息已发送')
+      await this.loadSelected()
+      this.cachedAt = Date.now()
+      await this.persistCache()
+    } catch (error) {
+      errorMessage = messageForError(error, '消息发送失败')
+    } finally {
+      this.sending = false
+    }
+    this.emit(this.active && this.online ? 'ready' : this.conversations.length > 0 ? 'stale' : 'disabled', errorMessage)
+    return errorMessage === undefined
+  }
+
+  async loadSelected() {
+    if (this.selectedId === null) {
+      this.messages = []
+      return
+    }
+    const response = await this.pairing.authenticatedRequest(
+      `/v1/conversations/${encodeURIComponent(this.selectedId)}?maxMessages=${MAX_MESSAGES}`,
+    )
+    if (!response.ok) throw new Error(`无法读取对话记录 (${response.status})`)
+    this.messages = parseHistory(response.value).messages
+  }
+
+  async connectEvents() {
+    if (!this.active || !this.online || this.socket !== undefined) return
+    let session
+    try {
+      session = await this.pairing.accessSession(this.forceRenewSession)
+      this.forceRenewSession = false
+    } catch {
+      this.scheduleReconnect()
+      return
+    }
+    if (!this.active || !this.online || this.socket !== undefined) return
+    const url = new URL('/v1/events', this.locationValue.origin)
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    let socket
+    try {
+      socket = this.socketFactory(url.toString())
+    } catch {
+      this.scheduleReconnect()
+      return
+    }
+    this.socket = socket
+    socket.addEventListener('open', async () => {
+      if (this.socket !== socket) return
+      try {
+        const cursor = await this.store.read(CURSOR_KEY)
+        socket.send(JSON.stringify({
+          type: 'events.authenticate', accessToken: session.accessToken,
+          ...(typeof cursor === 'string' && CURSOR_PATTERN.test(cursor) ? { cursor } : {}),
+        }))
+      } catch {
+        socket.close(1011, 'event cursor unavailable')
+      }
+    })
+    socket.addEventListener('message', event => {
+      void this.handleEvent(socket, event.data).catch(() => socket.close(1011, 'event processing failed'))
+    })
+    socket.addEventListener('close', () => {
+      if (this.socket !== socket) return
+      this.socket = undefined
+      this.scheduleReconnect()
+    })
+    socket.addEventListener('error', () => socket.close())
+  }
+
+  async handleEvent(socket, data) {
+    if (this.socket !== socket || typeof data !== 'string' || data.length > MAX_EVENT_CHARS) {
+      socket.close(1002, 'invalid event')
+      return
+    }
+    let event
+    try {
+      event = JSON.parse(data)
+    } catch {
+      socket.close(1002, 'invalid event')
+      return
+    }
+    if (event?.type === 'events.rejected') {
+      this.forceRenewSession = event.code === 'authentication_rejected' || event.code === 'session_invalid'
+        || event.code === 'session_expired' || event.code === 'device_revoked'
+      this.emit('stale', '实时连接认证已失效')
+      socket.close(1008, 'event authentication ended')
+      return
+    }
+    if (event?.type === 'events.ready') {
+      if (typeof event.cursor !== 'string' || !CURSOR_PATTERN.test(event.cursor) || typeof event.requiresSnapshot !== 'boolean') {
+        socket.close(1002, 'invalid ready event')
+        return
+      }
+      if (event.requiresSnapshot && !await this.refresh()) {
+        socket.close(1011, 'snapshot unavailable')
+        return
+      }
+      await this.store.write(CURSOR_KEY, event.cursor)
+      return
+    }
+    if (event?.version !== 1 || typeof event.cursor !== 'string' || !CURSOR_PATTERN.test(event.cursor)
+      || typeof event.type !== 'string' || !Number.isFinite(event.occurredAt)) {
+      socket.close(1002, 'invalid event')
+      return
+    }
+    let eventNotice
+    if (event.type === 'sync.required') {
+      this.emit('stale')
+      if (!await this.refresh()) return
+    } else if (event.type === 'conversation.created' || event.type === 'conversation.removed') {
+      if (!await this.refresh()) return
+    } else if (event.type === 'conversation.status' && ID_PATTERN.test(event.conversationId)
+      && typeof event.running === 'boolean') {
+      this.conversations = this.conversations.map(item => item.id === event.conversationId
+        ? { ...item, running: event.running, updatedAt: event.occurredAt }
+        : item).sort((left, right) => right.updatedAt - left.updatedAt)
+    } else if (event.type === 'conversation.message.committed' && ID_PATTERN.test(event.conversationId)
+      && validMessage(event.message)) {
+      this.conversations = this.conversations.map(item => item.id === event.conversationId
+        ? { ...item, blank: false, updatedAt: event.occurredAt }
+        : item).sort((left, right) => right.updatedAt - left.updatedAt)
+      if (event.conversationId === this.selectedId && !this.messages.some(message => message.id === event.message.id)) {
+        this.messages = [...this.messages, event.message].sort((left, right) => left.sequence - right.sequence).slice(-MAX_MESSAGES)
+      }
+    } else if (event.type === 'conversation.error' && ID_PATTERN.test(event.conversationId)) {
+      eventNotice = 'Jarvis 未能完成本次回复'
+    } else {
+      socket.close(1002, 'unsupported event')
+      return
+    }
+    this.addActivity(eventDescription(event))
+    this.cachedAt = Date.now()
+    await this.persistCache()
+    await this.store.write(CURSOR_KEY, event.cursor)
+    if (socket.readyState === 1) socket.send(JSON.stringify({ type: 'events.ack', cursor: event.cursor }))
+    this.emit('ready', eventNotice)
+  }
+
+  async persistCache() {
+    await this.store.write(CACHE_KEY, {
+      version: 1,
+      conversations: this.conversations.slice(0, 100),
+      selectedId: this.selectedId,
+      messages: this.messages.slice(-MAX_MESSAGES),
+      cachedAt: this.cachedAt ?? Date.now(),
+    })
+  }
+
+  async clearCache() {
+    await this.store.delete(CACHE_KEY)
+    await this.store.delete(CURSOR_KEY)
+  }
+
+  addActivity(label) {
+    this.activity = [{ label, occurredAt: Date.now() }, ...this.activity].slice(0, MAX_ACTIVITY)
+  }
+
+  scheduleReconnect() {
+    if (!this.active || !this.online || this.reconnectTimer !== undefined) return
+    this.reconnectTimer = this.setTimeoutValue(() => {
+      this.reconnectTimer = undefined
+      void this.connectEvents()
+    }, 2_000)
+  }
+
+  clearReconnect() {
+    if (this.reconnectTimer !== undefined) this.clearTimeoutValue(this.reconnectTimer)
+    this.reconnectTimer = undefined
+  }
+
+  emit(phase, message) {
+    this.onState({
+      phase,
+      conversations: this.conversations.map(item => ({ ...item })),
+      selectedId: this.selectedId,
+      messages: this.messages.map(item => ({ ...item })),
+      activity: this.activity.map(item => ({ ...item })),
+      cachedAt: this.cachedAt,
+      sending: this.sending,
+      ...(message === undefined ? {} : { message }),
+    })
+  }
+}

--- a/web/device-store.js
+++ b/web/device-store.js
@@ -1,0 +1,53 @@
+const DATABASE_NAME = 'jarvis-device-v1'
+const STORE_NAME = 'private-state'
+
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, 1)
+    request.onupgradeneeded = () => request.result.createObjectStore(STORE_NAME)
+    request.onerror = () => reject(new Error('device storage is unavailable'))
+    request.onsuccess = () => resolve(request.result)
+  })
+}
+
+export async function readDeviceState(key) {
+  const database = await openDatabase()
+  try {
+    return await new Promise((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, 'readonly')
+      const request = transaction.objectStore(STORE_NAME).get(key)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(new Error('device storage could not be read'))
+    })
+  } finally {
+    database.close()
+  }
+}
+
+export async function writeDeviceState(key, value) {
+  const database = await openDatabase()
+  try {
+    await new Promise((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, 'readwrite')
+      transaction.objectStore(STORE_NAME).put(value, key)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(new Error('device storage could not be written'))
+    })
+  } finally {
+    database.close()
+  }
+}
+
+export async function deleteDeviceState(key) {
+  const database = await openDatabase()
+  try {
+    await new Promise((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, 'readwrite')
+      transaction.objectStore(STORE_NAME).delete(key)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(new Error('device storage could not be updated'))
+    })
+  } finally {
+    database.close()
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js?v=4" type="module"></script>
+    <script src="./app.js?v=7" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>
@@ -46,9 +46,11 @@
         <div class="conversation-list">
           <div class="section-heading">
             <span>最近对话</span>
-            <button class="icon-button" type="button" aria-label="新建对话" title="新建对话" disabled>＋</button>
+            <button id="new-conversation-button" class="icon-button" type="button" aria-label="新建对话" title="新建对话" disabled>＋</button>
           </div>
-          <p class="empty-list">配对后显示对话</p>
+          <div id="conversation-list-items" class="conversation-list-items">
+            <p class="empty-list">配对后显示对话</p>
+          </div>
         </div>
         <div class="sidebar-footer">
           <span id="sidebar-device-state" class="freshness-label">未配对</span>
@@ -63,17 +65,25 @@
               <p class="eyebrow">移动工作区</p>
               <h1 id="chat-title">新对话</h1>
             </div>
-            <span id="chat-freshness" class="freshness-label">未同步</span>
+            <div class="chat-header-actions">
+              <select id="mobile-conversation-select" aria-label="选择对话" disabled>
+                <option>无对话</option>
+              </select>
+              <span id="chat-freshness" class="freshness-label">未同步</span>
+            </div>
           </header>
-          <div class="conversation-empty">
+          <div id="conversation-empty" class="conversation-empty">
             <div class="empty-symbol" aria-hidden="true">J</div>
             <h2 id="chat-state-title">连接到 Jarvis</h2>
             <p id="chat-state-detail">此设备完成配对后，对话会安全地显示在这里。</p>
             <button id="open-settings-button" class="primary-button" type="button">查看连接状态</button>
+            <button id="empty-new-conversation-button" class="primary-button" type="button" hidden>新建对话</button>
           </div>
-          <form class="composer" aria-label="消息输入">
+          <ol id="message-list" class="message-list" aria-live="polite" hidden></ol>
+          <p id="conversation-notice" class="conversation-notice" role="status" aria-live="polite" hidden></p>
+          <form id="message-form" class="composer" aria-label="消息输入">
             <textarea id="message-input" rows="1" placeholder="配对后即可发送消息" aria-label="消息" disabled></textarea>
-            <button class="send-button" type="submit" aria-label="发送消息" title="发送消息" disabled>↑</button>
+            <button id="send-button" class="send-button" type="submit" aria-label="发送消息" title="发送消息" disabled>↑</button>
           </form>
         </section>
 
@@ -83,12 +93,13 @@
               <p class="eyebrow">事件流</p>
               <h1 id="activity-title">动态</h1>
             </div>
-            <span class="freshness-label">未同步</span>
+            <span id="activity-freshness" class="freshness-label">未同步</span>
           </header>
-          <div class="plain-empty">
+          <div id="activity-empty" class="plain-empty">
             <h2>暂无动态</h2>
             <p>连接恢复后，新事件会出现在这里。</p>
           </div>
+          <ol id="activity-list" class="activity-list" hidden></ol>
         </section>
 
         <section class="view-panel" data-view-panel="settings" aria-labelledby="settings-title" hidden>
@@ -137,7 +148,7 @@
                 <h2 id="sync-heading">数据状态</h2>
                 <p id="last-check">尚未成功连接</p>
               </div>
-              <span class="value-label is-warning">不可用</span>
+              <span id="sync-value" class="value-label is-warning">不可用</span>
             </section>
             <section class="settings-row" aria-labelledby="install-heading">
               <div>

--- a/web/pairing.js
+++ b/web/pairing.js
@@ -1,59 +1,8 @@
-const DATABASE_NAME = 'jarvis-device-v1'
-const STORE_NAME = 'private-state'
-const MAX_RESPONSE_CHARS = 32 * 1024
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=7'
+
+const MAX_RESPONSE_CHARS = 2 * 1024 * 1024
 
 class GatewayUnavailableError extends Error {}
-
-function openDatabase() {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DATABASE_NAME, 1)
-    request.onupgradeneeded = () => request.result.createObjectStore(STORE_NAME)
-    request.onerror = () => reject(new Error('device storage is unavailable'))
-    request.onsuccess = () => resolve(request.result)
-  })
-}
-
-async function readState(key) {
-  const database = await openDatabase()
-  try {
-    return await new Promise((resolve, reject) => {
-      const transaction = database.transaction(STORE_NAME, 'readonly')
-      const request = transaction.objectStore(STORE_NAME).get(key)
-      request.onsuccess = () => resolve(request.result)
-      request.onerror = () => reject(new Error('device storage could not be read'))
-    })
-  } finally {
-    database.close()
-  }
-}
-
-async function writeState(key, value) {
-  const database = await openDatabase()
-  try {
-    await new Promise((resolve, reject) => {
-      const transaction = database.transaction(STORE_NAME, 'readwrite')
-      transaction.objectStore(STORE_NAME).put(value, key)
-      transaction.oncomplete = () => resolve()
-      transaction.onerror = () => reject(new Error('device storage could not be written'))
-    })
-  } finally {
-    database.close()
-  }
-}
-
-async function deleteState(key) {
-  const database = await openDatabase()
-  try {
-    await new Promise((resolve, reject) => {
-      const transaction = database.transaction(STORE_NAME, 'readwrite')
-      transaction.objectStore(STORE_NAME).delete(key)
-      transaction.oncomplete = () => resolve()
-      transaction.onerror = () => reject(new Error('device storage could not be updated'))
-    })
-  } finally {
-    database.close()
-  }
-}
 
 export function encodeBase64Url(value) {
   const bytes = value instanceof Uint8Array ? value : new Uint8Array(value)
@@ -137,9 +86,9 @@ export class BrowserPairing {
 
   async initializeState() {
     try {
-      const identity = await readState('identity')
-      const credential = await readState('credential')
-      const pending = await readState('pending')
+      const identity = await readDeviceState('identity')
+      const credential = await readDeviceState('credential')
+      const pending = await readDeviceState('pending')
       if (identity !== undefined && credential !== undefined) {
         await this.ensureSession(identity, credential)
         return
@@ -149,7 +98,7 @@ export class BrowserPairing {
         void this.poll(identity, pending)
         return
       }
-      if (pending !== undefined) await deleteState('pending')
+      if (pending !== undefined) await deleteDeviceState('pending')
       this.onState({ phase: 'unpaired' })
     } catch (error) {
       this.onState({ phase: 'error', message: error instanceof Error ? error.message : 'pairing initialization failed' })
@@ -164,13 +113,13 @@ export class BrowserPairing {
     }
     this.clearPoll()
     this.onState({ phase: 'starting' })
-    let identity = await readState('identity')
+    let identity = await readDeviceState('identity')
     if (identity === undefined) {
       identity = await createIdentity(normalizedName)
-      await writeState('identity', identity)
+      await writeDeviceState('identity', identity)
     } else if (identity.displayName !== normalizedName) {
       identity = { ...identity, displayName: normalizedName }
-      await writeState('identity', identity)
+      await writeDeviceState('identity', identity)
     }
     const response = await this.request('/v1/pairing/requests/browser', {
       method: 'POST',
@@ -195,14 +144,14 @@ export class BrowserPairing {
       expiresAt: challenge.expiresAt,
       displayName: normalizedName,
     }
-    await writeState('pending', pending)
+    await writeDeviceState('pending', pending)
     this.emitPending(pending)
     void this.poll(identity, pending)
   }
 
   async cancel() {
     this.clearPoll()
-    await deleteState('pending')
+    await deleteDeviceState('pending')
     this.onState({ phase: 'unpaired' })
   }
 
@@ -228,7 +177,7 @@ export class BrowserPairing {
 
   async poll(identity, pending) {
     if (pending.expiresAt <= Date.now()) {
-      await deleteState('pending')
+      await deleteDeviceState('pending')
       this.onState({ phase: 'expired' })
       return
     }
@@ -243,12 +192,12 @@ export class BrowserPairing {
         return
       }
       if (response.status === 410) {
-        await deleteState('pending')
+        await deleteDeviceState('pending')
         this.onState({ phase: 'expired' })
         return
       }
       if (!response.ok) {
-        await deleteState('pending')
+        await deleteDeviceState('pending')
         this.onState({ phase: 'error', message: `配对领取失败 (${response.status})` })
         return
       }
@@ -265,8 +214,8 @@ export class BrowserPairing {
         generation: claim.generation,
         issuedAt: claim.issuedAt,
       }
-      await writeState('credential', credential)
-      await deleteState('pending')
+      await writeDeviceState('credential', credential)
+      await deleteDeviceState('pending')
       await this.ensureSession(identity, credential)
     } catch (error) {
       if (error instanceof GatewayUnavailableError) {
@@ -274,21 +223,21 @@ export class BrowserPairing {
         this.schedulePoll(identity, pending, 5_000)
         return
       }
-      await deleteState('pending')
+      await deleteDeviceState('pending')
       this.onState({ phase: 'error', message: error instanceof Error ? error.message : '配对响应无效' })
     }
   }
 
   async ensureSession(identity, credential) {
     try {
-      const storedSession = await readState('session')
+      const storedSession = await readDeviceState('session')
       if (storedSession !== undefined && storedSession.accessExpiresAt > Date.now()) {
         const current = await this.request('/v1/sessions/current', {
           headers: { authorization: `Session ${storedSession.accessToken}` },
         })
         if (current.ok) {
           this.onState({ phase: 'paired', displayName: identity.displayName, nodeId: identity.nodeId })
-          return
+          return parseSession(storedSession, identity.nodeId)
         }
       }
       if (storedSession !== undefined && storedSession.refreshExpiresAt > Date.now()) {
@@ -297,9 +246,10 @@ export class BrowserPairing {
           body: JSON.stringify({ refreshToken: storedSession.refreshToken }),
         })
         if (refreshed.ok) {
-          await writeState('session', parseSession(refreshed.value, identity.nodeId))
+          const session = parseSession(refreshed.value, identity.nodeId)
+          await writeDeviceState('session', session)
           this.onState({ phase: 'paired', displayName: identity.displayName, nodeId: identity.nodeId })
-          return
+          return session
         }
       }
       const issued = await this.request('/v1/sessions', {
@@ -308,14 +258,16 @@ export class BrowserPairing {
         body: JSON.stringify({ nodeId: identity.nodeId }),
       })
       if (issued.status === 401) {
-        await deleteState('credential')
-        await deleteState('session')
+        await deleteDeviceState('credential')
+        await deleteDeviceState('session')
         this.onState({ phase: 'revoked' })
         return
       }
       if (!issued.ok) throw new Error(`Gateway 会话创建失败 (${issued.status})`)
-      await writeState('session', parseSession(issued.value, identity.nodeId))
+      const session = parseSession(issued.value, identity.nodeId)
+      await writeDeviceState('session', session)
       this.onState({ phase: 'paired', displayName: identity.displayName, nodeId: identity.nodeId })
+      return session
     } catch (error) {
       if (error instanceof GatewayUnavailableError) {
         this.onState({ phase: 'paired-offline', displayName: identity.displayName, nodeId: identity.nodeId })
@@ -328,6 +280,37 @@ export class BrowserPairing {
         message: error instanceof Error ? error.message : 'Gateway 会话响应无效',
       })
     }
+    return undefined
+  }
+
+  async accessSession(forceRenew = false) {
+    await this.initialize()
+    const identity = await readDeviceState('identity')
+    const credential = await readDeviceState('credential')
+    if (identity === undefined || credential === undefined) throw new Error('此设备尚未配对')
+    const storedSession = await readDeviceState('session')
+    if (!forceRenew && storedSession !== undefined && storedSession.accessExpiresAt > Date.now()) {
+      return parseSession(storedSession, identity.nodeId)
+    }
+    const session = await this.ensureSession(identity, credential)
+    if (session === undefined || session.accessExpiresAt <= Date.now()) throw new Error('Gateway 会话不可用')
+    return session
+  }
+
+  async authenticatedRequest(path, init = {}) {
+    let session = await this.accessSession()
+    let response = await this.request(path, {
+      ...init,
+      headers: { ...init.headers, authorization: `Session ${session.accessToken}` },
+    })
+    if (response.status !== 401) return response
+    await deleteDeviceState('session')
+    session = await this.accessSession(true)
+    response = await this.request(path, {
+      ...init,
+      headers: { ...init.headers, authorization: `Session ${session.accessToken}` },
+    })
+    return response
   }
 
   async request(path, init = {}) {

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,9 +1,11 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v4'
+const CACHE_NAME = 'jarvis-pwa-shell-v7'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js?v=4',
-  '/app/pairing.js?v=4',
+  '/app/app.js?v=7',
+  '/app/pairing.js?v=7',
+  '/app/device-store.js?v=7',
+  '/app/conversations.js?v=7',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',


### PR DESCRIPTION
## Summary
- add authenticated conversation list, creation, selection, history, and text submission to the paired PWA
- add same-origin IndexedDB snapshots with explicit stale, offline, loading, sending, and error states
- authenticate `/v1/events` in the first WebSocket frame, persist bounded cursors, and require authoritative refresh before advancing after replay gaps
- keep Session tokens inside the browser client module and out of URLs and rendered DOM
- add responsive desktop/mobile conversation and activity views

## Verification
- `npm run verify` (109/109)
- `npm run verify:runtime`
- real browser pairing and authenticated Harness conversation list/history
- reload, Gateway-offline stale snapshot, and no-reload recovery to live state
- responsive checks at 320x700, 390x844, and 1280x800 with no horizontal overflow
- final browser console: no warnings or errors
- changed-file credential scan and `git diff --check`

Closes #46
Tracks #16