### PR TITLE
Publish smart-device approval events through retained stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@
 - 已实现智能设备注册核心：规范化设备、位置、能力、风险、别名、稳定外部身份映射和带时间戳状态；暂未连接 Home Assistant、MQTT 或真实设备。
 - 已实现只读 Home Assistant WebSocket 协议核心：认证、确定性实体快照、状态事件过滤、删除实体降级、断线重连和全量重同步；真实 Home Assistant 地址、凭据、服务行为和硬件验收仍未完成。
 - 已实现低风险 Home Assistant 服务调用对账核心：灯、开关和普通媒体使用幂等键，服务确认与实际状态分离；只有后续目标状态被观察到才报告成功，中高风险动作和真实硬件验收仍需后续阶段。
-- 已实现智能家居高风险审批策略核心：锁和警报保持强制高风险，审批绑定精确命令摘要并只能消费一次；手机审批传输、真实锁/警报调用和硬件验收尚未接入。
-- Gateway 已提供独立的 `/v1/device-approvals` 会话接口，用于读取和幂等处理归一化的锁/警报审批记录；当前尚未接入 PWA 展示、事件推送或真实设备执行。
+- 已实现智能家居高风险审批策略核心：锁和警报保持强制高风险，审批绑定精确命令摘要并只能消费一次；PWA 审批工作区和实时事件传输已接入，真实锁/警报调用和硬件验收仍未完成。
+- Gateway 已提供独立的 `/v1/device-approvals` 会话接口，用于读取和幂等处理归一化的锁/警报审批记录；PWA 已展示该审批工作区，并通过 `/v1/events` 接收脱敏的 `device.approval.pending` / `device.approval.resolved` 事件。真实设备执行和物理验收仍未完成。
 
 ## 环境要求
 
@@ -101,7 +101,7 @@ JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:approve -- --code 1
 
 Owner Token 只提交给 loopback Gateway，不进入手机。Gateway 只持久化一次性领取密钥和设备凭据的 SHA-256 摘要；设备凭据通过领取密钥派生的 AES-256-GCM 密钥加密返回，重复领取返回同一密文。浏览器将不可导出的 P-256 私钥、设备凭据和短期 Session 保存在同源 IndexedDB；离线时只显示本地身份为非当前状态。清除站点数据会移除本地访问材料，但不会替代服务端设备撤销。
 
-短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages`、`POST /v1/conversations/:id/cancel`、`GET /v1/approvals`、`POST /v1/approvals/:id/decision` 以及 `GET/DELETE /v1/devices/current`。配对后的 PWA 可列出、新建、选择和继续文字对话，处理当前审批，并查看或撤销当前设备；设备状态响应只含名称、平台、凭据代次、配对时间和会话时限，不含公钥、凭据摘要或任何令牌。消息只接受最多 16 KiB 的纯文本，发送期间会锁定重复提交，远程 slash command 被拒绝。审批决定使用客户端幂等键，Gateway 将上游 `rpcId` 保留在 loopback 桥接层，手机只能提交 `allowed-once` 或 `rejected`；取消本轮沿用会话取消接口并由 Harness 产生 `cancelled`。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会先要求重新读取权威会话与审批快照，刷新失败时不会推进游标。
+短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages`、`POST /v1/conversations/:id/cancel`、`GET /v1/approvals`、`POST /v1/approvals/:id/decision`、`GET /v1/device-approvals`、`POST /v1/device-approvals/:id/decision` 以及 `GET/DELETE /v1/devices/current`。配对后的 PWA 可列出、新建、选择和继续文字对话，处理当前审批和智能设备审批，并查看或撤销当前设备；设备状态响应只含名称、平台、凭据代次、配对时间和会话时限，不含公钥、凭据摘要或任何令牌。消息只接受最多 16 KiB 的纯文本，发送期间会锁定重复提交，远程 slash command 被拒绝。审批决定使用客户端幂等键，Gateway 将上游 `rpcId` 保留在 loopback 桥接层，手机只能提交 `allowed-once` 或 `rejected`；取消本轮沿用会话取消接口并由 Harness 产生 `cancelled`。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；设备审批的请求和结果也会以不含服务数据或凭据的标准化事件进入 retained stream。若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会先要求重新读取权威会话与审批快照，刷新失败时不会推进游标。
 
 PWA 只在同源 IndexedDB 保存最近一次规范化对话列表、当前最多 50 条文字消息和事件游标，不缓存审批、API 响应或 Owner Token。Gateway 不可达时，离线壳可只读显示对话快照并明确标记为“旧数据”，审批详情会从页面内存清除；所有新建、发送和审批操作保持禁用，恢复连接并重新验证 Session 后才切回实时状态。
 

