### PR TITLE
Connect approved device decisions to execution handlers

### DIFF
--- a/docs/plan/05-stage-4-smart-home.md
+++ b/docs/plan/05-stage-4-smart-home.md
@@ -150,6 +150,21 @@ Deferred to later increments:
 - Dispatching an approved lock or alarm command through a real adapter.
 - Real Home Assistant or MQTT deployment evidence and physical-device acceptance.
 
+### Trusted approval execution handler
+
+Current increment: trusted in-process approval-to-adapter execution tracked by [#72](https://github.com/gh503/jarvis/issues/72).
+
+Implemented in the current increment:
+
+- `InMemoryDeviceApprovalStore` can invoke a trusted execution handler only after an allowed decision has passed exact digest, expiry, and idempotency checks.
+- The handler receives the original command and private authorization; public receipts and retained events remain normalized.
+- The Home Assistant fake-socket test covers the complete decision-to-service-call-to-observed-state path.
+
+Deferred to later increments:
+
+- Cross-process runtime configuration between the Harness tool producer and Gateway-owned device bridge.
+- Real Home Assistant credentials, deployment, and physical-device evidence.
+
 Acceptance:
 
 - Reconnect does not duplicate state events or service calls.

--- a/src/device-approval.ts
+++ b/src/device-approval.ts
@@ -41,6 +41,13 @@ export interface DeviceApprovalDecisionReceipt {
   accepted: true
 }
 
+export interface DeviceApprovalExecution {
+  command: HighRiskDeviceCommand
+  authorization: DeviceApprovalAuthorization
+}
+
+export type DeviceApprovalExecutionHandler = (execution: DeviceApprovalExecution) => void
+
 export interface DeviceApprovalSource {
   listApprovals(): readonly DeviceApprovalRequest[]
   decideApproval(
@@ -159,7 +166,10 @@ export class InMemoryDeviceApprovalStore implements DeviceApprovalSource {
   private readonly decisions = new Map<string, StoredDeviceDecision>()
   private readonly listeners = new Set<(event: Extract<JarvisEventPayload, { type: `device.approval.${string}` }>) => void>()
 
-  constructor(private readonly gate = new DeviceApprovalGate()) {}
+  constructor(
+    private readonly gate = new DeviceApprovalGate(),
+    private readonly onAllowed?: DeviceApprovalExecutionHandler,
+  ) {}
 
   request(approvalId: string, command: HighRiskDeviceCommand): DeviceApprovalRequest {
     const request = this.gate.request(approvalId, command)
@@ -195,11 +205,14 @@ export class InMemoryDeviceApprovalStore implements DeviceApprovalSource {
     if (pending === undefined) throw new Error('device approval is missing or already resolved')
     if (pending.request.digest !== normalizedDigest) throw new Error('device approval digest does not match')
     this.pending.delete(normalizedApprovalId)
-    if (outcome === 'allowed-once') this.gate.authorize(normalizedApprovalId, pending.command)
-    else this.gate.cancel(normalizedApprovalId)
+    const authorization = outcome === 'allowed-once'
+      ? this.gate.authorize(normalizedApprovalId, pending.command)
+      : undefined
+    if (outcome === 'rejected') this.gate.cancel(normalizedApprovalId)
     const receipt = { approvalId: normalizedApprovalId, outcome, accepted: true as const }
     this.decisions.set(normalizedIdempotencyKey, { fingerprint, receipt })
     this.emit({ type: 'device.approval.resolved', approvalId: normalizedApprovalId, outcome })
+    if (authorization !== undefined) this.onAllowed?.({ command: pending.command, authorization })
     return receipt
   }
 

--- a/test/device-approval.test.js
+++ b/test/device-approval.test.js
@@ -60,7 +60,8 @@ test('digest is stable across object key order but changes target or arguments',
 })
 
 test('stores normalized pending approvals and makes decisions idempotently without exposing commands', () => {
-  const store = new InMemoryDeviceApprovalStore(new DeviceApprovalGate(() => 1_000))
+  const executions = []
+  const store = new InMemoryDeviceApprovalStore(new DeviceApprovalGate(() => 1_000), execution => executions.push(execution))
   const events = []
   store.subscribe(event => events.push(event))
   const request = store.request('approval-lock-1', command())
@@ -71,6 +72,7 @@ test('stores normalized pending approvals and makes decisions idempotently witho
   assert.deepEqual(store.decideApproval('approval-lock-1', request.digest, 'allowed-once', 'decision-1'), receipt)
   assert.throws(() => store.decideApproval('approval-lock-1', request.digest, 'allowed-once', 'decision-2'), /missing or already resolved/)
   assert.doesNotMatch(JSON.stringify(store.listApprovals()), /provider-secret/)
+  assert.equal(executions.length, 1)
   assert.deepEqual(events, [
     { type: 'device.approval.pending', approval: request },
     { type: 'device.approval.resolved', approvalId: request.approvalId, outcome: 'allowed-once' },
@@ -78,9 +80,11 @@ test('stores normalized pending approvals and makes decisions idempotently witho
 })
 
 test('rejects conflicting decision retries and mismatched digests', () => {
-  const store = new InMemoryDeviceApprovalStore(new DeviceApprovalGate(() => 1_000))
+  const executions = []
+  const store = new InMemoryDeviceApprovalStore(new DeviceApprovalGate(() => 1_000), execution => executions.push(execution))
   const request = store.request('approval-lock-1', command())
   assert.throws(() => store.decideApproval('approval-lock-1', 'b'.repeat(64), 'allowed-once', 'decision-0'), /does not match/)
   store.decideApproval('approval-lock-1', request.digest, 'allowed-once', 'decision-1')
   assert.throws(() => store.decideApproval('approval-lock-1', request.digest, 'rejected', 'decision-1'), /idempotency key conflict/)
+  assert.equal(executions.length, 1)
 })

--- a/test/home-assistant.test.js
+++ b/test/home-assistant.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { DeviceApprovalGate } from '../dist/device-approval.js'
+import { DeviceApprovalGate, InMemoryDeviceApprovalStore } from '../dist/device-approval.js'
 import { HomeAssistantAdapter } from '../dist/home-assistant.js'
 
 class FakeSocket {
@@ -247,6 +247,45 @@ test('requires an exact single-use approval before dispatching lock or alarm ser
   })
   assert.equal(expired.state, 'failed')
   assert.match(expired.error, /invalid or expired/)
+})
+
+test('executes an approved device decision through the trusted adapter handler', async () => {
+  const context = createAdapter({ now: () => 1_000 })
+  context.adapter.start()
+  completeHandshake(context.sockets[0], [entity({
+    entity_id: 'lock.front_door', state: 'locked',
+    attributes: { friendly_name: 'Front door', area_name: 'Entry' },
+  })])
+  const executions = []
+  let executionPromise
+  const store = new InMemoryDeviceApprovalStore(new DeviceApprovalGate(() => 1_000, 60_000), execution => {
+    executions.push(execution)
+    executionPromise = context.adapter.callApprovedService({ ...execution.command, timeoutMs: 1_000 }, execution.authorization)
+  })
+  const command = {
+    commandId: 'command-lock-handler', idempotencyKey: 'once-lock-handler', capability: 'lock.set',
+    externalEntityId: 'lock.front_door', service: 'unlock', expectedState: 'unlocked',
+  }
+  const pending = store.request('device-approval-handler', command)
+  store.decideApproval(pending.approvalId, pending.digest, 'allowed-once', 'decision-handler')
+  assert.equal(executions.length, 1)
+  assert.equal(executions[0].command.serviceData, undefined)
+  assert.deepEqual(context.sockets[0].sent[3], {
+    id: 3, type: 'call_service', domain: 'lock', service: 'unlock', service_data: {}, target: { entity_id: 'lock.front_door' },
+  })
+  context.sockets[0].frame({ type: 'result', id: 3, success: true, result: {} })
+  context.sockets[0].frame({
+    type: 'event', id: 2, event: {
+      event_type: 'state_changed', data: {
+        entity_id: 'lock.front_door', new_state: entity({
+          entity_id: 'lock.front_door', state: 'unlocked', last_updated: '2026-08-17T01:01:00.000Z',
+          attributes: { friendly_name: 'Front door', area_name: 'Entry' },
+        }),
+      },
+    },
+  })
+  assert.equal((await executionPromise).state, 'succeeded')
+  assert.equal(context.sockets[0].sent.length, 4)
 })
 
 test('returns acknowledged-unconfirmed when the service is accepted but state never reaches target', async () => {


### PR DESCRIPTION
## Summary
- add a trusted in-process execution handler to `InMemoryDeviceApprovalStore`
- invoke it only after an allowed decision passes exact digest, expiry, and idempotency checks
- carry the private command and authorization to Home Assistant `callApprovedService` without changing public receipts/events
- cover the full fake-socket path from PWA-style decision to service acknowledgement and observed target state
- document the remaining cross-process runtime wiring and real-device evidence boundary

Closes #72

## Verification
- `npm run verify` (157 tests)
- `npm run verify:runtime`
- `git diff --check`

No real Home Assistant deployment or physical lock/alarm acceptance is claimed.
