### PR TITLE
Add private-network Gateway recovery diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [开发旅程与里程碑](docs/plan/00-development-journey.md)
 - [完整阶段计划](docs/plan/README.md)
 - [备份与恢复](docs/operations/backup-restore.md)
+- [私网恢复与 Gateway 诊断](docs/operations/private-network-recovery.md)
 - [v0.1.0 发布说明](docs/releases/v0.1.0.md)
 - [贡献指南](CONTRIBUTING.md)
 - [安全策略](SECURITY.md)

--- a/docs/operations/private-network-recovery.md
+++ b/docs/operations/private-network-recovery.md
@@ -1,0 +1,65 @@
+# Private Network Recovery
+
+This runbook restores the phone-to-Gateway path without exposing Harness or
+falling back to public HTTP. It applies to a loopback development Gateway, a
+local Wi-Fi address, and a trusted private overlay such as Tailscale.
+
+## Health Check
+
+The diagnostic uses only the unauthenticated Gateway health endpoint. It does
+not send or print the Owner Token, device credential, session token, or health
+response body.
+
+For a local Mac check:
+
+~~~bash
+npm run check:gateway
+~~~
+
+For a private HTTPS address:
+
+~~~bash
+JARVIS_GATEWAY_URL='https://100.64.0.10:3090' \
+JARVIS_GATEWAY_TIMEOUT_SECONDS=5 \
+npm run check:gateway
+~~~
+
+The command succeeds only when the health response identifies Jarvis Gateway,
+reports status ok, and matches the URL transport and expected scope. A
+non-loopback URL using HTTP, a URL containing credentials, or a URL with a
+path/query is rejected before any network request.
+
+## Recovery Order
+
+1. **Gateway stopped**: on the Mac, confirm the Gateway process is running and
+   repeat the loopback health check. Do not expose the Harness port.
+2. **Local Wi-Fi**: confirm the phone and Mac are on the same trusted network,
+   use the Mac's configured private address, and run the HTTPS health check from
+   a device that trusts the configured certificate.
+3. **Private overlay**: confirm the overlay client reports the Mac as reachable,
+   use its assigned private address, and repeat the HTTPS health check. The
+   Gateway must remain bound to that explicit address.
+4. **TLS failure**: verify the certificate name covers the address or hostname
+   used by the phone and that the private key is owner-only. Fix trust or
+   certificate configuration; do not downgrade to plaintext HTTP.
+5. **PWA stale state**: reopen the PWA, use its refresh control, and wait for a
+   fresh Gateway session. The offline snapshot is read-only and must not be
+   treated as current.
+6. **Expired session**: allow the paired PWA to refresh its session. If the
+   Gateway rejects the refresh, start a new owner-approved pairing flow.
+7. **Revoked device**: do not retry old credentials. Pair the browser again
+   through the Mac owner approval flow; no phone-side Owner Token is needed.
+
+## Failure Meaning
+
+| Observation | Meaning | Action |
+| --- | --- | --- |
+| Connection timeout/refused | Gateway or private route unavailable | Restore the process or private route, then rerun health |
+| TLS name/trust error | Certificate does not match the private endpoint | Correct certificate trust/name; keep HTTPS |
+| Health scope mismatch | The endpoint is not the configured private boundary | Stop and inspect Gateway binding |
+| 401 after health passes | Device/session authentication has expired or was revoked | Refresh once, then re-pair if rejected |
+| PWA shows stale data | No current authenticated synchronization | Restore health and session before mutating |
+
+There is no public-internet fallback. Harness stays loopback-only, and the
+Stage 3 exit gate still requires named-phone observations over local Wi-Fi and
+remote mobile access.