--- a/docs/plan/05-stage-4-smart-home.md
+++ b/docs/plan/05-stage-4-smart-home.md
@@ -115,8 +115,24 @@ Implemented in the current increment:
 
 Deferred to later increments:
 
-- PWA rendering, event-stream notifications, and real adapter dispatch.
-- Real lock/alarm service calls and physical-device acceptance.
+- Real adapter dispatch.
+- Physical lock/alarm service calls and hardware acceptance.
+
+### Real-time approval events
+
+Current increment: normalized smart-device approval lifecycle events tracked by [#68](https://github.com/gh503/jarvis/issues/68).
+
+Implemented in the current increment:
+
+- Approval sources can publish `device.approval.pending` and `device.approval.resolved` through the authenticated retained Gateway event stream.
+- Events use an explicit public allowlist and exclude service data, provider credentials, owner tokens, and raw adapter payloads.
+- PWA clients converge their smart-device approval list from live events and cursor-based replay without requiring polling.
+- Notification records use fixed redacted text and never include target service data.
+
+Deferred to later increments:
+
+- Dispatching an approved lock or alarm command through a real adapter.
+- Real Home Assistant or MQTT deployment evidence and physical-device acceptance.
 
 Acceptance:
 

--- a/src/device-approval.ts
+++ b/src/device-approval.ts
@@ -1,4 +1,5 @@
 import { APPROVAL_TTL_MS, ApprovalLedger, commandDigest } from './approval.js'
+import type { JarvisEventPayload } from './event-log.js'
 
 export type HighRiskDeviceCapability = 'lock.set' | 'alarm.set'
 
@@ -48,6 +49,7 @@ export interface DeviceApprovalSource {
     outcome: DeviceApprovalOutcome,
     idempotencyKey: string,
   ): DeviceApprovalDecisionReceipt | Promise<DeviceApprovalDecisionReceipt>
+  subscribe?(listener: (event: Extract<JarvisEventPayload, { type: `device.approval.${string}` }>) => void): () => void
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -151,12 +153,14 @@ interface StoredDeviceDecision {
 export class InMemoryDeviceApprovalStore implements DeviceApprovalSource {
   private readonly pending = new Map<string, PendingDeviceApproval>()
   private readonly decisions = new Map<string, StoredDeviceDecision>()
+  private readonly listeners = new Set<(event: Extract<JarvisEventPayload, { type: `device.approval.${string}` }>) => void>()
 
   constructor(private readonly gate = new DeviceApprovalGate()) {}
 
   request(approvalId: string, command: HighRiskDeviceCommand): DeviceApprovalRequest {
     const request = this.gate.request(approvalId, command)
     this.pending.set(request.approvalId, { command, request })
+    this.emit({ type: 'device.approval.pending', approval: { ...request } })
     return request
   }
 
@@ -191,6 +195,16 @@ export class InMemoryDeviceApprovalStore implements DeviceApprovalSource {
     else this.gate.cancel(normalizedApprovalId)
     const receipt = { approvalId: normalizedApprovalId, outcome, accepted: true as const }
     this.decisions.set(normalizedIdempotencyKey, { fingerprint, receipt })
+    this.emit({ type: 'device.approval.resolved', approvalId: normalizedApprovalId, outcome })
     return receipt
+  }
+
+  subscribe(listener: (event: Extract<JarvisEventPayload, { type: `device.approval.${string}` }>) => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private emit(event: Extract<JarvisEventPayload, { type: `device.approval.${string}` }>): void {
+    for (const listener of this.listeners) listener(event)
   }
 }

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'n
 import { dirname } from 'node:path'
 import type { ConversationMessage } from './harness-bridge.js'
 import type { MobileApproval, MobileApprovalOutcome } from './approval.js'
+import type { DeviceApprovalRequest, DeviceApprovalOutcome } from './device-approval.js'
 
 const DEFAULT_MAX_EVENTS = 512
 const DEFAULT_MAX_BYTES = 8 * 1024 * 1024
@@ -19,6 +20,8 @@ export type JarvisEventPayload =
   | { type: 'conversation.error'; conversationId: string; code: 'harness_agent_error' }
   | { type: 'approval.pending'; approval: MobileApproval }
   | { type: 'approval.resolved'; approvalId: string; conversationId: string; outcome: MobileApprovalOutcome | 'cancelled' | 'unavailable' }
+  | { type: 'device.approval.pending'; approval: DeviceApprovalRequest }
+  | { type: 'device.approval.resolved'; approvalId: string; outcome: DeviceApprovalOutcome }
   | { type: 'sync.required'; reason: SyncReason }
 
 export type JarvisEvent = JarvisEventPayload & {
@@ -107,6 +110,18 @@ function validApproval(value: unknown): value is MobileApproval {
     && (value.blockReason === 'evidence_missing' || value.blockReason === 'unsupported_action')
 }
 
+function validDeviceApproval(value: unknown): value is DeviceApprovalRequest {
+  return record(value) && exactFields(value, [
+    'approvalId', 'capability', 'externalEntityId', 'service', 'expectedState', 'digest', 'risk', 'expiresAt',
+  ]) && validId(value.approvalId)
+    && (value.capability === 'lock.set' || value.capability === 'alarm.set')
+    && typeof value.externalEntityId === 'string' && value.externalEntityId.length > 0 && value.externalEntityId.length <= 256
+    && typeof value.service === 'string' && value.service.length > 0 && value.service.length <= 64
+    && typeof value.expectedState === 'string' && value.expectedState.length > 0 && value.expectedState.length <= 128
+    && typeof value.digest === 'string' && /^[0-9a-f]{64}$/.test(value.digest)
+    && value.risk === 'high' && typeof value.expiresAt === 'number' && Number.isFinite(value.expiresAt)
+}
+
 function validPayload(value: Record<string, unknown>): boolean {
   if (value.type === 'conversation.created') {
     return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'conversation'])
@@ -138,6 +153,14 @@ function validPayload(value: Record<string, unknown>): boolean {
       && validId(value.approvalId) && validId(value.conversationId)
       && (value.outcome === 'allowed-once' || value.outcome === 'rejected'
         || value.outcome === 'cancelled' || value.outcome === 'unavailable')
+  }
+  if (value.type === 'device.approval.pending') {
+    return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'approval'])
+      && validDeviceApproval(value.approval)
+  }
+  if (value.type === 'device.approval.resolved') {
+    return exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'approvalId', 'outcome'])
+      && validId(value.approvalId) && (value.outcome === 'allowed-once' || value.outcome === 'rejected')
   }
   return value.type === 'sync.required' && exactFields(value, ['version', 'eventId', 'cursor', 'occurredAt', 'type', 'reason'])
     && (value.reason === 'gateway_restarted' || value.reason === 'harness_disconnected')

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -344,6 +344,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
   let server: GatewayServer | undefined
   let nodeSocketServer: WebSocketServer | undefined
   let eventSocketServer: WebSocketServer | undefined
