### PR TITLE
Add PWA smart-device approval workflow

### DIFF
--- a/test/conversations.test.js
+++ b/test/conversations.test.js
@@ -77,6 +77,7 @@ function gatewayPairing(calls, overrides = {}) {
       }
       if (path === '/v1/conversations') return { ok: true, status: 200, value: { conversations: [conversation] } }
       if (path === '/v1/approvals') return { ok: true, status: 200, value: { approvals: overrides.approvals ?? [] } }
+      if (path === '/v1/device-approvals') return { ok: true, status: 200, value: { approvals: overrides.deviceApprovals ?? [] } }
       if (path.startsWith('/v1/conversations/session-one?')) {
         return { ok: true, status: 200, value: { messages: [message], hasMore: false, nextBeforeSequence: null } }
       }
@@ -295,6 +296,37 @@ test('keeps approvals memory-only and reuses a decision key after a transport re
   client.setOnline(false)
   assert.deepEqual(states.at(-1).approvals, [])
   assert.equal(await client.decideApproval(approval.id, 'allowed-once'), false)
+})
+
+test('loads and decides smart-device approvals through the separate Gateway contract', async () => {
+  const calls = []
+  const states = []
+  let pending = [{
+    approvalId: 'device-approval-one', capability: 'lock.set', externalEntityId: 'lock.front_door',
+    service: 'lock_unlock', expectedState: 'unlocked', digest: 'b'.repeat(64), risk: 'high', expiresAt: Date.now() + 60_000,
+  }]
+  const pairing = gatewayPairing(calls, {
+    request: async (path, init) => {
+      if (path === '/v1/device-approvals') return { ok: true, status: 200, value: { approvals: pending } }
+      if (path.endsWith('/device-approval-one/decision')) {
+        pending = []
+        return { ok: true, status: 202, value: { approvalId: 'device-approval-one', outcome: 'allowed-once', accepted: true } }
+      }
+      return undefined
+    },
+  })
+  const client = new ConversationsClient(pairing, state => states.push(state), {
+    store: memoryStore(), location: { origin: 'https://jarvis.internal' }, socketFactory: url => new FakeSocket(url),
+    randomUUID: () => 'device-decision-one',
+  })
+  await client.start()
+  assert.equal(states.at(-1).deviceApprovals.length, 1)
+  assert.equal(await client.decideDeviceApproval('device-approval-one', 'allowed-once'), true)
+  const submitted = calls.find(call => typeof call[1] === 'string' && call[1].endsWith('/decision'))
+  assert.deepEqual(JSON.parse(submitted[3].body), {
+    digest: 'b'.repeat(64), outcome: 'allowed-once', idempotencyKey: 'device-decision-one',
+  })
+  assert.deepEqual(states.at(-1).deviceApprovals, [])
 })
 
 test('converges live approval requested and resolved events', async () => {

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -23,8 +23,8 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js?v=11', '/app/pairing.js?v=11', '/app/device-store.js?v=11',
-    '/app/conversations.js?v=11', '/app/notifications.js?v=11', '/app/apple-touch-icon.png', '/app/icon.svg',
+    '/app/', '/app/app.css', '/app/app.js?v=12', '/app/pairing.js?v=12', '/app/device-store.js?v=12',
+    '/app/conversations.js?v=12', '/app/notifications.js?v=12', '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {
     assert.ok(serviceWorker.includes(`'${path}'`), `${path} must be pre-cached`)
@@ -56,6 +56,7 @@ test('keeps the browser client on the public Gateway contract', async () => {
   assert.match(conversationsSource, /events\.authenticate/)
   assert.match(conversationsSource, /authenticatedRequest\('\/v1\/conversations'/)
   assert.match(conversationsSource, /authenticatedRequest\('\/v1\/approvals'/)
+  assert.match(conversationsSource, /authenticatedRequest\('\/v1\/device-approvals'/)
   assert.match(notificationsSource, /class NotificationCenter/)
   assert.match(notificationsSource, /固定摘要|高风险操作/)
   assert.doesNotMatch(notificationsSource, /arguments|message|rpcId|accessToken|refreshToken/)

--- a/web/app.js
+++ b/web/app.js
@@ -1,6 +1,6 @@
-import { ConversationsClient } from './conversations.js?v=11'
-import { BrowserPairing } from './pairing.js?v=11'
-import { NotificationCenter } from './notifications.js?v=11'
+import { ConversationsClient } from './conversations.js?v=12'
+import { BrowserPairing } from './pairing.js?v=12'
+import { NotificationCenter } from './notifications.js?v=12'
 
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')
@@ -71,7 +71,7 @@ let pairingPhase = 'loading'
 let pairingExpiresAt
 let disconnectBusy = false
 let conversationsClient
-let stateForRendering = { conversations: [], approvals: [], approvalSubmittedIds: [] }
+let stateForRendering = { conversations: [], approvals: [], deviceApprovals: [], approvalSubmittedIds: [], deviceApprovalSubmittedIds: [] }
 let notificationState = { history: [], unreadCount: 0, preferences: undefined, permission: 'default' }
 let lastPairingPhase = 'loading'
 
@@ -345,19 +345,76 @@ function approvalCard(approval, mutable, busy) {
   return item
 }
 
+function deviceApprovalStatus(approval) {
+  return approval.expiresAt <= Date.now() ? '已过期' : '等待决定'
+}
+
+function deviceApprovalCard(approval, mutable, busy) {
+  const item = document.createElement('li')
+  item.className = 'approval-card device-approval-card'
+  item.dataset.deviceApprovalId = approval.approvalId
+  const header = document.createElement('div')
+  header.className = 'approval-card-header'
+  const title = document.createElement('strong')
+  title.textContent = approval.capability === 'lock.set' ? '门锁操作' : '警报操作'
+  const risk = document.createElement('span')
+  risk.className = 'risk-label'
+  risk.textContent = '必须审批'
+  header.append(title, risk)
+  const target = document.createElement('p')
+  target.className = 'approval-target'
+  target.textContent = approval.externalEntityId
+  const details = document.createElement('dl')
+  details.className = 'approval-details'
+  for (const [label, value] of [
+    ['动作', approval.service],
+    ['目标状态', approval.expectedState],
+    ['状态', deviceApprovalStatus(approval)],
+    ['到期', formatDate(approval.expiresAt, true)],
+  ]) {
+    const term = document.createElement('dt')
+    term.textContent = label
+    const description = document.createElement('dd')
+    description.textContent = value
+    details.append(term, description)
+  }
+  const actions = document.createElement('div')
+  actions.className = 'approval-actions'
+  const reject = document.createElement('button')
+  reject.type = 'button'
+  reject.className = 'secondary-button'
+  reject.dataset.deviceApprovalAction = 'rejected'
+  reject.textContent = '拒绝'
+  const allow = document.createElement('button')
+  allow.type = 'button'
+  allow.className = 'primary-button'
+  allow.dataset.deviceApprovalAction = 'allowed-once'
+  allow.textContent = '允许一次'
+  reject.disabled = !mutable || busy
+  allow.disabled = !mutable || busy || approval.expiresAt <= Date.now()
+  actions.append(reject, allow)
+  item.append(header, target, details, actions)
+  return item
+}
+
 function renderApprovals(state, mutable) {
   approvalList.replaceChildren()
   for (const approval of state.approvals) {
     const submitted = state.approvalSubmittedIds.includes(approval.id)
     approvalList.append(approvalCard(approval, mutable, state.approvalBusyId === approval.id || submitted))
   }
-  approvalEmpty.hidden = state.approvals.length > 0
-  approvalList.hidden = state.approvals.length === 0
+  for (const approval of state.deviceApprovals ?? []) {
+    const submitted = (state.deviceApprovalSubmittedIds ?? []).includes(approval.approvalId)
+    approvalList.append(deviceApprovalCard(approval, mutable, state.deviceApprovalBusyId === approval.approvalId || submitted))
+  }
+  const approvalCount = state.approvals.length + (state.deviceApprovals?.length ?? 0)
+  approvalEmpty.hidden = approvalCount > 0
+  approvalList.hidden = approvalCount === 0
   approvalNotice.hidden = state.message === undefined
   approvalNotice.textContent = state.message ?? ''
   for (const count of document.querySelectorAll('[data-approval-count]')) {
-    count.textContent = String(state.approvals.length)
-    count.hidden = state.approvals.length === 0
+    count.textContent = String(approvalCount)
+    count.hidden = approvalCount === 0
   }
 }
 
@@ -570,6 +627,12 @@ approvalList.addEventListener('click', event => {
   if (button === null || card === null) return
   if (button.dataset.approvalAction === 'cancel') void conversationsClient.cancelApproval(card.dataset.approvalId)
   else void conversationsClient.decideApproval(card.dataset.approvalId, button.dataset.approvalAction)
+})
+approvalList.addEventListener('click', event => {
+  const button = event.target instanceof Element ? event.target.closest('[data-device-approval-action]') : null
+  const card = button?.closest('[data-device-approval-id]')
+  if (button === null || card === null) return
+  void conversationsClient.decideDeviceApproval(card.dataset.deviceApprovalId, button.dataset.deviceApprovalAction)
 })
 mobileConversationSelect.addEventListener('change', () => { void conversationsClient.select(mobileConversationSelect.value) })
 newConversationButton.addEventListener('click', () => { void conversationsClient.create() })

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=11'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=12'
 
 const CACHE_KEY = 'conversation-cache'
 const CURSOR_KEY = 'event-cursor'
@@ -71,6 +71,24 @@ function parseApprovalList(value) {
   return value.approvals.slice().sort((left, right) => (right.requestedAt ?? 0) - (left.requestedAt ?? 0))
 }
 
+function validDeviceApproval(value) {
+  return value !== null && typeof value === 'object' && ID_PATTERN.test(value.approvalId)
+    && (value.capability === 'lock.set' || value.capability === 'alarm.set')
+    && typeof value.externalEntityId === 'string' && value.externalEntityId.length > 0
+    && typeof value.service === 'string' && value.service.length > 0
+    && typeof value.expectedState === 'string' && value.expectedState.length > 0
+    && typeof value.digest === 'string' && /^[0-9a-f]{64}$/.test(value.digest)
+    && value.risk === 'high' && Number.isFinite(value.expiresAt)
+}
+
+function parseDeviceApprovalList(value) {
+  if (!Array.isArray(value?.approvals) || !value.approvals.every(validDeviceApproval)
+    || new Set(value.approvals.map(approval => approval.approvalId)).size !== value.approvals.length) {
+    throw new Error('Gateway 返回了无效智能设备审批列表')
+  }
+  return value.approvals.slice().sort((left, right) => right.expiresAt - left.expiresAt)
+}
+
 function parseCache(value) {
   if (value?.version !== 1 || !Array.isArray(value.conversations) || !value.conversations.every(validSummary)
     || (value.selectedId !== null && !ID_PATTERN.test(value.selectedId))
@@ -127,9 +145,13 @@ export class ConversationsClient {
     this.messages = []
     this.activity = []
     this.approvals = []
+    this.deviceApprovals = []
     this.approvalBusyId = null
+    this.deviceApprovalBusyId = null
     this.approvalDecisionKeys = new Map()
+    this.deviceApprovalDecisionKeys = new Map()
     this.approvalSubmittedIds = new Set()
+    this.deviceApprovalSubmittedIds = new Set()
     this.cachedAt = undefined
     this.socket = undefined
     this.reconnectTimer = undefined
@@ -166,9 +188,13 @@ export class ConversationsClient {
     this.loading = false
     this.sending = false
     this.approvals = []
+    this.deviceApprovals = []
     this.approvalBusyId = null
+    this.deviceApprovalBusyId = null
     this.approvalDecisionKeys.clear()
+    this.deviceApprovalDecisionKeys.clear()
     this.approvalSubmittedIds.clear()
+    this.deviceApprovalSubmittedIds.clear()
     this.clearReconnect()
     if (this.socket !== undefined) {
       const socket = this.socket
@@ -194,9 +220,13 @@ export class ConversationsClient {
     this.online = online
     if (!online) {
       this.approvals = []
+      this.deviceApprovals = []
       this.approvalBusyId = null
+      this.deviceApprovalBusyId = null
       this.approvalDecisionKeys.clear()
+      this.deviceApprovalDecisionKeys.clear()
       this.approvalSubmittedIds.clear()
+      this.deviceApprovalSubmittedIds.clear()
       this.clearReconnect()
       if (this.socket !== undefined) {
         const socket = this.socket
@@ -216,17 +246,27 @@ export class ConversationsClient {
     this.loading = true
     this.emit(this.conversations.length > 0 ? 'refreshing' : 'loading')
     try {
-      const [response, approvalsResponse] = await Promise.all([
+      const [response, approvalsResponse, deviceApprovalsResponse] = await Promise.all([
         this.pairing.authenticatedRequest('/v1/conversations'),
         this.pairing.authenticatedRequest('/v1/approvals'),
+        this.pairing.authenticatedRequest('/v1/device-approvals'),
       ])
       if (!response.ok) throw new Error(`无法读取对话 (${response.status})`)
       if (!approvalsResponse.ok) throw new Error(`无法读取审批 (${approvalsResponse.status})`)
+      if (!deviceApprovalsResponse.ok && deviceApprovalsResponse.status !== 503) {
+        throw new Error(`无法读取智能设备审批 (${deviceApprovalsResponse.status})`)
+      }
       this.conversations = parseConversationList(response.value)
       this.approvals = parseApprovalList(approvalsResponse.value)
+      this.deviceApprovals = deviceApprovalsResponse.status === 503
+        ? [] : parseDeviceApprovalList(deviceApprovalsResponse.value)
       const currentApprovalIds = new Set(this.approvals.map(approval => approval.id))
       for (const approvalId of this.approvalSubmittedIds) {
         if (!currentApprovalIds.has(approvalId)) this.approvalSubmittedIds.delete(approvalId)
+      }
+      const currentDeviceApprovalIds = new Set(this.deviceApprovals.map(approval => approval.approvalId))
+      for (const approvalId of this.deviceApprovalSubmittedIds) {
+        if (!currentDeviceApprovalIds.has(approvalId)) this.deviceApprovalSubmittedIds.delete(approvalId)
       }
       if (this.selectedId === null || !this.conversations.some(item => item.id === this.selectedId)) {
         this.selectedId = this.conversations[0]?.id ?? null
@@ -238,6 +278,7 @@ export class ConversationsClient {
       return true
     } catch (error) {
       this.approvals = []
+      this.deviceApprovals = []
       this.addActivity('同步失败')
       this.emit(this.conversations.length > 0 ? 'stale' : 'error', messageForError(error, '无法同步对话'))
       return false
@@ -372,6 +413,38 @@ export class ConversationsClient {
       errorMessage = messageForError(error, '取消本轮失败')
     } finally {
       this.approvalBusyId = null
+    }
+    this.emit(this.active && this.online ? 'ready' : 'stale', errorMessage)
+    return errorMessage === undefined
+  }
+
+  async decideDeviceApproval(approvalId, outcome) {
+    if (!this.active || !this.online || this.deviceApprovalBusyId !== null
+      || (outcome !== 'allowed-once' && outcome !== 'rejected')) return false
+    const approval = this.deviceApprovals.find(item => item.approvalId === approvalId)
+    if (approval === undefined || (outcome === 'allowed-once' && approval.expiresAt <= Date.now())) return false
+    this.deviceApprovalBusyId = approval.approvalId
+    this.emit('sending')
+    let errorMessage
+    try {
+      const decisionKey = `${approval.approvalId}:${outcome}:${approval.digest}`
+      const idempotencyKey = this.deviceApprovalDecisionKeys.get(decisionKey) ?? this.randomUUID()
+      this.deviceApprovalDecisionKeys.set(decisionKey, idempotencyKey)
+      const response = await this.pairing.authenticatedRequest(
+        `/v1/device-approvals/${encodeURIComponent(approval.approvalId)}/decision`,
+        { method: 'POST', body: JSON.stringify({ digest: approval.digest, outcome, idempotencyKey }) },
+      )
+      if (response.status !== 202 || response.value?.accepted !== true
+        || response.value.approvalId !== approval.approvalId || response.value.outcome !== outcome) {
+        throw new Error(`智能设备审批未被接受 (${response.status})`)
+      }
+      this.deviceApprovalSubmittedIds.add(approval.approvalId)
+      this.addActivity(outcome === 'allowed-once' ? '已允许智能设备操作一次' : '已拒绝智能设备操作')
+      await this.refresh()
+    } catch (error) {
+      errorMessage = messageForError(error, '智能设备审批提交失败')
+    } finally {
+      this.deviceApprovalBusyId = null
     }
     this.emit(this.active && this.online ? 'ready' : 'stale', errorMessage)
     return errorMessage === undefined
@@ -557,8 +630,11 @@ export class ConversationsClient {
       messages: this.messages.map(item => ({ ...item })),
       activity: this.activity.map(item => ({ ...item })),
       approvals: this.approvals.map(item => ({ ...item, arguments: item.arguments === null ? null : { ...item.arguments } })),
+      deviceApprovals: this.deviceApprovals.map(item => ({ ...item })),
       approvalBusyId: this.approvalBusyId,
+      deviceApprovalBusyId: this.deviceApprovalBusyId,
       approvalSubmittedIds: [...this.approvalSubmittedIds],
+      deviceApprovalSubmittedIds: [...this.deviceApprovalSubmittedIds],
       cachedAt: this.cachedAt,
       sending: this.sending,
       ...(message === undefined ? {} : { message }),

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js?v=11" type="module"></script>
+    <script src="./app.js?v=12" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,12 +1,12 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v11'
+const CACHE_NAME = 'jarvis-pwa-shell-v12'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js?v=11',
-  '/app/pairing.js?v=11',
-  '/app/device-store.js?v=11',
-  '/app/conversations.js?v=11',
-  '/app/notifications.js?v=11',
+  '/app/app.js?v=12',
+  '/app/pairing.js?v=12',
+  '/app/device-store.js?v=12',
+  '/app/conversations.js?v=12',
+  '/app/notifications.js?v=12',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',


### PR DESCRIPTION
## Summary
- load normalized smart-device approvals alongside the existing PWA snapshot
- render lock/alarm target, service, expected state, risk, and expiry in the approval workspace
- submit dedicated Gateway decisions with stable idempotency keys
- refresh the authoritative device approval list after a decision
- treat an unconfigured device-approval source as optional `503` capability
- bump the offline shell cache to v12 and cover the client contract/tests

## Verification
- `npm run verify` (153 tests)
- `npm run verify:runtime`
- `git diff --check`

## Evidence boundary
This PR adds PWA review/decision UI only. It does not add real-time device approval events, physical lock/alarm execution, or hardware acceptance.

Closes #66
Parent: #6