--- a/docs/plan/04-stage-3-mobile-remote.md
+++ b/docs/plan/04-stage-3-mobile-remote.md
@@ -19,6 +19,8 @@ The platform-independent increments tracked in [#42](https://github.com/gh503/ja
 
 ## Modules
 
+Private-ingress recovery is tracked in [#54](https://github.com/gh503/jarvis/issues/54). Its health diagnostic and runbook cover loopback, local Wi-Fi, and private-overlay recovery without allowing a plaintext or public-internet fallback. Physical network, certificate, and phone observations remain part of the Stage 3 exit gate.
+
 ### Private ingress
 
 Deliver:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pair:approve": "npm run build --silent && node dist/pairing-approval-main.js",
     "verify": "npm run typecheck && npm test",
     "verify:runtime": "./scripts/verify-local-runtime.sh",
+    "check:gateway": "./scripts/check-private-gateway.sh",
     "verify:release": "./scripts/verify-release-macos.sh",
     "release:archive": "./scripts/build-release-archive.sh"
   },

--- a/scripts/check-private-gateway.sh
+++ b/scripts/check-private-gateway.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -eu
+
+gateway_url=${JARVIS_GATEWAY_URL:-http://127.0.0.1:3090}
+timeout_seconds=${JARVIS_GATEWAY_TIMEOUT_SECONDS:-5}
+health_file=$(mktemp "${TMPDIR:-/tmp}/jarvis-gateway-health.XXXXXX")
+
+cleanup() {
+  rm -f "$health_file"
+}
+trap cleanup EXIT HUP INT TERM
+
+node --input-type=module - "$gateway_url" "$timeout_seconds" <<'NODE'
+const [urlValue, timeoutValue] = process.argv.slice(2)
+let gatewayUrl
+try {
+  gatewayUrl = new URL(urlValue)
+} catch {
+  console.error('Gateway URL is invalid')
+  process.exit(2)
+}
+const timeout = Number(timeoutValue)
+if (!Number.isInteger(timeout) || timeout < 1 || timeout > 30) {
+  console.error('Gateway timeout must be an integer from 1 to 30 seconds')
+  process.exit(2)
+}
+if (gatewayUrl.username || gatewayUrl.password || gatewayUrl.search || gatewayUrl.hash
+  || (gatewayUrl.pathname !== '' && gatewayUrl.pathname !== '/')) {
+  console.error('Gateway URL must not contain credentials, query, fragment, or a path')
+  process.exit(2)
+}
+const host = gatewayUrl.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+const loopback = host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host)
+if (!loopback && gatewayUrl.protocol !== 'https:') {
+  console.error('Non-loopback Gateway URLs must use HTTPS')
+  process.exit(2)
+}
+NODE
+
+health_url="${gateway_url%/}/v1/health"
+if ! curl --fail --silent --show-error --connect-timeout "$timeout_seconds" \
+  --max-time "$timeout_seconds" --output "$health_file" "$health_url"; then
+  echo 'Gateway health request failed' >&2
+  exit 1
+fi
+
+node --input-type=module - "$health_file" "$gateway_url" <<'NODE'
+import { readFileSync } from 'node:fs'
+
+const [healthFile, urlValue] = process.argv.slice(2)
+let payload
+try {
+  payload = JSON.parse(readFileSync(healthFile, 'utf8'))
+} catch {
+  console.error('Gateway health response is not valid JSON')
+  process.exit(1)
+}
+const gatewayUrl = new URL(urlValue)
+const host = gatewayUrl.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+const loopback = host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host)
+const expectedScope = loopback ? 'loopback-only' : 'private-network'
+const expectedTransport = gatewayUrl.protocol === 'https:' ? 'https' : 'http'
+if (payload?.service !== 'jarvis-gateway' || payload.status !== 'ok'
+  || payload.scope !== expectedScope || payload.transport !== expectedTransport) {
+  console.error('Gateway health response does not match the configured private transport')
+  process.exit(1)
+}
+console.log('Gateway health passed (' + payload.scope + ', ' + payload.transport + ')')
+NODE