+  let deviceApprovalUnsubscribe: (() => void) | undefined
   let harnessAvailable = false
   let harnessWasAvailable = false
   const nodeConnections = new Map<string, WebSocket>()
@@ -1094,6 +1095,7 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
           const host = binding.host.includes(':') ? `[${binding.host}]` : binding.host
           const protocol = secure ? 'https' : 'http'
           try {
+            deviceApprovalUnsubscribe = options.deviceApprovals?.subscribe?.(event => eventLog.publish(event))
             harnessEvents.start({
               onEvent: event => { eventLog.publish(event) },
               onAvailability: handleHarnessAvailability,
@@ -1105,6 +1107,8 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
             eventSocketServer?.close()
             nodeSocketServer = undefined
             eventSocketServer = undefined
+            deviceApprovalUnsubscribe?.()
+            deviceApprovalUnsubscribe = undefined
             failedServer?.close()
             reject(error)
             return
@@ -1127,6 +1131,8 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
       server = undefined
       nodeSocketServer = undefined
       eventSocketServer = undefined
+      deviceApprovalUnsubscribe?.()
+      deviceApprovalUnsubscribe = undefined
       for (const state of connectionStates.values()) clearTimeout(state.handshakeTimer)
       for (const state of eventConnectionStates.values()) {
         clearTimeout(state.handshakeTimer)

--- a/test/conversations.test.js
+++ b/test/conversations.test.js
@@ -10,6 +10,10 @@ const approval = {
   action: 'open_app', target: 'notes', arguments: { application: 'notes' }, digest: 'a'.repeat(64), risk: 'high',
   requestedAt: 1_000, expiresAt: Date.now() + 60_000, canAllow: true, blockReason: null,
 }
+const deviceApproval = {
+  approvalId: 'device-approval-one', capability: 'lock.set', externalEntityId: 'lock.front_door',
+  service: 'lock_unlock', expectedState: 'unlocked', digest: 'b'.repeat(64), risk: 'high', expiresAt: Date.now() + 60_000,
+}
 
 function memoryStore() {
   const values = new Map()
@@ -354,6 +358,18 @@ test('converges live approval requested and resolved events', async () => {
   })
   await tick()
   assert.deepEqual(states.at(-1).approvals, [])
+  sockets[0].message({
+    version: 1, type: 'device.approval.pending', cursor: `${'A'.repeat(22)}.4`, occurredAt: 4_000,
+    approval: deviceApproval,
+  })
+  await tick()
+  assert.deepEqual(states.at(-1).deviceApprovals, [deviceApproval])
+  sockets[0].message({
+    version: 1, type: 'device.approval.resolved', cursor: `${'A'.repeat(22)}.5`, occurredAt: 5_000,
+    approvalId: deviceApproval.approvalId, outcome: 'rejected',
+  })
+  await tick()
+  assert.deepEqual(states.at(-1).deviceApprovals, [])
 })
 
 test('converges a server-side device revocation across an active browser tab', async () => {

--- a/test/device-approval.test.js
+++ b/test/device-approval.test.js
@@ -61,6 +61,8 @@ test('digest is stable across object key order but changes target or arguments',
 
 test('stores normalized pending approvals and makes decisions idempotently without exposing commands', () => {
   const store = new InMemoryDeviceApprovalStore(new DeviceApprovalGate(() => 1_000))
+  const events = []
+  store.subscribe(event => events.push(event))
   const request = store.request('approval-lock-1', command())
   assert.deepEqual(store.listApprovals(), [request])
   const receipt = store.decideApproval('approval-lock-1', request.digest, 'allowed-once', 'decision-1')
@@ -69,6 +71,10 @@ test('stores normalized pending approvals and makes decisions idempotently witho
   assert.deepEqual(store.decideApproval('approval-lock-1', request.digest, 'allowed-once', 'decision-1'), receipt)
   assert.throws(() => store.decideApproval('approval-lock-1', request.digest, 'allowed-once', 'decision-2'), /missing or already resolved/)
   assert.doesNotMatch(JSON.stringify(store.listApprovals()), /provider-secret/)
+  assert.deepEqual(events, [
+    { type: 'device.approval.pending', approval: request },
+    { type: 'device.approval.resolved', approvalId: request.approvalId, outcome: 'allowed-once' },
+  ])
 })
 
 test('rejects conflicting decision retries and mismatched digests', () => {

--- a/test/event-log.test.js
+++ b/test/event-log.test.js
@@ -88,6 +88,21 @@ test('persists public approval events without Harness transport identifiers', as
   }
 })
 
+test('retains redacted smart-device approval events and rejects private fields', () => {
+  const log = new RetainedEventLog()
+  const approval = {
+    approvalId: 'device-approval-one', capability: 'lock.set', externalEntityId: 'lock.front_door',
+    service: 'lock_unlock', expectedState: 'unlocked', digest: 'b'.repeat(64), risk: 'high', expiresAt: 61_000,
+  }
+  const pending = log.publish({ type: 'device.approval.pending', approval })
+  const resolved = log.publish({ type: 'device.approval.resolved', approvalId: approval.approvalId, outcome: 'rejected' })
+  assert.deepEqual(log.replay().events, [])
+  assert.deepEqual(log.replay(pending.cursor).events, [resolved])
+  assert.throws(() => log.publish({
+    type: 'device.approval.pending', approval: { ...approval, serviceData: { token: 'private' } },
+  }), /payload/)
+})
+
 test('rejects invalid payloads and oversized single events before publication', () => {
   const log = new RetainedEventLog({ maxBytes: 256 })
   assert.throws(() => log.publish({ type: 'conversation.status', conversationId: '../private', running: true }), /payload/)

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -988,6 +988,79 @@ test('authenticates normalized smart-device approvals without exposing command p
   }
 })
 
+test('publishes smart-device approval lifecycle events and replays them to authenticated clients', async () => {
+  const authority = new PairingAuthority()
+  issueCredential(authority)
+  const sessions = new SessionAuthority()
+  const access = sessions.issue('node-1')
+  const deviceApprovals = new InMemoryDeviceApprovalStore(new DeviceApprovalGate(() => 1_000))
+  const harnessEvents = fakeConversationEvents()
+  const service = createJarvisGateway({ ownerToken, authority, sessions, deviceApprovals, harnessEvents })
+  const gateway = await service.start()
+  const endpoint = `ws://127.0.0.1:${gateway.port}/v1/events`
+  const sockets = []
+  const nextEvent = (inbox, label) => Promise.race([
+    inbox.next(),
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), 2_000)),
+  ])
+  const command = {
+    commandId: 'lock-command-live', idempotencyKey: 'lock-once-live', capability: 'lock.set',
+    externalEntityId: 'lock.front_door', service: 'lock_unlock', serviceData: { token: 'secret' }, expectedState: 'unlocked',
+  }
+  try {
+    const socket = new WebSocket(endpoint)
+    sockets.push(socket)
+    const inbox = socketInbox(socket)
+    await new Promise((resolve, reject) => {
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    })
+    socket.send(JSON.stringify({ type: 'events.authenticate', accessToken: access.accessToken }))
+    const ready = await nextEvent(inbox, 'initial ready')
+    assert.equal(ready.type, 'events.ready')
+
+    const pending = deviceApprovals.request('device-approval-live', command)
+    let pendingEvent = await nextEvent(inbox, 'device approval pending')
+    while (pendingEvent.type !== 'device.approval.pending') pendingEvent = await nextEvent(inbox, 'device approval pending after sync')
+    assert.deepEqual({
+      type: pendingEvent.type, approval: pendingEvent.approval, serviceData: pendingEvent.approval.serviceData,
+    }, { type: 'device.approval.pending', approval: pending, serviceData: undefined })
+    socket.send(JSON.stringify({ type: 'events.ack', cursor: pendingEvent.cursor }))
+
+    deviceApprovals.decideApproval('device-approval-live', pending.digest, 'rejected', 'decision-live')
+    const resolvedEvent = await nextEvent(inbox, 'device approval resolved')
+    assert.deepEqual({
+      type: resolvedEvent.type, approvalId: resolvedEvent.approvalId, outcome: resolvedEvent.outcome,
+    }, { type: 'device.approval.resolved', approvalId: pending.approvalId, outcome: 'rejected' })
+    socket.send(JSON.stringify({ type: 'events.ack', cursor: resolvedEvent.cursor }))
+    const socketClosed = new Promise((resolve, reject) => {
+      socket.once('close', resolve)
+      socket.once('error', reject)
+    })
+    socket.close()
+    await socketClosed
+
+    const replaySocket = new WebSocket(endpoint)
+    sockets.push(replaySocket)
+    const replayInbox = socketInbox(replaySocket)
+    await new Promise((resolve, reject) => {
+      replaySocket.once('open', resolve)
+      replaySocket.once('error', reject)
+    })
+    replaySocket.send(JSON.stringify({ type: 'events.authenticate', accessToken: access.accessToken, cursor: ready.cursor }))
+    const replayReady = await nextEvent(replayInbox, 'replay ready')
+    assert.equal(replayReady.type, 'events.ready')
+    const replayed = []
+    for (let index = 0; index < replayReady.replayCount; index += 1) replayed.push(await nextEvent(replayInbox, 'replayed event'))
+    assert.deepEqual(replayed.filter(event => event.type.startsWith('device.approval.')).map(event => event.type), [
+      'device.approval.pending', 'device.approval.resolved',
+    ])
+  } finally {
+    for (const socket of sockets) socket.terminate()
+    await service.stop()
+  }
+})
+
 test('authenticates conversation events, replays retained cursors, and closes revoked sessions', async () => {
   const authority = new PairingAuthority()
   issueCredential(authority)

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -227,6 +227,18 @@ test('creates redacted, deduplicated notifications from normalized events', asyn
   const restarted = new NotificationCenter({ store, permission: 'default' })
   await restarted.initialize()
   assert.equal(restarted.history[0].id, 'approval:approval-1:pending')
+
+  const deviceEvent = {
+    version: 1, cursor: 'A'.repeat(22) + '.9', occurredAt: 1_700_000_000_001,
+    type: 'device.approval.pending',
+    approval: {
+      approvalId: 'device-approval-1', capability: 'lock.set', externalEntityId: 'lock.front_door',
+      service: 'lock_unlock', expectedState: 'unlocked', digest: 'b'.repeat(64), risk: 'high', expiresAt: 1_700_000_060_000,
+    },
+  }
+  assert.equal(await center.ingestEvent(deviceEvent), true)
+  assert.equal(systemNotifications.at(-1).body.includes('lock.front_door'), false)
+  assert.deepEqual(systemNotifications.at(-1).resource, { view: 'activity', approvalId: 'device-approval-1' })
 })
 
 test('quiet hours and rate limits suppress system presentation but retain history', async () => {

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -74,9 +74,9 @@ function parseApprovalList(value) {
 function validDeviceApproval(value) {
   return value !== null && typeof value === 'object' && ID_PATTERN.test(value.approvalId)
     && (value.capability === 'lock.set' || value.capability === 'alarm.set')
-    && typeof value.externalEntityId === 'string' && value.externalEntityId.length > 0
-    && typeof value.service === 'string' && value.service.length > 0
-    && typeof value.expectedState === 'string' && value.expectedState.length > 0
+    && typeof value.externalEntityId === 'string' && value.externalEntityId.length > 0 && value.externalEntityId.length <= 256
+    && typeof value.service === 'string' && value.service.length > 0 && value.service.length <= 64
+    && typeof value.expectedState === 'string' && value.expectedState.length > 0 && value.expectedState.length <= 128
     && typeof value.digest === 'string' && /^[0-9a-f]{64}$/.test(value.digest)
     && value.risk === 'high' && Number.isFinite(value.expiresAt)
 }
@@ -118,6 +118,8 @@ function eventDescription(event) {
   if (event.type === 'conversation.error') return '对话执行失败'
   if (event.type === 'approval.pending') return '收到待审批操作'
   if (event.type === 'approval.resolved') return event.outcome === 'allowed-once' ? '操作已允许一次' : '操作未获允许'
+  if (event.type === 'device.approval.pending') return '收到智能设备待审批操作'
+  if (event.type === 'device.approval.resolved') return event.outcome === 'allowed-once' ? '智能设备操作已允许一次' : '智能设备操作未获允许'
   return '正在重新同步对话'
 }
 
@@ -576,6 +578,16 @@ export class ConversationsClient {
       this.approvalSubmittedIds.delete(event.approvalId)
       for (const key of this.approvalDecisionKeys.keys()) {
         if (key.startsWith(`${event.approvalId}:`)) this.approvalDecisionKeys.delete(key)
+      }
+    } else if (event.type === 'device.approval.pending' && validDeviceApproval(event.approval)) {
+      this.deviceApprovals = [event.approval, ...this.deviceApprovals.filter(item => item.approvalId !== event.approval.approvalId)]
+        .sort((left, right) => right.expiresAt - left.expiresAt)
+    } else if (event.type === 'device.approval.resolved' && ID_PATTERN.test(event.approvalId)
+      && ['allowed-once', 'rejected'].includes(event.outcome)) {
+      this.deviceApprovals = this.deviceApprovals.filter(item => item.approvalId !== event.approvalId)
+      this.deviceApprovalSubmittedIds.delete(event.approvalId)
+      for (const key of this.deviceApprovalDecisionKeys.keys()) {
+        if (key.startsWith(`${event.approvalId}:`)) this.deviceApprovalDecisionKeys.delete(key)
       }
     } else {
       socket.close(CLOSE_PROTOCOL, 'unsupported event')

--- a/web/notifications.js
+++ b/web/notifications.js
@@ -77,6 +77,20 @@ function notificationForEvent(event) {
       resource: { view: 'activity', approvalId: event.approvalId },
     }
   }
+  if (event.type === 'device.approval.pending' && RESOURCE_ID_PATTERN.test(event.approval?.approvalId ?? '')) {
+    return {
+      id: `device-approval:${event.approval.approvalId}:pending`, category: 'approval',
+      title: '有一项智能设备审批等待处理', body: 'Jarvis 有一项高风险智能设备操作等待你的决定。',
+      resource: { view: 'activity', approvalId: event.approval.approvalId },
+    }
+  }
+  if (event.type === 'device.approval.resolved' && RESOURCE_ID_PATTERN.test(event.approvalId ?? '')) {
+    return {
+      id: `device-approval:${event.approvalId}:resolved`, category: 'approval',
+      title: '智能设备审批状态已更新', body: 'Jarvis 的一项智能设备操作审批已经完成。',
+      resource: { view: 'activity', approvalId: event.approvalId },
+    }
+  }
   if (event.type === 'conversation.status' && RESOURCE_ID_PATTERN.test(event.conversationId ?? '')
     && event.running === false) {
     return {


### PR DESCRIPTION
## Summary
- add redacted `device.approval.pending` and `device.approval.resolved` event contracts
- publish device approval lifecycle changes through the authenticated retained Gateway stream
- converge PWA smart-device approvals and notifications from live events and cursor replay
- document the increment and explicitly defer real adapter dispatch and physical hardware acceptance

Closes #68

## Verification
- `npm run verify`
- `npm run verify:runtime`
- `git diff --check`

Evidence remains limited to unit tests, fake WebSockets, local Gateway/Harness runtime checks, and source-level privacy validation. No real Home Assistant deployment or physical lock/alarm acceptance is claimed.
