### PR TITLE
Add privacy-preserving PWA notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - Gateway 已从 `/app/` 提供响应式 PWA 外壳、安装清单和离线应用缓存；未配对时只显示真实连接状态，不缓存或伪装账户数据。真机安装仍待指定首台 iPhone 或 Android 后验收。
 - Gateway 已通过 Harness 的公开审批传输提供移动审批收件箱；只有带完整 `tool/call`、`approval/asked` 和 `approval/requested` 证据的 `jarvis_open_app` 可在 60 秒内远程允许一次，其他请求只能拒绝或取消本轮。
 - 配对后的 PWA 可读取 Gateway 认可的当前设备与会话状态，并可在设置中撤销自身设备凭据；撤销会关闭该设备全部会话与实时连接，并清除浏览器中的身份、令牌、对话快照和事件游标。
+- 配对后的 PWA 提供隐私优先的应用内通知中心；审批、对话完成和连接事件只生成固定摘要，支持分类开关、静默时段、每小时系统通知上限、已读/清空和显式系统通知授权。
 - 已提供离线一致性备份和原子恢复命令；运行租约阻止在 Harness 或 Gateway 活跃时复制状态，恢复前校验结构、权限和 SHA-256。
 
 ## 环境要求
@@ -97,6 +98,8 @@ Owner Token 只提交给 loopback Gateway，不进入手机。Gateway 只持久�
 短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages`、`POST /v1/conversations/:id/cancel`、`GET /v1/approvals`、`POST /v1/approvals/:id/decision` 以及 `GET/DELETE /v1/devices/current`。配对后的 PWA 可列出、新建、选择和继续文字对话，处理当前审批，并查看或撤销当前设备；设备状态响应只含名称、平台、凭据代次、配对时间和会话时限，不含公钥、凭据摘要或任何令牌。消息只接受最多 16 KiB 的纯文本，发送期间会锁定重复提交，远程 slash command 被拒绝。审批决定使用客户端幂等键，Gateway 将上游 `rpcId` 保留在 loopback 桥接层，手机只能提交 `allowed-once` 或 `rejected`；取消本轮沿用会话取消接口并由 Harness 产生 `cancelled`。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会先要求重新读取权威会话与审批快照，刷新失败时不会推进游标。
 
 PWA 只在同源 IndexedDB 保存最近一次规范化对话列表、当前最多 50 条文字消息和事件游标，不缓存审批、API 响应或 Owner Token。Gateway 不可达时，离线壳可只读显示对话快照并明确标记为“旧数据”，审批详情会从页面内存清除；所有新建、发送和审批操作保持禁用，恢复连接并重新验证 Session 后才切回实时状态。
+
+通知中心同样只保存最多 50 条固定摘要，不写入消息正文、审批参数、目标、令牌或 Harness 内部标识。系统通知不会自动请求权限；用户必须在设置中明确允许，静默时段和分类/频率限制只抑制系统弹出，不丢失应用内记录。后台 Web Push 和锁屏内容仍需在指定首台实体手机上完成可行性与隐私验收。
 
 Gateway 默认允许每个连接来源突发 60 次请求并每秒恢复 1 次额度；每个已认证 Owner、设备或 Session 可突发 120 次并每秒恢复 2 次额度。它只使用直接连接地址，不信任客户端提供的转发来源头；HTTP `429` 会返回 `Retry-After`、限额余量和 correlation ID。
 

--- a/docs/plan/04-stage-3-mobile-remote.md
+++ b/docs/plan/04-stage-3-mobile-remote.md
@@ -15,6 +15,7 @@ Allow the owner to converse with Jarvis, observe status, and approve actions fro
 - Background always-listening voice is explicitly outside this stage.
 
 The platform-independent increments tracked in [#42](https://github.com/gh503/jarvis/issues/42), [#44](https://github.com/gh503/jarvis/issues/44), [#46](https://github.com/gh503/jarvis/issues/46), [#48](https://github.com/gh503/jarvis/issues/48), and [#50](https://github.com/gh503/jarvis/issues/50) serve a scoped responsive PWA shell, owner-approved browser pairing, authenticated text conversations with cursor-based live synchronization, a Harness-backed approval inbox, and authoritative current-device status with self-revocation. The browser keeps an origin-bound private key, claims an encrypted device credential without receiving the Owner Token, and obtains a short-lived Gateway session. Approval allows require the exact live `jarvis_open_app` call, matching audit/request evidence, the existing normalized digest, and its original 60-second expiry; unsupported or replay-only requests cannot be remotely allowed. The upstream response uses the stable private `rpcId` through `POST /api/respond`, while the public Gateway API exposes only the normalized approval id. A self-revocation invalidates the device credential and all of its access sessions, closes active streams, and clears browser-private state without affecting other devices. Offline startup renders only a bounded normalized conversation snapshot marked stale, clears approval details from memory, and disables mutations. Physical installation remains unqualified until the owner names the first iPhone or Android device.
+The platform-independent increments tracked in [#42](https://github.com/gh503/jarvis/issues/42), [#44](https://github.com/gh503/jarvis/issues/44), [#46](https://github.com/gh503/jarvis/issues/46), [#48](https://github.com/gh503/jarvis/issues/48), [#50](https://github.com/gh503/jarvis/issues/50), and [#52](https://github.com/gh503/jarvis/issues/52) serve a scoped responsive PWA shell, owner-approved browser pairing, authenticated text conversations with cursor-based live synchronization, a Harness-backed approval inbox, authoritative current-device status with self-revocation, and a privacy-preserving in-app notification center. The browser keeps an origin-bound private key, claims an encrypted device credential without receiving the Owner Token, and obtains a short-lived Gateway session. Approval allows require the exact live `jarvis_open_app` call, matching audit/request evidence, the existing normalized digest, and its original 60-second expiry; unsupported or replay-only requests cannot be remotely allowed. The upstream response uses the stable private `rpcId` through `POST /api/respond`, while the public Gateway API exposes only the normalized approval id. A self-revocation invalidates the device credential and all of its access sessions, closes active streams, and clears browser-private state without affecting other devices. Offline startup renders only a bounded normalized conversation snapshot marked stale, clears approval details and notifications from memory, and disables mutations. Physical installation and background Web Push remain unqualified until the owner names the first iPhone or Android device.
 
 ## Modules
 
@@ -82,12 +83,16 @@ Acceptance:
 Deliver:
 
 - In-app notifications first.
+- Fixed redacted summaries for approval, conversation completion, and connection events.
+- Bounded notification history, category preferences, quiet hours, and per-category rate limits.
 - Web Push feasibility probe on the named phone platform.
 - Notification preferences, quiet hours, and per-category rate limits.
 - Redacted lock-screen content by default.
 
 Acceptance:
 
+- Default notification text contains no message, command, target, token, or Harness identifier.
+- Explicit permission is required before any system notification; suppressed system notifications remain in the in-app center.
 - Notification tap opens the exact current resource after authentication.
 - Revoked devices stop receiving pushes.
 - Sensitive command arguments are absent from default notification payloads.

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -20,6 +20,7 @@ const ASSET_DEFINITIONS = new Map<string, PwaAssetDefinition>([
   ['/app/pairing.js', { file: 'pairing.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/device-store.js', { file: 'device-store.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/conversations.js', { file: 'conversations.js', contentType: 'text/javascript; charset=utf-8' }],
+  ['/app/notifications.js', { file: 'notifications.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/manifest.webmanifest', { file: 'manifest.webmanifest', contentType: 'application/manifest+json; charset=utf-8' }],
   ['/app/sw.js', { file: 'sw.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/icon.svg', { file: 'icon.svg', contentType: 'image/svg+xml' }],

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -215,6 +215,11 @@ test('serves the exact PWA shell routes with restrictive browser headers', async
     assert.match(head.headers.get('content-type') ?? '', /^text\/css/)
     assert.equal(await head.text(), '')
 
+    const notifications = await request(gateway, '/app/notifications.js?v=11')
+    assert.equal(notifications.status, 200)
+    assert.match(notifications.headers.get('content-type') ?? '', /^text\/javascript/)
+    assert.match(await notifications.text(), /class NotificationCenter/)
+
     const icon = await request(gateway, '/app/icon-192.png')
     assert.equal(icon.status, 200)
     assert.equal(icon.headers.get('content-type'), 'image/png')

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import test from 'node:test'
 import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
 import { BrowserPairing, decryptPairingCredential } from '../web/pairing.js'
+import { NotificationCenter } from '../web/notifications.js'
 
 const webRoot = join(process.cwd(), 'web')
 
@@ -22,8 +23,8 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js?v=10', '/app/pairing.js?v=10', '/app/device-store.js?v=10',
-    '/app/conversations.js?v=10', '/app/apple-touch-icon.png', '/app/icon.svg',
+    '/app/', '/app/app.css', '/app/app.js?v=11', '/app/pairing.js?v=11', '/app/device-store.js?v=11',
+    '/app/conversations.js?v=11', '/app/notifications.js?v=11', '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {
     assert.ok(serviceWorker.includes(`'${path}'`), `${path} must be pre-cached`)
@@ -45,6 +46,7 @@ test('keeps the browser client on the public Gateway contract', async () => {
   const appSource = await readFile(join(webRoot, 'app.js'), 'utf8')
   const pairingSource = await readFile(join(webRoot, 'pairing.js'), 'utf8')
   const conversationsSource = await readFile(join(webRoot, 'conversations.js'), 'utf8')
+  const notificationsSource = await readFile(join(webRoot, 'notifications.js'), 'utf8')
   const deviceStoreSource = await readFile(join(webRoot, 'device-store.js'), 'utf8')
   const htmlSource = await readFile(join(webRoot, 'index.html'), 'utf8')
   assert.match(appSource, /fetch\('\.\.\/v1\/health'/)
@@ -54,6 +56,9 @@ test('keeps the browser client on the public Gateway contract', async () => {
   assert.match(conversationsSource, /events\.authenticate/)
   assert.match(conversationsSource, /authenticatedRequest\('\/v1\/conversations'/)
   assert.match(conversationsSource, /authenticatedRequest\('\/v1\/approvals'/)
+  assert.match(notificationsSource, /class NotificationCenter/)
+  assert.match(notificationsSource, /固定摘要|高风险操作/)
+  assert.doesNotMatch(notificationsSource, /arguments|message|rpcId|accessToken|refreshToken/)
   assert.match(htmlSource, /id="approval-list"/)
   assert.match(htmlSource, /id="disconnect-device-dialog"/)
   assert.match(htmlSource, /id="disconnect-device-button"[^>]+hidden disabled/)
@@ -112,7 +117,7 @@ function currentDevice(state) {
   }
 }
 
-function memoryDeviceStore(initial) {
+function memoryDeviceStore(initial = {}) {
   const values = new Map(Object.entries(initial))
   return {
     values,
@@ -188,4 +193,82 @@ test('rejects current-device responses containing private or unexpected fields',
   await pairing.initialize()
   assert.equal(states.at(-1).phase, 'paired-error')
   assert.match(states.at(-1).message, /invalid current device/)
+})
+
+test('creates redacted, deduplicated notifications from normalized events', async () => {
+  const store = memoryDeviceStore()
+  const states = []
+  const systemNotifications = []
+  const center = new NotificationCenter({
+    store,
+    onState: state => states.push(state),
+    permission: 'granted',
+    systemNotify: notification => systemNotifications.push(notification),
+    now: () => 1_700_000_000_000,
+  })
+  await center.initialize()
+  const event = {
+    version: 1, cursor: 'A'.repeat(22) + '.8', occurredAt: 1_700_000_000_000,
+    type: 'approval.pending',
+    approval: {
+      id: 'approval-1', conversationId: 'conversation-1', toolName: 'jarvis_open_app',
+      callId: 'call-1', risk: 'high', canAllow: true,
+    },
+    arguments: { application: 'Secret App', command: 'private argument' },
+  }
+  assert.equal(await center.ingestEvent(event), true)
+  assert.equal(await center.ingestEvent(event), false)
+  assert.equal(states.at(-1).unreadCount, 1)
+  assert.equal(systemNotifications.length, 1)
+  assert.equal(systemNotifications[0].body.includes('private argument'), false)
+  assert.equal(JSON.stringify(systemNotifications[0]).includes('Secret App'), false)
+  assert.deepEqual(systemNotifications[0].resource, { view: 'activity', approvalId: 'approval-1' })
+  const restarted = new NotificationCenter({ store, permission: 'default' })
+  await restarted.initialize()
+  assert.equal(restarted.history[0].id, 'approval:approval-1:pending')
+})
+
+test('quiet hours and rate limits suppress system presentation but retain history', async () => {
+  const store = memoryDeviceStore()
+  const systemNotifications = []
+  const center = new NotificationCenter({
+    store,
+    permission: 'granted',
+    systemNotify: notification => systemNotifications.push(notification),
+    now: () => Date.parse('2026-01-01T23:30:00+08:00'),
+  })
+  await center.initialize()
+  await center.updatePreferences({
+    quietHours: { enabled: true, start: '23:00', end: '07:00' },
+    rateLimits: { conversation: 1 },
+  })
+  const base = { version: 1, occurredAt: Date.parse('2026-01-01T23:30:00+08:00'), type: 'conversation.status', running: false }
+  await center.ingestEvent({ ...base, cursor: 'B'.repeat(22) + '.1', conversationId: 'conversation-1' })
+  assert.equal(systemNotifications.length, 0)
+  assert.equal(store.values.get('notification-history').length, 1)
+  await center.updatePreferences({ quietHours: { enabled: false } })
+  await center.ingestEvent({ ...base, cursor: 'B'.repeat(22) + '.2', conversationId: 'conversation-2' })
+  assert.equal(systemNotifications.length, 1)
+  await center.ingestEvent({ ...base, cursor: 'B'.repeat(22) + '.3', conversationId: 'conversation-3' })
+  assert.equal(systemNotifications.length, 1)
+})
+
+test('notification history is bounded, persisted, and cleared on revocation', async () => {
+  const store = memoryDeviceStore()
+  const center = new NotificationCenter({ store, permission: 'default' })
+  await center.initialize()
+  for (let index = 0; index < 60; index += 1) {
+    await center.ingestEvent({
+      version: 1, cursor: 'C'.repeat(22) + '.' + index, occurredAt: 1_700_000_000_000 + index,
+      type: 'sync.required',
+    })
+  }
+  assert.equal(center.history.length, 50)
+  assert.equal(store.values.get('notification-history').length, 50)
+  await center.markAllRead()
+  assert.equal(center.history.every(item => item.read), true)
+  await center.clear()
+  assert.equal(store.values.has('notification-history'), false)
+  assert.equal(store.values.has('notification-preferences'), false)
+  assert.equal(center.history.length, 0)
 })

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -231,18 +231,19 @@ test('creates redacted, deduplicated notifications from normalized events', asyn
 test('quiet hours and rate limits suppress system presentation but retain history', async () => {
   const store = memoryDeviceStore()
   const systemNotifications = []
+  const quietNow = new Date(2026, 0, 1, 23, 30, 0, 0)
   const center = new NotificationCenter({
     store,
     permission: 'granted',
     systemNotify: notification => systemNotifications.push(notification),
-    now: () => Date.parse('2026-01-01T23:30:00+08:00'),
+    now: () => quietNow.getTime(),
   })
   await center.initialize()
   await center.updatePreferences({
     quietHours: { enabled: true, start: '23:00', end: '07:00' },
     rateLimits: { conversation: 1 },
   })
-  const base = { version: 1, occurredAt: Date.parse('2026-01-01T23:30:00+08:00'), type: 'conversation.status', running: false }
+  const base = { version: 1, occurredAt: quietNow.getTime(), type: 'conversation.status', running: false }
   await center.ingestEvent({ ...base, cursor: 'B'.repeat(22) + '.1', conversationId: 'conversation-1' })
   assert.equal(systemNotifications.length, 0)
   assert.equal(store.values.get('notification-history').length, 1)

--- a/web/app.css
+++ b/web/app.css
@@ -279,6 +279,24 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
 .approval-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
 .approval-notice { margin: 14px 0 0; color: var(--danger); font-size: 13px; }
 .approval-notice[hidden] { display: none; }
+.notification-actions { display: flex; gap: 8px; }
+.notification-list { display: grid; gap: 8px; margin: 24px 0 0; padding: 0; list-style: none; }
+.notification-list[hidden] { display: none; }
+.notification-item { border: 1px solid var(--border); border-radius: 8px; background: var(--surface); }
+.notification-item.is-unread { border-color: #9bd8bf; background: #f1fbf6; }
+.notification-link {
+  display: grid;
+  width: 100%;
+  gap: 5px;
+  padding: 15px 16px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+}
+.notification-link strong { overflow-wrap: anywhere; }
+.notification-link span { color: var(--text-muted); line-height: 1.45; }
+.notification-link small { color: var(--text-muted); font-size: 11px; }
 .activity-history { margin-top: 36px; }
 .activity-history h2 { margin: 0; font-size: 15px; }
 .activity-empty { margin-top: 14px; color: var(--text-muted); font-size: 13px; }
@@ -338,6 +356,10 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
 .settings-row h2 { margin: 0 0 5px; font-size: 15px; }
 .settings-row p { margin: 0; color: var(--text-muted); line-height: 1.45; }
 .settings-actions { display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
+.notification-options, .notification-rates { display: flex; flex-wrap: wrap; gap: 10px 14px; margin-top: 12px; color: var(--text-muted); font-size: 13px; }
+.notification-options label, .notification-rates label { display: inline-flex; align-items: center; gap: 5px; }
+.notification-options input, .notification-rates input { accent-color: var(--accent); }
+.notification-rates input { width: 50px; height: 30px; padding: 0 5px; border: 1px solid var(--border); border-radius: 5px; background: var(--surface); color: var(--text); }
 .device-metadata { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px 18px; margin: 14px 0 0; }
 .device-metadata[hidden] { display: none; }
 .device-metadata div { min-width: 0; }
@@ -432,7 +454,7 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
     bottom: 0;
     left: 0;
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     height: calc(64px + env(safe-area-inset-bottom));
     padding: 5px 8px env(safe-area-inset-bottom);
     border-top: 1px solid var(--border);
@@ -470,6 +492,8 @@ body[data-connection="unavailable"] .status-dot { background: var(--danger); }
   .pairing-form-controls button { width: 100%; }
   .approval-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .approval-actions .primary-button { grid-column: 1 / -1; grid-row: 1; }
+  .notification-actions { flex-wrap: wrap; justify-content: flex-end; }
+  .notification-options, .notification-rates { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web/app.js
+++ b/web/app.js
@@ -1,5 +1,6 @@
-import { ConversationsClient } from './conversations.js?v=10'
-import { BrowserPairing } from './pairing.js?v=10'
+import { ConversationsClient } from './conversations.js?v=11'
+import { BrowserPairing } from './pairing.js?v=11'
+import { NotificationCenter } from './notifications.js?v=11'
 
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')
@@ -51,6 +52,18 @@ const approvalList = document.querySelector('#approval-list')
 const approvalEmpty = document.querySelector('#approval-empty')
 const approvalNotice = document.querySelector('#approval-notice')
 const syncValue = document.querySelector('#sync-value')
+const notificationList = document.querySelector('#notification-list')
+const notificationEmpty = document.querySelector('#notification-empty')
+const notificationCount = document.querySelectorAll('[data-notification-count]')
+const markNotificationsReadButton = document.querySelector('#mark-notifications-read-button')
+const clearNotificationsButton = document.querySelector('#clear-notifications-button')
+const notificationPermissionButton = document.querySelector('#notification-permission-button')
+const notificationPermissionDetail = document.querySelector('#notification-permission-detail')
+const notificationCategoryInputs = document.querySelectorAll('[data-notification-category]')
+const quietHoursEnabled = document.querySelector('#notification-quiet-hours-enabled')
+const quietHoursStart = document.querySelector('#notification-quiet-hours-start')
+const quietHoursEnd = document.querySelector('#notification-quiet-hours-end')
+const notificationRateInputs = document.querySelectorAll('[data-notification-rate]')
 let installPrompt
 let probeInProgress = false
 let gatewayReachable = false
@@ -59,6 +72,90 @@ let pairingExpiresAt
 let disconnectBusy = false
 let conversationsClient
 let stateForRendering = { conversations: [], approvals: [], approvalSubmittedIds: [] }
+let notificationState = { history: [], unreadCount: 0, preferences: undefined, permission: 'default' }
+let lastPairingPhase = 'loading'
+
+function showView(name) {
+  for (const panel of document.querySelectorAll('[data-view-panel]')) {
+    const active = panel.dataset.viewPanel === name
+    panel.hidden = !active
+    panel.classList.toggle('is-active', active)
+  }
+  for (const button of document.querySelectorAll('[data-view-target]')) {
+    const active = button.dataset.viewTarget === name
+    button.classList.toggle('is-active', active)
+    if (active) button.setAttribute('aria-current', 'page')
+    else button.removeAttribute('aria-current')
+  }
+}
+
+function notificationLabel(notification) {
+  return notification.category === 'approval' ? '审批动态'
+    : notification.category === 'conversation' ? '对话动态' : '连接动态'
+}
+
+function renderNotifications(state = notificationState) {
+  notificationList.replaceChildren()
+  for (const notification of state.history) {
+    const item = document.createElement('li')
+    item.className = `notification-item ${notification.read ? '' : 'is-unread'}`
+    item.dataset.notificationId = notification.id
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'notification-link'
+    button.dataset.notificationId = notification.id
+    const heading = document.createElement('strong')
+    heading.textContent = notification.title
+    const body = document.createElement('span')
+    body.textContent = notification.body
+    const meta = document.createElement('small')
+    meta.textContent = `${notificationLabel(notification)} · ${formatDate(notification.occurredAt, true)}`
+    button.append(heading, body, meta)
+    item.append(button)
+    notificationList.append(item)
+  }
+  notificationEmpty.hidden = state.history.length > 0
+  notificationList.hidden = state.history.length === 0
+  for (const count of notificationCount) {
+    count.textContent = String(state.unreadCount)
+    count.hidden = state.unreadCount === 0
+  }
+  markNotificationsReadButton.disabled = state.unreadCount === 0
+  clearNotificationsButton.disabled = state.history.length === 0
+  if (state.preferences !== undefined) {
+    for (const input of notificationCategoryInputs) input.checked = state.preferences.categories[input.dataset.notificationCategory]
+    quietHoursEnabled.checked = state.preferences.quietHours.enabled
+    quietHoursStart.value = state.preferences.quietHours.start
+    quietHoursEnd.value = state.preferences.quietHours.end
+    for (const input of notificationRateInputs) input.value = state.preferences.rateLimits[input.dataset.notificationRate]
+  }
+  notificationPermissionDetail.textContent = state.permission === 'granted' ? '已允许系统通知'
+    : state.permission === 'denied' ? '系统通知已拒绝，可在浏览器设置中恢复'
+      : state.permission === 'unsupported' ? '此浏览器不支持系统通知' : '尚未请求系统通知权限'
+  notificationPermissionButton.disabled = state.permission === 'unsupported' || state.permission === 'granted'
+}
+
+function handleNotificationState(state) {
+  notificationState = state
+  renderNotifications(state)
+}
+
+const notificationCenter = new NotificationCenter({
+  onState: handleNotificationState,
+  systemNotify: notification => {
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return
+    const systemNotification = new Notification(notification.title, { body: notification.body, tag: notification.id })
+    systemNotification.onclick = () => {
+      window.focus()
+      if (pairingPhase !== 'paired' || notification.resource === null) return
+      showView(notification.resource.view)
+      if (notification.resource.conversationId !== undefined && conversationsClient !== undefined) {
+        void conversationsClient.select(notification.resource.conversationId)
+      }
+      systemNotification.close()
+    }
+  },
+})
 
 function updateDeviceSummary() {
   const connected = pairingPhase === 'paired'
@@ -97,7 +194,12 @@ function updateDisconnectControl() {
 }
 
 function handlePairingState(state) {
+  const previousPhase = lastPairingPhase
   pairingPhase = state.phase
+  lastPairingPhase = state.phase
+  if ((state.phase === 'unpaired' || state.phase === 'revoked') && previousPhase !== state.phase) {
+    void notificationCenter.clear()
+  }
   pairingExpiresAt = state.expiresAt
   pairButton.disabled = state.phase === 'loading' || state.phase === 'starting'
   pairingSetup.hidden = state.phase === 'paired' || state.phase === 'paired-offline' || state.phase === 'paired-error'
@@ -163,7 +265,9 @@ function handlePairingState(state) {
 }
 
 const pairing = new BrowserPairing(handlePairingState)
-conversationsClient = new ConversationsClient(pairing, handleConversationState)
+conversationsClient = new ConversationsClient(pairing, handleConversationState, {
+  onEvent: event => notificationCenter.ingestEvent(event),
+})
 handlePairingState({ phase: 'loading' })
 
 function formatDate(value, includeDate = false) {
@@ -398,25 +502,35 @@ async function probeGateway() {
   }
 }
 
-function showView(name) {
-  for (const panel of document.querySelectorAll('[data-view-panel]')) {
-    const active = panel.dataset.viewPanel === name
-    panel.hidden = !active
-    panel.classList.toggle('is-active', active)
-  }
-  for (const button of document.querySelectorAll('[data-view-target]')) {
-    const active = button.dataset.viewTarget === name
-    button.classList.toggle('is-active', active)
-    if (active) button.setAttribute('aria-current', 'page')
-    else button.removeAttribute('aria-current')
-  }
-}
-
 for (const button of document.querySelectorAll('[data-view-target]')) {
   button.addEventListener('click', () => showView(button.dataset.viewTarget))
 }
 
 document.querySelector('#open-settings-button').addEventListener('click', () => showView('settings'))
+notificationList.addEventListener('click', event => {
+  const button = event.target instanceof Element ? event.target.closest('[data-notification-id]') : null
+  if (button === null) return
+  const notification = notificationState.history.find(item => item.id === button.dataset.notificationId)
+  if (notification === undefined) return
+  void notificationCenter.markRead(notification.id)
+  if (pairingPhase !== 'paired' || notification.resource === null) return
+  showView(notification.resource.view)
+  if (notification.resource.conversationId !== undefined) void conversationsClient.select(notification.resource.conversationId)
+})
+markNotificationsReadButton.addEventListener('click', () => { void notificationCenter.markAllRead() })
+clearNotificationsButton.addEventListener('click', () => { void notificationCenter.clear() })
+notificationPermissionButton.addEventListener('click', () => { void notificationCenter.requestSystemPermission() })
+for (const input of notificationCategoryInputs) input.addEventListener('change', () => {
+  void notificationCenter.updatePreferences({ categories: { [input.dataset.notificationCategory]: input.checked } })
+})
+for (const input of notificationRateInputs) input.addEventListener('change', () => {
+  void notificationCenter.updatePreferences({ rateLimits: { [input.dataset.notificationRate]: Number(input.value) } })
+})
+for (const input of [quietHoursEnabled, quietHoursStart, quietHoursEnd]) input.addEventListener('change', () => {
+  void notificationCenter.updatePreferences({
+    quietHours: { enabled: quietHoursEnabled.checked, start: quietHoursStart.value, end: quietHoursEnd.value },
+  })
+})
 pairButton.addEventListener('click', async () => {
   try {
     await pairing.begin(deviceName.value)
@@ -527,7 +641,7 @@ if ('serviceWorker' in navigator) {
 }
 
 void probeGateway()
-void pairing.initialize()
+void notificationCenter.initialize().catch(() => {}).finally(() => { void pairing.initialize() })
 window.setInterval(() => { void probeGateway() }, 30_000)
 window.setInterval(() => {
   if (pairingPhase !== 'pending' || pairingExpiresAt === undefined) return

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=10'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=11'
 
 const CACHE_KEY = 'conversation-cache'
 const CURSOR_KEY = 'event-cursor'
@@ -112,6 +112,7 @@ export class ConversationsClient {
     this.setTimeoutValue = options.setTimeout ?? ((callback, delay) => window.setTimeout(callback, delay))
     this.clearTimeoutValue = options.clearTimeout ?? (timer => window.clearTimeout(timer))
     this.randomUUID = options.randomUUID ?? (() => crypto.randomUUID())
+    this.onEvent = options.onEvent ?? (async () => {})
     this.store = options.store ?? {
       read: readDeviceState,
       write: writeDeviceState,
@@ -507,6 +508,7 @@ export class ConversationsClient {
       socket.close(CLOSE_PROTOCOL, 'unsupported event')
       return
     }
+    await this.onEvent(event)
     this.addActivity(eventDescription(event))
     this.cachedAt = Date.now()
     await this.persistCache()

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js?v=10" type="module"></script>
+    <script src="./app.js?v=11" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>
@@ -38,6 +38,9 @@
           </button>
           <button class="nav-button" type="button" data-view-target="activity">
             <span aria-hidden="true">✓</span><span>审批</span><span class="approval-count" data-approval-count hidden>0</span>
+          </button>
+          <button class="nav-button" type="button" data-view-target="notifications">
+            <span aria-hidden="true">•</span><span>通知</span><span class="approval-count" data-notification-count hidden>0</span>
           </button>
           <button class="nav-button" type="button" data-view-target="settings">
             <span aria-hidden="true">⚙</span><span>设置</span>
@@ -108,6 +111,24 @@
           </section>
         </section>
 
+        <section class="view-panel" data-view-panel="notifications" aria-labelledby="notifications-title" hidden>
+          <header class="view-header">
+            <div>
+              <p class="eyebrow">隐私优先</p>
+              <h1 id="notifications-title">通知</h1>
+            </div>
+            <div class="notification-actions">
+              <button id="mark-notifications-read-button" class="secondary-button" type="button" disabled>全部已读</button>
+              <button id="clear-notifications-button" class="secondary-button" type="button" disabled>清空</button>
+            </div>
+          </header>
+          <div id="notification-empty" class="plain-empty">
+            <h2>暂无通知</h2>
+            <p>新的审批、对话完成和连接状态会显示在这里。</p>
+          </div>
+          <ol id="notification-list" class="notification-list" aria-live="polite" hidden></ol>
+        </section>
+
         <section class="view-panel" data-view-panel="settings" aria-labelledby="settings-title" hidden>
           <header class="view-header">
             <div>
@@ -172,6 +193,29 @@
               </div>
               <button id="install-button" class="secondary-button" type="button" hidden>安装</button>
             </section>
+            <section class="settings-row notification-settings" aria-labelledby="notification-settings-heading">
+              <div>
+                <h2 id="notification-settings-heading">通知偏好</h2>
+                <p>默认只保存固定的摘要文案，不保存消息正文或操作参数。</p>
+                <div class="notification-options">
+                  <label><input type="checkbox" data-notification-category="approval" checked> 审批</label>
+                  <label><input type="checkbox" data-notification-category="conversation" checked> 对话完成</label>
+                  <label><input type="checkbox" data-notification-category="connection" checked> 连接</label>
+                  <label><input id="notification-quiet-hours-enabled" type="checkbox"> 静默时段</label>
+                  <label>开始 <input id="notification-quiet-hours-start" type="time" value="22:00"></label>
+                  <label>结束 <input id="notification-quiet-hours-end" type="time" value="07:00"></label>
+                </div>
+                <div class="notification-rates" aria-label="每小时系统通知上限">
+                  <label>审批 <input data-notification-rate="approval" type="number" min="0" max="20" value="5"></label>
+                  <label>对话 <input data-notification-rate="conversation" type="number" min="0" max="20" value="5"></label>
+                  <label>连接 <input data-notification-rate="connection" type="number" min="0" max="20" value="3"></label>
+                </div>
+              </div>
+              <div class="settings-actions">
+                <button id="notification-permission-button" class="secondary-button" type="button">允许系统通知</button>
+                <span id="notification-permission-detail" class="value-label">尚未请求系统通知权限</span>
+              </div>
+            </section>
           </div>
         </section>
       </main>
@@ -180,6 +224,7 @@
     <nav class="mobile-nav" aria-label="主导航">
       <button class="mobile-nav-button is-active" type="button" data-view-target="chat" aria-current="page"><span aria-hidden="true">◫</span><span>对话</span></button>
       <button class="mobile-nav-button" type="button" data-view-target="activity"><span aria-hidden="true">✓</span><span>审批</span><span class="approval-count" data-approval-count hidden>0</span></button>
+      <button class="mobile-nav-button" type="button" data-view-target="notifications"><span aria-hidden="true">•</span><span>通知</span><span class="approval-count" data-notification-count hidden>0</span></button>
       <button class="mobile-nav-button" type="button" data-view-target="settings"><span aria-hidden="true">⚙</span><span>设置</span></button>
     </nav>
     <dialog id="disconnect-device-dialog" class="confirmation-dialog" aria-labelledby="disconnect-device-title">

--- a/web/notifications.js
+++ b/web/notifications.js
@@ -1,0 +1,220 @@
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=11'
+
+export const NOTIFICATION_HISTORY_KEY = 'notification-history'
+export const NOTIFICATION_PREFERENCES_KEY = 'notification-preferences'
+export const NOTIFICATION_CATEGORIES = ['approval', 'conversation', 'connection']
+export const MAX_NOTIFICATIONS = 50
+
+const NOTIFICATION_ID_PATTERN = /^[a-z]+:[A-Za-z0-9_.:-]{1,320}$/
+const RESOURCE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+const TIME_PATTERN = /^([01][0-9]|2[0-3]):[0-5][0-9]$/
+
+export const DEFAULT_NOTIFICATION_PREFERENCES = Object.freeze({
+  categories: Object.freeze({ approval: true, conversation: true, connection: true }),
+  quietHours: Object.freeze({ enabled: false, start: '22:00', end: '07:00' }),
+  rateLimits: Object.freeze({ approval: 5, conversation: 5, connection: 3 }),
+})
+
+function clonePreferences(preferences) {
+  return {
+    categories: { ...preferences.categories },
+    quietHours: { ...preferences.quietHours },
+    rateLimits: { ...preferences.rateLimits },
+  }
+}
+
+function validNotification(value) {
+  return value !== null && typeof value === 'object'
+    && typeof value.id === 'string' && NOTIFICATION_ID_PATTERN.test(value.id)
+    && NOTIFICATION_CATEGORIES.includes(value.category)
+    && typeof value.title === 'string' && typeof value.body === 'string'
+    && Number.isFinite(value.occurredAt) && typeof value.read === 'boolean'
+    && (value.presentedAt === undefined || Number.isFinite(value.presentedAt))
+    && (value.resource === null || (value.resource !== null && typeof value.resource === 'object'
+      && ['activity', 'chat', 'settings'].includes(value.resource.view)
+      && (value.resource.conversationId === undefined || RESOURCE_ID_PATTERN.test(value.resource.conversationId))
+      && (value.resource.approvalId === undefined || RESOURCE_ID_PATTERN.test(value.resource.approvalId))))
+}
+
+function parseHistory(value) {
+  if (!Array.isArray(value) || !value.every(validNotification)) return []
+  const unique = new Map()
+  for (const notification of value) unique.set(notification.id, {
+    ...notification,
+    resource: notification.resource === null ? null : { ...notification.resource },
+  })
+  return [...unique.values()].slice(0, MAX_NOTIFICATIONS)
+}
+
+function parsePreferences(value) {
+  const preferences = clonePreferences(DEFAULT_NOTIFICATION_PREFERENCES)
+  if (value === null || typeof value !== 'object') return preferences
+  for (const category of NOTIFICATION_CATEGORIES) {
+    if (typeof value.categories?.[category] === 'boolean') preferences.categories[category] = value.categories[category]
+    if (Number.isInteger(value.rateLimits?.[category])) {
+      preferences.rateLimits[category] = Math.max(0, Math.min(20, value.rateLimits[category]))
+    }
+  }
+  if (typeof value.quietHours?.enabled === 'boolean') preferences.quietHours.enabled = value.quietHours.enabled
+  if (TIME_PATTERN.test(value.quietHours?.start ?? '')) preferences.quietHours.start = value.quietHours.start
+  if (TIME_PATTERN.test(value.quietHours?.end ?? '')) preferences.quietHours.end = value.quietHours.end
+  return preferences
+}
+
+function notificationForEvent(event) {
+  if (event?.version !== 1 || typeof event.cursor !== 'string' || !Number.isFinite(event.occurredAt)) return null
+  if (event.type === 'approval.pending' && RESOURCE_ID_PATTERN.test(event.approval?.id ?? '')) {
+    return {
+      id: `approval:${event.approval.id}:pending`, category: 'approval',
+      title: '有一项审批等待处理', body: 'Jarvis 有一项高风险操作等待你的决定。',
+      resource: { view: 'activity', approvalId: event.approval.id },
+    }
+  }
+  if (event.type === 'approval.resolved' && RESOURCE_ID_PATTERN.test(event.approvalId ?? '')) {
+    return {
+      id: `approval:${event.approvalId}:resolved`, category: 'approval',
+      title: '审批状态已更新', body: 'Jarvis 的一项操作审批已经完成。',
+      resource: { view: 'activity', approvalId: event.approvalId },
+    }
+  }
+  if (event.type === 'conversation.status' && RESOURCE_ID_PATTERN.test(event.conversationId ?? '')
+    && event.running === false) {
+    return {
+      id: `conversation:${event.conversationId}:complete:${event.cursor}`, category: 'conversation',
+      title: 'Jarvis 已完成回复', body: '一个对话回合已经完成。',
+      resource: { view: 'chat', conversationId: event.conversationId },
+    }
+  }
+  if (event.type === 'sync.required') {
+    return {
+      id: `connection:${event.cursor}`, category: 'connection',
+      title: '需要重新同步', body: '实时事件需要重新同步，请检查当前连接状态。',
+      resource: { view: 'settings' },
+    }
+  }
+  return null
+}
+
+function minutesSinceMidnight(value) {
+  const [hour, minute] = value.split(':').map(Number)
+  return hour * 60 + minute
+}
+
+function inQuietHours(preferences, now) {
+  if (!preferences.quietHours.enabled) return false
+  const current = now.getHours() * 60 + now.getMinutes()
+  const start = minutesSinceMidnight(preferences.quietHours.start)
+  const end = minutesSinceMidnight(preferences.quietHours.end)
+  return start === end ? true : start < end ? current >= start && current < end : current >= start || current < end
+}
+
+export class NotificationCenter {
+  constructor(options = {}) {
+    this.store = options.store ?? { read: readDeviceState, write: writeDeviceState, delete: deleteDeviceState }
+    this.onState = options.onState ?? (() => {})
+    this.systemNotify = options.systemNotify ?? (notification => {
+      if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+        new Notification(notification.title, { body: notification.body, tag: notification.id })
+      }
+    })
+    this.now = options.now ?? (() => Date.now())
+    this.permission = options.permission ?? (typeof Notification === 'undefined' ? 'unsupported' : Notification.permission)
+    this.history = []
+    this.preferences = clonePreferences(DEFAULT_NOTIFICATION_PREFERENCES)
+  }
+
+  async initialize() {
+    this.history = parseHistory(await this.store.read(NOTIFICATION_HISTORY_KEY))
+    this.preferences = parsePreferences(await this.store.read(NOTIFICATION_PREFERENCES_KEY))
+    this.emit()
+  }
+
+  async ingestEvent(event) {
+    const candidate = notificationForEvent(event)
+    if (candidate === null || this.history.some(item => item.id === candidate.id)) return false
+    const notification = {
+      ...candidate,
+      occurredAt: event.occurredAt,
+      read: false,
+      resource: { ...candidate.resource },
+    }
+    if (this.permission === 'granted' && this.shouldPresent(notification)) {
+      notification.presentedAt = this.now()
+      try {
+        this.systemNotify({ ...notification, resource: { ...notification.resource } })
+      } catch {
+        delete notification.presentedAt
+      }
+    }
+    this.history = [notification, ...this.history].slice(0, MAX_NOTIFICATIONS)
+    await this.persist()
+    this.emit()
+    return true
+  }
+
+  async updatePreferences(update) {
+    this.preferences = parsePreferences({ ...this.preferences, ...update,
+      categories: { ...this.preferences.categories, ...update.categories },
+      quietHours: { ...this.preferences.quietHours, ...update.quietHours },
+      rateLimits: { ...this.preferences.rateLimits, ...update.rateLimits },
+    })
+    await this.store.write(NOTIFICATION_PREFERENCES_KEY, this.preferences)
+    this.emit()
+  }
+
+  shouldPresent(notification, now = this.now()) {
+    if (!this.preferences.categories[notification.category] || inQuietHours(this.preferences, new Date(now))) return false
+    const limit = this.preferences.rateLimits[notification.category]
+    if (limit <= 0) return false
+    const hourAgo = now - 60 * 60 * 1_000
+    const recent = this.history.filter(item => item.category === notification.category
+      && item.presentedAt !== undefined && item.presentedAt >= hourAgo)
+    return recent.length < limit
+  }
+
+  async markRead(id) {
+    const notification = this.history.find(item => item.id === id)
+    if (notification === undefined || notification.read) return
+    notification.read = true
+    await this.persist()
+    this.emit()
+  }
+
+  async markAllRead() {
+    if (this.history.every(item => item.read)) return
+    this.history = this.history.map(item => ({ ...item, read: true }))
+    await this.persist()
+    this.emit()
+  }
+
+  async clear() {
+    this.history = []
+    await this.store.delete(NOTIFICATION_HISTORY_KEY)
+    await this.store.delete(NOTIFICATION_PREFERENCES_KEY)
+    this.preferences = clonePreferences(DEFAULT_NOTIFICATION_PREFERENCES)
+    this.emit()
+  }
+
+  async requestSystemPermission() {
+    if (typeof Notification === 'undefined') return 'unsupported'
+    const permission = Notification.permission === 'default' ? await Notification.requestPermission() : Notification.permission
+    this.permission = permission
+    this.emit(permission)
+    return permission
+  }
+
+  async persist() {
+    await this.store.write(NOTIFICATION_HISTORY_KEY, this.history)
+  }
+
+  emit(permission) {
+    this.onState({
+      history: this.history.map(item => ({ ...item, resource: item.resource === null ? null : { ...item.resource } })),
+      preferences: clonePreferences(this.preferences),
+      unreadCount: this.history.filter(item => !item.read).length,
+      permission: permission ?? this.permission,
+    })
+  }
+}
+
+export { inQuietHours, notificationForEvent, parseHistory, parsePreferences }

--- a/web/pairing.js
+++ b/web/pairing.js
@@ -1,4 +1,4 @@
-import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=10'
+import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=11'
 
 const MAX_RESPONSE_CHARS = 2 * 1024 * 1024
 

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,11 +1,12 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v10'
+const CACHE_NAME = 'jarvis-pwa-shell-v11'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js?v=10',
-  '/app/pairing.js?v=10',
-  '/app/device-store.js?v=10',
-  '/app/conversations.js?v=10',
+  '/app/app.js?v=11',
+  '/app/pairing.js?v=11',
+  '/app/device-store.js?v=11',
+  '/app/conversations.js?v=11',
+  '/app/notifications.js?v=11',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',


### PR DESCRIPTION
## Summary
- add a bounded notification center for normalized approval, conversation-completion, and resync events
- keep fixed redacted copy and safe resource references; never store or display message bodies or command arguments
- add IndexedDB persistence, deduplication, unread state, clear/read controls, quiet hours, category toggles, rate limits, and explicit system-notification permission
- add responsive desktop/mobile UI, Gateway static asset serving, Service Worker cache v11, tests, and Stage 3 documentation

## Verification
- `npm run verify` (126/126 passing)
- `npm run verify:runtime`
- `node --check web/app.js`
- `node --check web/notifications.js`
- `git diff --check`
- Gateway static preview served `/app/notifications.js?v=11` and `/app/` successfully

Background Web Push and lock-screen qualification remain deferred until the first physical phone is named and tested.

Closes #52