### PR TITLE
Expose bounded MQTT device commands through Gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DEEPSEEK_API_KEY=replace-with-your-key
 # JARVIS_MQTT_USERNAME=device-scoped-user
 # JARVIS_MQTT_PASSWORD=keep-this-local-and-uncommitted
 # JARVIS_MQTT_CLIENT_ID=jarvis-mac-mqtt
+# JARVIS_MQTT_DEVICE_ID=constrained-device-1
 # JARVIS_HARNESS_URL=http://127.0.0.1:3080
 # JARVIS_HARNESS_TIMEOUT_MS=10000
 # JARVIS_GATEWAY_TLS_KEY=/absolute/path/to/private/tls-key.pem

--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@
 - 配对后的 PWA 可读取 Gateway 认可的当前设备与会话状态，并可在设置中撤销自身设备凭据；撤销会关闭该设备全部会话与实时连接，并清除浏览器中的身份、令牌、对话快照和事件游标。
 - 配对后的 PWA 提供隐私优先的应用内通知中心；审批、对话完成和连接事件只生成固定摘要，支持分类开关、静默时段、每小时系统通知上限、已读/清空和显式系统通知授权。
 - 已提供离线一致性备份和原子恢复命令；运行租约阻止在 Harness 或 Gateway 活跃时复制状态，恢复前校验结构、权限和 SHA-256。
-- 已实现智能设备注册核心：规范化设备、位置、能力、风险、别名、稳定外部身份映射和带时间戳状态；暂未连接 Home Assistant、MQTT 或真实设备。
-- 已实现只读 Home Assistant WebSocket 协议核心：认证、确定性实体快照、状态事件过滤、删除实体降级、断线重连和全量重同步；真实 Home Assistant 地址、凭据、服务行为和硬件验收仍未完成。
+- 已实现智能设备注册核心：规范化设备、位置、能力、风险、别名、稳定外部身份映射和带时间戳状态；真实设备验收仍未完成。
+- 已实现只读 Home Assistant WebSocket 协议核心及可选 Gateway 运行时装配：认证、确定性实体快照、状态事件过滤、删除实体降级、断线重连和全量重同步；真实 Home Assistant 地址、凭据、服务行为和硬件验收仍未完成。
 - 已实现低风险 Home Assistant 服务调用对账核心：灯、开关和普通媒体使用幂等键，服务确认与实际状态分离；只有后续目标状态被观察到才报告成功，中高风险动作和真实硬件验收仍需后续阶段。
 - 已实现智能家居高风险审批策略核心：锁和警报保持强制高风险，审批绑定精确命令摘要并只能消费一次；PWA 审批工作区、实时事件传输和带授权的 Home Assistant 锁/警报服务调用核心已接入，真实部署和硬件验收仍未完成。
 - Gateway 已提供独立的 `/v1/device-approvals` 会话接口，用于读取和幂等处理归一化的锁/警报审批记录；PWA 已展示该审批工作区，并通过 `/v1/events` 接收脱敏的 `device.approval.pending` / `device.approval.resolved` 事件。真实设备执行和物理验收仍未完成。
+- 已提供可选的 MQTT 5 设备适配器和 Gateway 低风险命令通道；默认不连接 Broker，真实 Broker、设备凭据和物理设备验收仍需单独配置与验证。
 
 ## 环境要求
 
@@ -116,9 +117,10 @@ export JARVIS_MQTT_URL='mqtts://broker.example:8883'
 export JARVIS_MQTT_USERNAME='device-scoped-user'
 export JARVIS_MQTT_PASSWORD='keep-this-local-and-uncommitted'
 export JARVIS_MQTT_CLIENT_ID='jarvis-mac-mqtt'
+export JARVIS_MQTT_DEVICE_ID='constrained-device-1'
 ```
 
-适配器固定在 `jarvis/v1/devices/{deviceId}/` topic 范围内，命令带有 MQTT message expiry 和 Jarvis 侧过期时间；相同幂等键不会重复发布，设备确认与最终结果分开处理。当前增量提供协议和运行时传输层，尚未声称连接了真实 Broker、定制硬件或完成物理设备验收。
+适配器固定在 `jarvis/v1/devices/{deviceId}/` topic 范围内，命令带有 MQTT message expiry 和 Jarvis 侧过期时间；相同幂等键不会重复发布，设备确认与最终结果分开处理。配置 `JARVIS_DEVICE_COMMAND_TOKEN` 后，Harness 可使用 `jarvis_mqtt_device_control` 提交 `switch.set`、`light.set`、`media.play_pause` 或 `cover.set`；锁和警报仍必须走审批工具。当前仍未声称连接了真实 Broker、定制硬件或完成物理设备验收。
 
 默认模式只监听 `127.0.0.1:3090`，并只连接 `http://127.0.0.1:3080` 的 Harness。可用 `JARVIS_HARNESS_URL` 指向其他 `127.0.0.1` 端口，`JARVIS_HARNESS_TIMEOUT_MS` 默认 10000；非 loopback Harness 地址会在启动前被拒绝。配对状态原子写入未纳入 Git 的 `data/pairing-state.json`。节点和客户端 WebSocket 分别只接受 `/v1/node` 与 `/v1/events`，并各自限制消息大小、握手时间和连接数。
 