--- a/test/private-network.test.js
+++ b/test/private-network.test.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { createServer } from 'node:http'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { promisify } from 'node:util'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { createJarvisGateway } from '../dist/gateway.js'
+
+const execFileAsync = promisify(execFile)
+const ownerToken = 'private-network-test-owner-token'
+const scriptPath = join(process.cwd(), 'scripts/check-private-gateway.sh')
+
+async function runDiagnostic(environment) {
+  try {
+    const result = await execFileAsync(scriptPath, [], { env: { ...process.env, ...environment } })
+    return { ok: true, ...result }
+  } catch (error) {
+    return { ok: false, ...error }
+  }
+}
+
+async function createGateway() {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-private-network-test-'))
+  const service = createJarvisGateway({
+    ownerToken,
+    pairingStatePath: join(directory, 'pairing.json'),
+    sessionStatePath: join(directory, 'sessions.json'),
+    eventStatePath: join(directory, 'events.json'),
+  })
+  const gateway = await service.start()
+  return { service, gateway, directory }
+}
+
+test('diagnostic accepts a healthy loopback Gateway without credentials', async () => {
+  const { service, gateway, directory } = await createGateway()
+  try {
+    const result = await runDiagnostic({ JARVIS_GATEWAY_URL: gateway.origin, JARVIS_GATEWAY_TIMEOUT_SECONDS: '2' })
+    assert.equal(result.ok, true, result.stderr)
+    assert.match(result.stdout, /Gateway health passed \(loopback-only, http\)/)
+    assert.doesNotMatch(result.stdout + result.stderr, /private-network-test-owner-token/)
+  } finally {
+    await service.stop()
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('diagnostic rejects unsafe URLs and invalid timeouts before connecting', async () => {
+  const httpResult = await runDiagnostic({ JARVIS_GATEWAY_URL: 'http://192.168.1.20:3090' })
+  assert.equal(httpResult.ok, false)
+  assert.match(httpResult.stderr, /must use HTTPS/)
+  const credentialResult = await runDiagnostic({ JARVIS_GATEWAY_URL: 'https://user:secret@example.com' })
+  assert.equal(credentialResult.ok, false)
+  assert.doesNotMatch(credentialResult.stdout + credentialResult.stderr, /secret/)
+  const timeoutResult = await runDiagnostic({ JARVIS_GATEWAY_TIMEOUT_SECONDS: '0' })
+  assert.equal(timeoutResult.ok, false)
+  assert.match(timeoutResult.stderr, /timeout must be an integer/)
+})
+
+test('diagnostic fails closed on an unexpected health response', async () => {
+  const server = createServer((_request, response) => {
+    response.setHeader('content-type', 'application/json')
+    response.end(JSON.stringify({ service: 'other-service', status: 'ok', scope: 'loopback-only', transport: 'http' }))
+  })
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  try {
+    const result = await runDiagnostic({ JARVIS_GATEWAY_URL: 'http://127.0.0.1:' + address.port })
+    assert.equal(result.ok, false)
+    assert.match(result.stderr, /does not match/)
+    assert.doesNotMatch(result.stdout + result.stderr, /other-service/)
+  } finally {
+    await new Promise(resolve => server.close(resolve))
+  }
+})
+
+test('private-network recovery runbook distinguishes secure failure modes', async () => {
+  const runbook = await readFile(join(process.cwd(), 'docs/operations/private-network-recovery.md'), 'utf8')
+  assert.match(runbook, /local Wi-Fi/)
+  assert.match(runbook, /private overlay/)
+  assert.match(runbook, /TLS failure/)
+  assert.match(runbook, /Revoked device/)
+  assert.match(runbook, /no public-internet fallback/i)
+  assert.doesNotMatch(runbook, /JARVIS_OWNER_TOKEN=/)
+})


### PR DESCRIPTION
## Summary
- add `npm run check:gateway` for no-credential loopback/private HTTPS health validation
- reject non-loopback HTTP, embedded credentials, URL paths/queries, invalid timeouts, and mismatched Gateway health scope/transport
- document Gateway, local Wi-Fi, overlay, TLS, stale PWA, expired-session, and revoked-device recovery without public fallback
- add executable contract tests and Stage 3 documentation links

## Verification
- `npm run verify` (130/130 passing)
- `npm run verify:runtime`
- `node --test test/private-network.test.js`
- `sh -n scripts/check-private-gateway.sh`
- healthy loopback diagnostic passed against a running Gateway
- unsafe HTTP and credential-bearing URL checks returned nonzero without leaking the credential
- `git diff --check`

Physical Wi-Fi, overlay, certificate trust, and phone journeys remain deferred under #16.

Closes #54