--- a/docs/plan/05-stage-4-smart-home.md
+++ b/docs/plan/05-stage-4-smart-home.md
@@ -35,7 +35,7 @@ Acceptance:
 
 ### `src/device-registry`
 
-Current increment: normalized registry core only. It is provider-independent and does not connect to Home Assistant, MQTT, or physical devices.
+Current increment: normalized registry core. It is provider-independent; provider runtime adapters remain separately configured and physical devices are not assumed.
 
 Deliver:
 
@@ -57,8 +57,8 @@ Implemented in the current increment:
 
 Deferred to later increments:
 
-- Home Assistant discovery/subscription and medium/high-risk service calls.
-- MQTT transport and duplicate-delivery handling.
+- Gateway/provider runtime assembly and medium/high-risk service calls.
+- Physical device discovery and acceptance evidence.
 - Simulator protocol behavior and real-device acceptance.
 
 ### `src/home-assistant`
@@ -131,7 +131,6 @@ Implemented in the current increment:
 
 Deferred to later increments:
 
-- Wiring a real Jarvis device command producer to this adapter.
 - Named Home Assistant instance, real lock/alarm behavior, and physical acceptance evidence.
 
 ### Real-time approval events
@@ -177,7 +176,6 @@ Implemented in the current increment:
 
 Deferred to later increments:
 
-- Real Home Assistant adapter assembly and provider credential configuration.
 - Real device execution and physical acceptance evidence.
 
 ### Configured Home Assistant execution wiring
@@ -239,7 +237,7 @@ Acceptance:
 
 ### `packages/device-mqtt`
 
-Current increment: scoped MQTT adapter and runtime transport tracked by [#78](https://github.com/gh503/jarvis/issues/78).
+Current increment: scoped MQTT adapter, runtime transport, and Gateway command path tracked by [#78](https://github.com/gh503/jarvis/issues/78) and [#80](https://github.com/gh503/jarvis/issues/80).
 
 Implemented in the current increment:
 
@@ -248,10 +246,13 @@ Implemented in the current increment:
 - Commands carry a bounded expiry and MQTT message expiry, while idempotency prevents duplicate or conflicting command delivery from creating a second publish.
 - The runtime transport uses the pinned MQTT client, supports `mqtt`/`mqtts`, keeps credentials in memory, and rejects embedded URL credentials.
 - Acknowledgement, observed state, terminal results, unavailable connection state, and retained-message expiry remain distinct.
+- A loopback-only Gateway route reuses the separate `DeviceCommand` token and returns only normalized command outcomes.
+- The Harness tool exposes only `switch.set`, `light.set`, `media.play_pause`, and `cover.set`; lock and alarm actions remain on the high-risk approval path.
+- Gateway startup survives an unavailable Broker, while command requests return an explicit unavailable outcome until the adapter is ready.
 
 Deferred to later increments:
 
-- Gateway command-source integration and provider-specific capability mapping.
+- Provider-specific capability and payload mapping.
 - Named owner-provided Broker, constrained-device credentials, and physical hardware evidence.
 
 Proposed topic family:

--- a/src/device-command-client.ts
+++ b/src/device-command-client.ts
@@ -11,7 +11,7 @@ function record(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function validateUrl(value: string): string {
+export function validateLoopbackGatewayUrl(value: string): string {
   let parsed: URL
   try {
     parsed = new URL(value)
@@ -50,7 +50,7 @@ export class DeviceCommandGatewayClient {
   private readonly fetchImpl: typeof fetch
 
   constructor(options: DeviceCommandGatewayClientOptions) {
-    this.origin = validateUrl(options.url)
+    this.origin = validateLoopbackGatewayUrl(options.url)
     if (options.token.length < 16) throw new Error('device Gateway token must contain at least 16 characters')
     this.token = options.token
     this.fetchImpl = options.fetchImpl ?? fetch

--- a/src/device-mqtt.ts
+++ b/src/device-mqtt.ts
@@ -57,9 +57,14 @@ export interface MqttDeviceTransport {
   close(): Promise<void>
 }
 
+export interface MqttDeviceCommandSource {
+  sendCommand(command: MqttDeviceCommand): Promise<MqttDeviceCommandResult>
+}
+
 export interface MqttDeviceAdapterOptions {
   deviceId: string
   transport: MqttDeviceTransport
+  allowedCapabilities?: readonly string[]
   topicPrefix?: string
   commandTtlMs?: number
   now?: () => number
@@ -72,6 +77,7 @@ export interface MqttDeviceAdapterOptions {
 
 const DEFAULT_TTL_MS = 60_000
 const MAX_PAYLOAD_BYTES = 32 * 1024
+const DEFAULT_ALLOWED_CAPABILITIES = ['switch.set', 'light.set', 'media.play_pause', 'cover.set'] as const
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -103,6 +109,38 @@ function commandFingerprint(command: MqttDeviceCommand): string {
   return commandDigest(command)
 }
 
+export function normalizeMqttDeviceCommand(command: MqttDeviceCommand, allowedCapabilities: readonly string[] = DEFAULT_ALLOWED_CAPABILITIES): MqttDeviceCommand {
+  if (!isRecord(command)) throw new TypeError('MQTT command must be an object')
+  const commandId = requiredText(command.commandId, 'commandId')
+  const idempotencyKey = requiredText(command.idempotencyKey, 'idempotencyKey')
+  const capability = requiredText(command.capability, 'capability')
+  if (!allowedCapabilities.includes(capability)) throw new Error(`MQTT capability is not allowlisted: ${capability}`)
+  if (!isRecord(command.payload)) throw new TypeError('MQTT command payload must be an object')
+  const expectedState = command.expectedState === undefined ? undefined : requiredText(command.expectedState, 'expectedState')
+  return { commandId, idempotencyKey, capability, payload: command.payload, ...(expectedState === undefined ? {} : { expectedState }) }
+}
+
+export function normalizeMqttDeviceCommandResult(value: MqttDeviceCommandResult): MqttDeviceCommandResult {
+  if (!isRecord(value) || Object.keys(value).some(key => ![
+    'commandId', 'idempotencyKey', 'capability', 'state', 'acknowledged', 'observedState', 'error',
+  ].includes(key))) throw new TypeError('MQTT command result is invalid')
+  const commandId = requiredText(value.commandId, 'commandId')
+  const idempotencyKey = requiredText(value.idempotencyKey, 'idempotencyKey')
+  const capability = requiredText(value.capability, 'capability')
+  if (!['succeeded', 'acknowledged-unconfirmed', 'failed', 'timed-out', 'unavailable', 'expired'].includes(value.state)) {
+    throw new TypeError('MQTT command result state is invalid')
+  }
+  if (typeof value.acknowledged !== 'boolean') throw new TypeError('MQTT command result acknowledgement is invalid')
+  if (value.state === 'succeeded' && !value.acknowledged) throw new TypeError('MQTT command success lacks acknowledgement')
+  const observedState = value.observedState === undefined ? undefined : requiredText(value.observedState, 'observedState')
+  const error = value.error === undefined ? undefined : requiredText(value.error, 'error', 512)
+  return {
+    commandId, idempotencyKey, capability, state: value.state, acknowledged: value.acknowledged,
+    ...(observedState === undefined ? {} : { observedState }),
+    ...(error === undefined ? {} : { error }),
+  }
+}
+
 function parseJson(payload: Uint8Array): unknown {
   if (payload.byteLength > MAX_PAYLOAD_BYTES) throw new Error('MQTT payload is too large')
   return JSON.parse(Buffer.from(payload).toString('utf8')) as unknown
@@ -123,6 +161,7 @@ interface StoredOutcome {
 export class MqttDeviceAdapter {
   private readonly deviceId: string
   private readonly transport: MqttDeviceTransport
+  private readonly allowedCapabilities: readonly string[]
   private readonly topicPrefix: string
   private readonly commandTtlMs: number
   private readonly now: () => number
@@ -137,10 +176,15 @@ export class MqttDeviceAdapter {
   private removeMessageListener: (() => void) | undefined
   private removeConnectListener: (() => void) | undefined
   private removeCloseListener: (() => void) | undefined
+  private lifecycleGeneration = 0
 
   constructor(options: MqttDeviceAdapterOptions) {
     this.deviceId = validateDeviceId(requiredText(options.deviceId, 'deviceId'))
     this.transport = options.transport
+    this.allowedCapabilities = [...(options.allowedCapabilities ?? DEFAULT_ALLOWED_CAPABILITIES)]
+    if (this.allowedCapabilities.length === 0 || this.allowedCapabilities.some(capability => !/^[A-Za-z0-9_.-]{1,128}$/.test(capability))) {
+      throw new TypeError('allowedCapabilities must contain valid capability names')
+    }
     this.topicPrefix = validateTopicPrefix(options.topicPrefix ?? 'jarvis/v1')
     this.commandTtlMs = options.commandTtlMs ?? DEFAULT_TTL_MS
     if (!Number.isInteger(this.commandTtlMs) || this.commandTtlMs < 1 || this.commandTtlMs > 120_000) {
@@ -164,6 +208,7 @@ export class MqttDeviceAdapter {
 
   async start(): Promise<void> {
     if (this.state === 'ready' || this.state === 'connecting') return
+    const generation = ++this.lifecycleGeneration
     this.state = 'connecting'
     this.notifyStatus()
     this.removeMessageListener?.()
@@ -176,12 +221,15 @@ export class MqttDeviceAdapter {
     this.removeCloseListener = this.transport.onClose(() => this.handleClose())
     try {
       await this.transport.connect()
+      if (generation !== this.lifecycleGeneration) return
       for (const suffix of ['presence', 'capabilities', 'state/reported', 'acks', 'results']) {
         await this.transport.subscribe(topicParts(this.topicPrefix, this.deviceId, suffix))
+        if (generation !== this.lifecycleGeneration) return
       }
       this.state = 'ready'
       this.notifyStatus()
     } catch (error) {
+      if (generation !== this.lifecycleGeneration) return
       this.state = 'degraded'
       this.notifyStatus()
       throw error
@@ -189,6 +237,7 @@ export class MqttDeviceAdapter {
   }
 
   async stop(): Promise<void> {
+    this.lifecycleGeneration += 1
     this.removeMessageListener?.()
     this.removeConnectListener?.()
     this.removeCloseListener?.()
@@ -235,13 +284,7 @@ export class MqttDeviceAdapter {
   }
 
   private normalizeCommand(command: MqttDeviceCommand): MqttDeviceCommand {
-    if (!isRecord(command)) throw new TypeError('MQTT command must be an object')
-    const commandId = requiredText(command.commandId, 'commandId')
-    const idempotencyKey = requiredText(command.idempotencyKey, 'idempotencyKey')
-    const capability = requiredText(command.capability, 'capability')
-    if (!isRecord(command.payload)) throw new TypeError('MQTT command payload must be an object')
-    const expectedState = command.expectedState === undefined ? undefined : requiredText(command.expectedState, 'expectedState')
-    return { commandId, idempotencyKey, capability, payload: command.payload, ...(expectedState === undefined ? {} : { expectedState }) }
+    return normalizeMqttDeviceCommand(command, this.allowedCapabilities)
   }
 
   private receive(topic: string, payload: Uint8Array): void {

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -4,6 +4,8 @@ import { InMemoryDeviceApprovalStore, type DeviceApprovalExecution } from './dev
 import { createJarvisGateway, type GatewayTlsOptions } from './gateway.js'
 import { HomeAssistantAdapter } from './home-assistant.js'
 import { createHomeAssistantSocketFactory, readHomeAssistantRuntimeConfig } from './home-assistant-runtime.js'
+import { MqttDeviceAdapter } from './device-mqtt.js'
+import { createMqttDeviceTransport, readMqttRuntimeConfig } from './mqtt-runtime.js'
 import { acquireRuntimeLease } from './runtime-lease.js'
 
 const ownerToken = process.env.JARVIS_OWNER_TOKEN
@@ -30,6 +32,15 @@ if (!Number.isInteger(harnessRequestTimeoutMs) || harnessRequestTimeoutMs < 1) {
 }
 const deviceCommandToken = process.env.JARVIS_DEVICE_COMMAND_TOKEN
 const homeAssistantConfig = readHomeAssistantRuntimeConfig()
+const mqttConfig = readMqttRuntimeConfig()
+const mqttDeviceId = process.env.JARVIS_MQTT_DEVICE_ID
+if (mqttConfig === undefined && mqttDeviceId !== undefined) throw new Error('JARVIS_MQTT_URL is required when JARVIS_MQTT_DEVICE_ID is configured')
+if (mqttConfig !== undefined && (mqttDeviceId === undefined || mqttDeviceId.length === 0)) {
+  throw new Error('JARVIS_MQTT_DEVICE_ID is required when MQTT is configured')
+}
+if (mqttConfig !== undefined && deviceCommandToken === undefined) {
+  throw new Error('JARVIS_DEVICE_COMMAND_TOKEN is required when MQTT is configured')
+}
 const tlsKeyPath = process.env.JARVIS_GATEWAY_TLS_KEY
 const tlsCertPath = process.env.JARVIS_GATEWAY_TLS_CERT
 if ((tlsKeyPath === undefined) !== (tlsCertPath === undefined)) {
@@ -62,6 +73,11 @@ const deviceApprovals = deviceCommandToken === undefined
   ? undefined
   : new InMemoryDeviceApprovalStore(undefined, homeAssistantExecutionHandler)
 const deviceApprovalOptions = deviceApprovals === undefined ? {} : { deviceApprovals }
+const mqttDevice = mqttConfig === undefined || mqttDeviceId === undefined ? undefined : new MqttDeviceAdapter({
+  deviceId: mqttDeviceId,
+  transport: createMqttDeviceTransport(mqttConfig),
+})
+const mqttCommandOptions = mqttDevice === undefined ? {} : { mqttCommands: mqttDevice }
 const lease = await acquireRuntimeLease(runtimeDir, 'gateway')
 let gateway: ReturnType<typeof createJarvisGateway>
 
@@ -71,15 +87,18 @@ try {
     harnessRequestTimeoutMs, pwaRoot,
     ...(deviceCommandToken === undefined ? {} : { deviceCommandToken }),
     ...deviceApprovalOptions,
+    ...mqttCommandOptions,
   }
   gateway = tls === undefined
     ? createJarvisGateway(gatewayOptions)
     : createJarvisGateway({ ...gatewayOptions, tls })
   homeAssistant?.start()
+  void mqttDevice?.start().catch(() => undefined)
   const running = await gateway.start(configuredPort)
   console.log(`Jarvis Gateway listening on ${running.origin}`)
 } catch (error) {
   homeAssistant?.stop()
+  await mqttDevice?.stop()
   await lease.release()
   throw error
 }
@@ -87,6 +106,7 @@ try {
 async function stop(): Promise<void> {
   try {
     homeAssistant?.stop()
+    await mqttDevice?.stop()
     await gateway.stop()
   } finally {
     await lease.release()

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -5,6 +5,7 @@ import { BlockList, isIP } from 'node:net'
 import { WebSocket, WebSocketServer, type RawData } from 'ws'
 import { MobileApprovalDecisionError } from './approval.js'
 import { normalizeHighRiskDeviceCommand, type DeviceApprovalOutcome, type DeviceApprovalSource, type HighRiskDeviceCommand } from './device-approval.js'
+import { normalizeMqttDeviceCommand, normalizeMqttDeviceCommandResult, type MqttDeviceCommand, type MqttDeviceCommandSource } from './device-mqtt.js'
 import { FileEventLogStore, RetainedEventLog, type JarvisEvent } from './event-log.js'
 import { HarnessBridge, HarnessBridgeError, type HarnessClient } from './harness-bridge.js'
 import { HarnessEventBridge, type ConversationEventSource } from './harness-events.js'
@@ -60,6 +61,7 @@ export interface JarvisGatewayOptions {
   harnessEvents?: ConversationEventSource
   deviceApprovals?: DeviceApprovalSource
   deviceCommandToken?: string
+  mqttCommands?: MqttDeviceCommandSource
   eventLog?: RetainedEventLog
   eventStatePath?: string
   eventHandshakeTimeoutMs?: number
@@ -700,6 +702,39 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         const command = normalizeHighRiskDeviceCommand(body as unknown as HighRiskDeviceCommand)
         const approval = await options.deviceApprovals.requestApproval(command)
         sendJson(response, 202, correlationId, { approval })
+        return
+      }
+      if (parts[0] === 'v1' && parts[1] === 'mqtt-commands') {
+        if (!binding.loopback || options.deviceCommandToken === undefined) {
+          sendJson(response, 404, correlationId, { error: 'route not found', correlationId })
+          return
+        }
+        if (!isLoopbackAddress(request.socket.remoteAddress)) {
+          sendJson(response, 403, correlationId, { error: 'loopback MQTT command required', correlationId })
+          return
+        }
+        if (!sameSecret(options.deviceCommandToken, bearerToken(request, 'DeviceCommand'))) {
+          sendJson(response, 401, correlationId, { error: 'device command authentication required', correlationId })
+          return
+        }
+        if (request.method !== 'POST' || parts.length !== 2 || options.mqttCommands === undefined) {
+          sendJson(response, options.mqttCommands === undefined ? 503 : 405, correlationId, {
+            error: options.mqttCommands === undefined ? 'MQTT device service is unavailable' : 'method not allowed',
+            ...(options.mqttCommands === undefined ? { code: 'mqtt_device_unavailable' } : {}),
+            correlationId,
+          })
+          return
+        }
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || !exactFields(body, ['commandId', 'idempotencyKey', 'capability', 'payload', 'expectedState'])) {
+          throw new Error('MQTT command body is invalid')
+        }
+        const command = normalizeMqttDeviceCommand(body as unknown as MqttDeviceCommand)
+        const result = normalizeMqttDeviceCommandResult(await options.mqttCommands.sendCommand(command))
+        if (result.commandId !== command.commandId || result.idempotencyKey !== command.idempotencyKey || result.capability !== command.capability) {
+          throw new Error('MQTT command result does not match the request')
+        }
+        sendJson(response, 200, correlationId, { result })
         return
       }
       if (request.method === 'POST' && parts.length === 3 && parts[0] === 'v1' && parts[1] === 'sessions' && parts[2] === 'refresh') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,14 @@ import { ApprovalLedger } from './approval.js'
 import { AppRegistry } from './apps.js'
 import { AuditLog } from './audit.js'
 import { DeviceCommandGatewayClient } from './device-command-client.js'
+import { MqttCommandGatewayClient } from './mqtt-command-client.js'
 import { ReminderStore, type Reminder } from './reminders.js'
 import { readSystemStatus } from './system-status.js'
 
 export const name = 'jarvis-mac-mvp'
 export const inject = ['tools', 'webServer']
 
-const JARVIS_TOOLS = new Set(['jarvis_system_status', 'jarvis_open_app', 'jarvis_reminder', 'jarvis_device_control'])
+const JARVIS_TOOLS = new Set(['jarvis_system_status', 'jarvis_open_app', 'jarvis_reminder', 'jarvis_device_control', 'jarvis_mqtt_device_control'])
 
 function reminderOutput(reminders: Reminder[]) {
   return { reminders }
@@ -26,6 +27,8 @@ function safeAuditDetail(tool: string, argumentsValue: unknown): Record<string, 
     ? ['application']
     : tool === 'jarvis_device_control'
       ? ['capability', 'externalEntityId', 'service', 'expectedState']
+      : tool === 'jarvis_mqtt_device_control'
+        ? ['capability', 'expectedState']
       : ['action', 'id', 'dueAt']
   for (const key of keys) {
     const value = Reflect.get(argumentsValue, key)
@@ -43,6 +46,10 @@ export async function apply(ctx: Context): Promise<void> {
   const approvals = new ApprovalLedger()
   const deviceCommandToken = process.env.JARVIS_DEVICE_COMMAND_TOKEN
   const deviceClient = deviceCommandToken === undefined ? undefined : new DeviceCommandGatewayClient({
+    url: process.env.JARVIS_DEVICE_GATEWAY_URL ?? 'http://127.0.0.1:3090',
+    token: deviceCommandToken,
+  })
+  const mqttClient = deviceCommandToken === undefined ? undefined : new MqttCommandGatewayClient({
     url: process.env.JARVIS_DEVICE_GATEWAY_URL ?? 'http://127.0.0.1:3090',
     token: deviceCommandToken,
   })
@@ -166,6 +173,49 @@ export async function apply(ctx: Context): Promise<void> {
     },
     async execute() {
       return readSystemStatus()
+    },
+  }))
+
+  ctx.tools.register(defineTool({
+    name: 'jarvis_mqtt_device_control',
+    description: 'Send one bounded low-risk command to the configured MQTT device. Lock and alarm capabilities require the separate approval tool.',
+    parameters: {
+      capability: { type: 'string', required: true, enum: ['switch.set', 'light.set', 'media.play_pause', 'cover.set'] },
+      payload: { type: 'object', required: true, additionalProperties: true, description: 'Private device payload; never returned in the public result' },
+      expectedState: { type: 'string', description: 'Expected reported device state' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          commandId: { type: 'string', required: true },
+          idempotencyKey: { type: 'string', required: true },
+          capability: { type: 'string', required: true },
+          state: { type: 'string', required: true },
+          acknowledged: { type: 'boolean', required: true },
+          observedState: { type: 'string' },
+          error: { type: 'string' },
+        },
+      },
+      render: (_args, value) => [{ type: 'text', text: `MQTT device command ${String(value.state)}.` }],
+    },
+    async execute(args, exec) {
+      if (mqttClient === undefined) throw new Error('MQTT device control is not configured')
+      if (!['switch.set', 'light.set', 'media.play_pause', 'cover.set'].includes(args.capability)) {
+        throw new Error('MQTT device capability is invalid')
+      }
+      if (typeof args.payload !== 'object' || args.payload === null || Array.isArray(args.payload)) {
+        throw new Error('MQTT device payload is invalid')
+      }
+      if (args.expectedState !== undefined && typeof args.expectedState !== 'string') throw new Error('MQTT expectedState is invalid')
+      return mqttClient.sendCommand({
+        commandId: String(exec.callId),
+        idempotencyKey: String(exec.callId),
+        capability: args.capability,
+        payload: args.payload as Readonly<Record<string, unknown>>,
+        ...(args.expectedState === undefined ? {} : { expectedState: args.expectedState }),
+      })
     },
   }))
 

--- a/src/mqtt-command-client.ts
+++ b/src/mqtt-command-client.ts
@@ -1,0 +1,62 @@
+import { validateLoopbackGatewayUrl } from './device-command-client.js'
+import { normalizeMqttDeviceCommand, type MqttDeviceCommand, type MqttDeviceCommandResult } from './device-mqtt.js'
+
+export interface MqttCommandGatewayClientOptions {
+  url: string
+  token: string
+  fetchImpl?: typeof fetch
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function validResult(value: unknown): value is MqttDeviceCommandResult {
+  return record(value)
+    && Object.keys(value).every(key => ['commandId', 'idempotencyKey', 'capability', 'state', 'acknowledged', 'observedState', 'error'].includes(key))
+    && typeof value.commandId === 'string' && value.commandId.length > 0
+    && typeof value.idempotencyKey === 'string' && value.idempotencyKey.length > 0
+    && typeof value.capability === 'string' && value.capability.length > 0
+    && ['succeeded', 'acknowledged-unconfirmed', 'failed', 'timed-out', 'unavailable', 'expired'].includes(value.state as string)
+    && typeof value.acknowledged === 'boolean'
+    && (value.observedState === undefined || typeof value.observedState === 'string')
+    && (value.error === undefined || typeof value.error === 'string')
+}
+
+export class MqttCommandGatewayClient {
+  private readonly origin: string
+  private readonly token: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(options: MqttCommandGatewayClientOptions) {
+    this.origin = validateLoopbackGatewayUrl(options.url)
+    if (options.token.length < 16) throw new Error('device Gateway token must contain at least 16 characters')
+    this.token = options.token
+    this.fetchImpl = options.fetchImpl ?? fetch
+  }
+
+  async sendCommand(command: MqttDeviceCommand): Promise<MqttDeviceCommandResult> {
+    const normalized = normalizeMqttDeviceCommand(command)
+    let response: Response
+    try {
+      response = await this.fetchImpl(`${this.origin}/v1/mqtt-commands`, {
+        method: 'POST',
+        headers: { authorization: `DeviceCommand ${this.token}`, 'content-type': 'application/json' },
+        body: JSON.stringify(normalized),
+      })
+    } catch {
+      throw new Error('device Gateway is unavailable')
+    }
+    let body: unknown
+    try {
+      body = await response.json()
+    } catch {
+      throw new Error('device Gateway returned an invalid response')
+    }
+    if (!response.ok) throw new Error(`device Gateway rejected the command (${response.status})`)
+    if (!record(body) || !validResult(body.result)) throw new Error('device Gateway returned an invalid response')
+    if (body.result.commandId !== normalized.commandId || body.result.idempotencyKey !== normalized.idempotencyKey
+      || body.result.capability !== normalized.capability) throw new Error('device Gateway returned an invalid response')
+    return body.result
+  }
+}

--- a/test/device-mqtt.test.js
+++ b/test/device-mqtt.test.js
@@ -110,6 +110,30 @@ test('separates acknowledgement from result and ignores duplicate delivery', asy
   await context.adapter.stop()
 })
 
+test('rejects non-allowlisted capabilities before publishing', async () => {
+  const context = createAdapter()
+  await context.adapter.start()
+  assert.throws(() => context.adapter.sendCommand({
+    commandId: 'command-lock', idempotencyKey: 'once-lock', capability: 'lock.set', payload: { state: 'unlocked' },
+  }), /not allowlisted/)
+  assert.equal(context.transport.published.length, 0)
+  await context.adapter.stop()
+})
+
+test('remains stopped when shutdown races with initial connection', async () => {
+  const transport = new FakeMqttTransport()
+  let finishConnect
+  transport.connect = () => new Promise(resolve => { finishConnect = resolve })
+  const adapter = new MqttDeviceAdapter({ deviceId: 'sensor-node-1', transport })
+  const starting = adapter.start()
+  await new Promise(resolve => setImmediate(resolve))
+  const stopping = adapter.stop()
+  finishConnect()
+  await Promise.all([starting, stopping])
+  assert.equal(adapter.getStatus(), 'stopped')
+  assert.equal(transport.subscriptions.length, 0)
+})
+
 test('expires commands and fails pending work when the device connection closes', async () => {
   const context = createAdapter({ commandTtlMs: 20 })
   await context.adapter.start()

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -285,6 +285,28 @@ test('gateway entrypoint rejects incomplete TLS and permissive private-key files
   }
 })
 
+test('gateway entrypoint rejects incomplete MQTT command configuration', () => {
+  const environment = Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => !name.startsWith('JARVIS_MQTT_') && name !== 'JARVIS_DEVICE_COMMAND_TOKEN'),
+  )
+  const cases = [
+    { values: { JARVIS_MQTT_DEVICE_ID: 'sensor-node-1' }, message: /JARVIS_MQTT_URL is required/ },
+    { values: { JARVIS_MQTT_URL: 'mqtt://broker.invalid' }, message: /JARVIS_MQTT_DEVICE_ID is required/ },
+    {
+      values: { JARVIS_MQTT_URL: 'mqtt://broker.invalid', JARVIS_MQTT_DEVICE_ID: 'sensor-node-1' },
+      message: /JARVIS_DEVICE_COMMAND_TOKEN is required/,
+    },
+  ]
+  for (const entry of cases) {
+    const result = spawnSync(process.execPath, ['dist/gateway-main.js'], {
+      encoding: 'utf8',
+      env: { ...environment, JARVIS_OWNER_TOKEN: ownerToken, JARVIS_GATEWAY_PORT: '0', ...entry.values },
+    })
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, entry.message)
+  }
+})
+
 test('runs authenticated pairing, device rotation, and owner revocation over versioned HTTP', async () => {
   const authority = new PairingAuthority(() => 1_000, 60_000)
   const service = createJarvisGateway({ ownerToken, authority })
@@ -1017,6 +1039,75 @@ test('accepts only loopback internal device-command submissions and returns a re
     assert.equal(invalid.status, 400)
   } finally {
     await service.stop()
+  }
+})
+
+test('accepts only bounded loopback MQTT commands and returns a redacted outcome', async () => {
+  const deviceCommandToken = 'device-command-token-for-tests'
+  const received = []
+  const mqttCommands = {
+    async sendCommand(command) {
+      received.push(command)
+      if (command.commandId === 'mqtt-command-unredacted') {
+        return {
+          commandId: command.commandId, idempotencyKey: command.idempotencyKey, capability: command.capability,
+          state: 'succeeded', acknowledged: true, payload: { providerToken: 'private-provider-token' },
+        }
+      }
+      return {
+        commandId: command.commandId, idempotencyKey: command.idempotencyKey, capability: command.capability,
+        state: 'succeeded', acknowledged: true, observedState: command.expectedState,
+      }
+    },
+  }
+  const service = createJarvisGateway({ ownerToken, deviceCommandToken, mqttCommands })
+  const gateway = await service.start()
+  const body = {
+    commandId: 'mqtt-command-gateway', idempotencyKey: 'mqtt-once-gateway', capability: 'light.set',
+    payload: { brightness: 50, providerToken: 'private-provider-token' }, expectedState: 'on',
+  }
+  const headers = { 'content-type': 'application/json', authorization: `DeviceCommand ${deviceCommandToken}` }
+  try {
+    assert.equal((await request(gateway, '/v1/mqtt-commands', {
+      method: 'POST', headers: { ...headers, authorization: 'DeviceCommand wrong-token' }, body: JSON.stringify(body),
+    })).status, 401)
+    const response = await request(gateway, '/v1/mqtt-commands', { method: 'POST', headers, body: JSON.stringify(body) })
+    assert.equal(response.status, 200)
+    const responseBody = await response.json()
+    assert.equal(received.length, 1)
+    assert.equal(received[0].payload.providerToken, 'private-provider-token')
+    assert.equal(responseBody.result.state, 'succeeded')
+    assert.equal('payload' in responseBody.result, false)
+    assert.doesNotMatch(JSON.stringify(responseBody), /private-provider-token/)
+
+    const unredacted = await request(gateway, '/v1/mqtt-commands', {
+      method: 'POST', headers,
+      body: JSON.stringify({ ...body, commandId: 'mqtt-command-unredacted', idempotencyKey: 'mqtt-once-unredacted' }),
+    })
+    assert.equal(unredacted.status, 400)
+    assert.doesNotMatch(JSON.stringify(await unredacted.json()), /private-provider-token/)
+
+    for (const invalidBody of [
+      { ...body, capability: 'lock.set' },
+      { ...body, payload: 'not-an-object' },
+      { ...body, rawFrame: 'private-provider-token' },
+    ]) {
+      const invalid = await request(gateway, '/v1/mqtt-commands', { method: 'POST', headers, body: JSON.stringify(invalidBody) })
+      assert.equal(invalid.status, 400)
+    }
+    assert.equal(received.length, 2)
+  } finally {
+    await service.stop()
+  }
+
+  const unavailableService = createJarvisGateway({ ownerToken, deviceCommandToken })
+  const unavailableGateway = await unavailableService.start()
+  try {
+    const unavailable = await request(unavailableGateway, '/v1/mqtt-commands', { method: 'POST', headers, body: JSON.stringify(body) })
+    assert.equal(unavailable.status, 503)
+    assert.equal((await unavailable.json()).code, 'mqtt_device_unavailable')
+  } finally {
+    await unavailableService.stop()
   }
 })
 

--- a/test/mqtt-command-client.test.js
+++ b/test/mqtt-command-client.test.js
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MqttCommandGatewayClient } from '../dist/mqtt-command-client.js'
+
+const command = {
+  commandId: 'command-mqtt-client',
+  idempotencyKey: 'once-mqtt-client',
+  capability: 'light.set',
+  payload: { brightness: 50, providerToken: 'private-provider-token' },
+  expectedState: 'on',
+}
+
+test('submits bounded MQTT commands to the loopback Gateway and returns only the normalized result', async () => {
+  let request
+  const client = new MqttCommandGatewayClient({
+    url: 'http://127.0.0.1:3090', token: 'device-command-token',
+    fetchImpl: async (input, init) => {
+      request = { input, init }
+      return new Response(JSON.stringify({ result: {
+        commandId: command.commandId, idempotencyKey: command.idempotencyKey, capability: command.capability,
+        state: 'succeeded', acknowledged: true, observedState: 'on',
+      } }), { status: 200, headers: { 'content-type': 'application/json' } })
+    },
+  })
+  const result = await client.sendCommand(command)
+  assert.equal(request.input, 'http://127.0.0.1:3090/v1/mqtt-commands')
+  assert.equal(request.init.headers.authorization, 'DeviceCommand device-command-token')
+  assert.equal(JSON.parse(request.init.body).payload.providerToken, 'private-provider-token')
+  assert.equal('payload' in result, false)
+  assert.doesNotMatch(JSON.stringify(result), /private-provider-token/)
+})
+
+test('rejects non-loopback URLs and malformed or unredacted Gateway results', async () => {
+  assert.throws(() => new MqttCommandGatewayClient({ url: 'http://gateway.example.test', token: 'device-command-token' }), /loopback/)
+  assert.doesNotThrow(() => new MqttCommandGatewayClient({ url: 'http://[::1]:3090', token: 'device-command-token' }))
+  const client = new MqttCommandGatewayClient({
+    url: 'http://127.0.0.1:3090', token: 'device-command-token',
+    fetchImpl: async () => new Response(JSON.stringify({ result: {
+      commandId: command.commandId, idempotencyKey: command.idempotencyKey, capability: command.capability,
+      state: 'succeeded', acknowledged: true, payload: { providerToken: 'private-provider-token' },
+    } }), { status: 200 }),
+  })
+  await assert.rejects(client.sendCommand(command), /invalid response/)
+
+  const mismatched = new MqttCommandGatewayClient({
+    url: 'http://127.0.0.1:3090', token: 'device-command-token',
+    fetchImpl: async () => new Response(JSON.stringify({ result: {
+      commandId: 'another-command', idempotencyKey: command.idempotencyKey, capability: command.capability,
+      state: 'succeeded', acknowledged: true,
+    } }), { status: 200 }),
+  })
+  await assert.rejects(mismatched.sendCommand(command), /invalid response/)
+})


### PR DESCRIPTION
Closes #80

## Summary
- add a loopback-only authenticated MQTT command route and Gateway-owned adapter lifecycle
- expose a bounded low-risk Harness tool while preserving lock/alarm approval requirements
- validate and redact command results so payloads, credentials, and raw frames cannot cross the Gateway response boundary
- document configured runtime behavior without claiming a real Broker or physical-device acceptance

## Verification
- `npm run verify` (172/172)
- `npm run verify:runtime`
- `npm run verify:release` from committed clean checkout
- `git diff --check`