### PR TITLE
Add owner-controlled memory store core

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - 配对后的 PWA 可读取 Gateway 认可的当前设备与会话状态，并可在设置中撤销自身设备凭据；撤销会关闭该设备全部会话与实时连接，并清除浏览器中的身份、令牌、对话快照和事件游标。
 - 配对后的 PWA 提供隐私优先的应用内通知中心；审批、对话完成和连接事件只生成固定摘要，支持分类开关、静默时段、每小时系统通知上限、已读/清空和显式系统通知授权。
 - 已提供离线一致性备份和原子恢复命令；运行租约阻止在 Harness 或 Gateway 活跃时复制状态，恢复前校验结构、权限和 SHA-256。
+- 已提供用户可控记忆的私有存储核心：候选默认仅为提议，确认、拒绝、编辑继承、到期、导出和物理删除均使用严格版本化状态；尚未接入模型自动提取、提示词召回或管理 UI。
 - 已实现智能设备注册核心：规范化设备、位置、能力、风险、别名、稳定外部身份映射和带时间戳状态；真实设备验收仍未完成。
 - 已实现只读 Home Assistant WebSocket 协议核心及可选 Gateway 运行时装配：认证、确定性实体快照、状态事件过滤、删除实体降级、断线重连和全量重同步；真实 Home Assistant 地址、凭据、服务行为和硬件验收仍未完成。
 - 已实现低风险 Home Assistant 服务调用对账核心：灯、开关和普通媒体使用幂等键，服务确认与实际状态分离；只有后续目标状态被观察到才报告成功，中高风险动作和真实硬件验收仍需后续阶段。
@@ -192,12 +193,13 @@ npm run backup -- --output backups/jarvis-backup.jarvis
 npm run restore -- --archive backups/jarvis-backup.jarvis
 ```
 
-归档包含 Harness 会话、工作区映射、提醒、审计和已有 Gateway 状态，文件权限为 `0600`。它不包含 `.env`、Harness 模型凭据、Keychain 项、Owner Token 或 TLS 私钥。当前归档未加密，应只保存在受保护磁盘；完整停止、验证和跨机器恢复步骤见[备份与恢复指南](docs/operations/backup-restore.md)。
+归档包含 Harness 会话、工作区映射、提醒、用户记忆、审计和已有 Gateway 状态，文件权限为 `0600`。它不包含 `.env`、Harness 模型凭据、Keychain 项、Owner Token 或 TLS 私钥。当前归档未加密，应只保存在受保护磁盘；完整停止、验证和跨机器恢复步骤见[备份与恢复指南](docs/operations/backup-restore.md)。
 
 ## 数据与安全
 
 - Harness 会话：`.dsh/sessions/`
 - Jarvis 提醒：`data/reminders.json`
+- Jarvis 用户记忆：`data/memory.json`
 - Jarvis 审计：`data/audit.jsonl`
 - Gateway 配对、访问会话和有界归一化事件：`data/pairing-state.json`、`data/session-state.json`、`data/event-state.json`
 - API Key：存放在未纳入 Git 的 `.env` 或 Harness 本机凭据存储，均不进入备份归档

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -7,7 +7,7 @@ and Jarvis state. The archive is private but not encrypted.
 
 - Harness sessions under `.dsh/sessions/`.
 - Harness workspace and projection stores under `.dsh/storages/`.
-- Jarvis reminders and append-only audit records.
+- Jarvis reminders, owner-controlled memory, and append-only audit records.
 - Gateway pairing, access-session, and retained-event state when present.
 
 The archive never includes `.env`, Harness root settings or credentials,
@@ -33,7 +33,7 @@ owner-only permissions.
 
 Store the archive on an encrypted volume or in another encrypted backup system.
 The `0600` file mode prevents other local accounts from reading it but does not
-encrypt its conversations, reminders, or audit history.
+encrypt its conversations, reminders, memory, or audit history.
 
 ## Restore a backup
 
@@ -54,7 +54,7 @@ state.
 
 Restart with `npm start` or reinstall the LaunchAgent. Reconfigure Harness
 settings, model credentials, Keychain, Owner Token, and TLS credentials
-separately on a new Mac, then verify one restored conversation and reminder
+separately on a new Mac, then verify one restored conversation, reminder, and memory item
 before deleting the pre-restore copy.
 
 ## Alternate state directories

--- a/docs/plan/07-stage-6-memory-proactivity.md
+++ b/docs/plan/07-stage-6-memory-proactivity.md
@@ -24,6 +24,15 @@ Harness Schedule is retained only for session-local reminders. Its current deliv
 
 Raw model reasoning is never a memory authority.
 
+## Current Increment
+
+The versioned owner-controlled source store is tracked by [#88](https://github.com/gh503/jarvis/issues/88).
+
+- Candidates enter only the proposed state and cannot become confirmed through model authority in this increment.
+- Confirmed edits supersede the previous source item; rejected, superseded, expired, and physically deleted items are excluded from recall.
+- The bounded private source file is initialized by Jarvis and included in offline backup/restore with semantic validation.
+- Automatic extraction, prompt-context retrieval, derived indexes, owner management UI, and proactive rules remain deferred.
+
 ## Modules
 
 ### `packages/memory`

--- a/scripts/verify-local-runtime.sh
+++ b/scripts/verify-local-runtime.sh
@@ -78,6 +78,15 @@ done
 
 [[ -s "$HEALTH_FILE" ]]
 
+MEMORY_FILE="$RUNTIME_DIR/harness-data/memory.json"
+[[ -f "$MEMORY_FILE" ]]
+[[ "$(stat -f '%Lp' "$MEMORY_FILE")" == "600" ]]
+node --input-type=module -e '
+  import { readFileSync } from "node:fs"
+  const memory = JSON.parse(readFileSync(process.argv[1], "utf8"))
+  if (memory.version !== 1 || !Array.isArray(memory.items) || memory.items.length !== 0) process.exit(1)
+' "$MEMORY_FILE"
+
 http_status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/jarvis/health")"
 [[ "$http_status" == "405" ]]
 

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -13,6 +13,7 @@ import {
 import { dirname, isAbsolute, join, posix, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { acquireMaintenanceLease } from './runtime-lease.js'
+import { validateMemoryDocument } from './memory.js'
 
 const FORMAT = 'jarvis-backup'
 const FORMAT_VERSION = 1
@@ -25,6 +26,7 @@ const EXACT_FILES = [
   { path: '.dsh/storages/workspace.json', required: true },
   { path: '.dsh/storages/session_projcache.json', required: false },
   { path: 'data/reminders.json', required: true },
+  { path: 'data/memory.json', required: false },
   { path: 'data/audit.jsonl', required: true },
   { path: 'data/pairing-state.json', required: false },
   { path: 'data/session-state.json', required: false },
@@ -265,6 +267,8 @@ function validatePayloadSemantics(files: ValidatedFile[]): void {
   }
   const reminders = parseJsonFile(byPath.get('data/reminders.json') as ValidatedFile, 'data/reminders.json')
   if (!Array.isArray(reminders)) throw new Error('data/reminders.json must contain an array')
+  const memory = byPath.get('data/memory.json')
+  if (memory !== undefined) validateMemoryDocument(parseJsonFile(memory, 'data/memory.json'))
   parseJsonFile(byPath.get('.dsh/storages/workspace.json') as ValidatedFile, '.dsh/storages/workspace.json')
   for (const path of ['.dsh/storages/session_projcache.json', 'data/pairing-state.json', 'data/session-state.json', 'data/event-state.json']) {
     const file = byPath.get(path)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { ApprovalLedger } from './approval.js'
 import { AppRegistry } from './apps.js'
 import { AuditLog } from './audit.js'
 import { DeviceCommandGatewayClient } from './device-command-client.js'
+import { MemoryStore } from './memory.js'
 import { MqttCommandGatewayClient } from './mqtt-command-client.js'
 import { ReminderStore, type Reminder } from './reminders.js'
 import { readSystemStatus } from './system-status.js'
@@ -53,7 +54,8 @@ export async function apply(ctx: Context): Promise<void> {
     url: process.env.JARVIS_DEVICE_GATEWAY_URL ?? 'http://127.0.0.1:3090',
     token: deviceCommandToken,
   })
-  await Promise.all([audit.initialize(), reminders.initialize()])
+  const memories = new MemoryStore(dataDir)
+  await Promise.all([audit.initialize(), reminders.initialize(), memories.initialize()])
 
   ctx.tools.guard(exec => JARVIS_TOOLS.has(exec.name) || exec.name === 'ask_user_question'
     ? undefined

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,353 @@
+import { randomUUID } from 'node:crypto'
+import { constants } from 'node:fs'
+import { chmod, lstat, mkdir, open, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+const DOCUMENT_VERSION = 1
+const MAX_ITEMS = 1_000
+const MAX_FILE_BYTES = 2 * 1024 * 1024
+const MAX_CONTENT_BYTES = 4 * 1024
+const MAX_REFERENCE_BYTES = 1_024
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+
+export type MemoryClass = 'profile' | 'episodic'
+export type MemorySensitivity = 'standard' | 'sensitive'
+export type MemoryStatus = 'proposed' | 'confirmed' | 'rejected' | 'superseded' | 'expired'
+export type MemorySourceKind = 'explicit-user' | 'model-candidate' | 'owner-edit'
+
+export interface MemorySource {
+  kind: MemorySourceKind
+  reference: string | null
+}
+
+export interface MemoryRetention {
+  kind: 'until-deleted' | 'expires-at'
+  expiresAt: string | null
+}
+
+export interface MemoryItem {
+  id: string
+  ownerId: 'local-owner'
+  class: MemoryClass
+  content: string
+  sensitivity: MemorySensitivity
+  confidence: number
+  source: MemorySource
+  retention: MemoryRetention
+  status: MemoryStatus
+  createdAt: string
+  updatedAt: string
+  confirmedAt: string | null
+  supersedesId: string | null
+}
+
+export interface MemoryDocument {
+  version: typeof DOCUMENT_VERSION
+  items: MemoryItem[]
+}
+
+export interface MemoryProposal {
+  class: MemoryClass
+  content: string
+  sensitivity: MemorySensitivity
+  confidence: number
+  source: Omit<MemorySource, 'kind'> & { kind: 'explicit-user' | 'model-candidate' }
+  retention: MemoryRetention
+}
+
+export interface MemoryStoreOptions {
+  now?: () => Date
+  randomUUID?: () => string
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function exactFields(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort()
+  const wanted = [...expected].sort()
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index])
+}
+
+function boundedString(value: unknown, maxBytes: number, nullable = false): value is string | null {
+  if (nullable && value === null) return true
+  return typeof value === 'string' && value.length > 0 && Buffer.byteLength(value, 'utf8') <= maxBytes && !value.includes('\0')
+}
+
+function canonicalTimestamp(value: unknown, nullable = false): value is string | null {
+  if (nullable && value === null) return true
+  if (typeof value !== 'string') return false
+  try {
+    return new Date(value).toISOString() === value
+  } catch {
+    return false
+  }
+}
+
+function validSource(value: unknown): value is MemorySource {
+  return record(value) && exactFields(value, ['kind', 'reference'])
+    && ['explicit-user', 'model-candidate', 'owner-edit'].includes(String(value.kind))
+    && boundedString(value.reference, MAX_REFERENCE_BYTES, true)
+}
+
+function validRetention(value: unknown): value is MemoryRetention {
+  if (!record(value) || !exactFields(value, ['kind', 'expiresAt'])) return false
+  if (value.kind === 'until-deleted') return value.expiresAt === null
+  return value.kind === 'expires-at' && canonicalTimestamp(value.expiresAt)
+}
+
+function validItem(value: unknown): value is MemoryItem {
+  if (!record(value) || !exactFields(value, [
+    'id', 'ownerId', 'class', 'content', 'sensitivity', 'confidence', 'source', 'retention', 'status',
+    'createdAt', 'updatedAt', 'confirmedAt', 'supersedesId',
+  ])) return false
+  if (!(typeof value.id === 'string' && ID_PATTERN.test(value.id) && value.ownerId === 'local-owner'
+    && (value.class === 'profile' || value.class === 'episodic')
+    && boundedString(value.content, MAX_CONTENT_BYTES)
+    && (value.sensitivity === 'standard' || value.sensitivity === 'sensitive')
+    && typeof value.confidence === 'number' && Number.isFinite(value.confidence)
+    && value.confidence >= 0 && value.confidence <= 1
+    && validSource(value.source) && validRetention(value.retention)
+    && ['proposed', 'confirmed', 'rejected', 'superseded', 'expired'].includes(String(value.status))
+    && canonicalTimestamp(value.createdAt) && canonicalTimestamp(value.updatedAt)
+    && canonicalTimestamp(value.confirmedAt, true)
+    && (value.supersedesId === null || typeof value.supersedesId === 'string' && ID_PATTERN.test(value.supersedesId)))) return false
+  const createdAt = new Date(value.createdAt as string).getTime()
+  const updatedAt = new Date(value.updatedAt as string).getTime()
+  const confirmedAt = value.confirmedAt === null ? null : new Date(value.confirmedAt as string).getTime()
+  if (updatedAt < createdAt || (confirmedAt !== null && (confirmedAt < createdAt || confirmedAt > updatedAt))) return false
+  if ((value.status === 'confirmed' || value.status === 'superseded') && confirmedAt === null) return false
+  if ((value.status === 'proposed' || value.status === 'rejected') && confirmedAt !== null) return false
+  if (value.retention.kind === 'expires-at' && new Date(value.retention.expiresAt as string).getTime() <= createdAt) return false
+  return value.source.kind === 'owner-edit'
+    ? value.supersedesId !== null && value.source.reference === value.supersedesId
+      && (value.status === 'confirmed' || value.status === 'superseded' || value.status === 'expired')
+    : value.supersedesId === null
+}
+
+export function validateMemoryDocument(value: unknown): MemoryDocument {
+  if (!record(value) || !exactFields(value, ['version', 'items']) || value.version !== DOCUMENT_VERSION
+    || !Array.isArray(value.items) || value.items.length > MAX_ITEMS || !value.items.every(validItem)) {
+    throw new Error('memory document is invalid')
+  }
+  if (new Set(value.items.map(item => item.id)).size !== value.items.length) {
+    throw new Error('memory document contains duplicate ids')
+  }
+  return structuredClone(value) as unknown as MemoryDocument
+}
+
+function normalizeProposal(value: MemoryProposal): MemoryProposal {
+  const content = value.content.trim()
+  if (!boundedString(content, MAX_CONTENT_BYTES)) throw new Error('memory content must contain 1 to 4096 UTF-8 bytes without NUL')
+  if (value.class !== 'profile' && value.class !== 'episodic') throw new Error('memory class is invalid')
+  if (value.sensitivity !== 'standard' && value.sensitivity !== 'sensitive') throw new Error('memory sensitivity is invalid')
+  if (!Number.isFinite(value.confidence) || value.confidence < 0 || value.confidence > 1) throw new Error('memory confidence must be between 0 and 1')
+  if ((value.source.kind !== 'explicit-user' && value.source.kind !== 'model-candidate')
+    || !boundedString(value.source.reference, MAX_REFERENCE_BYTES, true)) throw new Error('memory source is invalid')
+  if (!validRetention(value.retention)) throw new Error('memory retention is invalid')
+  return structuredClone({ ...value, content })
+}
+
+function cloneItem(item: MemoryItem): MemoryItem {
+  return structuredClone(item)
+}
+
+export class MemoryStore {
+  readonly path: string
+  private readonly now: () => Date
+  private readonly createId: () => string
+  private pending: Promise<void> = Promise.resolve()
+
+  constructor(dataDir: string, options: MemoryStoreOptions = {}) {
+    this.path = join(dataDir, 'memory.json')
+    this.now = options.now ?? (() => new Date())
+    this.createId = options.randomUUID ?? randomUUID
+  }
+
+  async initialize(): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true, mode: 0o700 })
+    await chmod(dirname(this.path), 0o700)
+    try {
+      const metadata = await lstat(this.path)
+      if (!metadata.isFile() || metadata.isSymbolicLink()) throw new Error('memory file must be a regular file')
+    } catch (error: unknown) {
+      if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error
+      await writeFile(this.path, '{"version":1,"items":[]}\n', { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    }
+    await chmod(this.path, 0o600)
+    await this.readDocument()
+  }
+
+  async propose(input: MemoryProposal): Promise<MemoryItem> {
+    const proposal = normalizeProposal(input)
+    if (proposal.retention.kind === 'expires-at'
+      && new Date(proposal.retention.expiresAt as string).getTime() <= this.now().getTime()) {
+      throw new Error('memory expiry must be in the future')
+    }
+    return this.mutate(document => {
+      const duplicate = document.items.find(item => (item.status === 'proposed' || item.status === 'confirmed')
+        && item.class === proposal.class && item.content === proposal.content
+        && item.sensitivity === proposal.sensitivity && item.confidence === proposal.confidence
+        && item.source.kind === proposal.source.kind
+        && item.source.reference === proposal.source.reference
+        && item.retention.kind === proposal.retention.kind && item.retention.expiresAt === proposal.retention.expiresAt)
+      if (duplicate !== undefined) return { result: cloneItem(duplicate), changed: false }
+      if (document.items.length >= MAX_ITEMS) throw new Error(`memory store cannot exceed ${MAX_ITEMS} items`)
+      const timestamp = this.timestamp()
+      const item: MemoryItem = {
+        id: this.nextId(), ownerId: 'local-owner', class: proposal.class, content: proposal.content,
+        sensitivity: proposal.sensitivity, confidence: proposal.confidence, source: proposal.source,
+        retention: proposal.retention, status: 'proposed', createdAt: timestamp, updatedAt: timestamp,
+        confirmedAt: null, supersedesId: null,
+      }
+      document.items.push(item)
+      return { result: cloneItem(item), changed: true }
+    })
+  }
+
+  async confirm(id: string): Promise<MemoryItem> {
+    return this.transition(id, 'proposed', 'confirmed', true)
+  }
+
+  async reject(id: string): Promise<MemoryItem> {
+    return this.transition(id, 'proposed', 'rejected', false)
+  }
+
+  async editConfirmed(id: string, content: string): Promise<MemoryItem> {
+    const normalizedContent = content.trim()
+    if (!boundedString(normalizedContent, MAX_CONTENT_BYTES)) throw new Error('memory content must contain 1 to 4096 UTF-8 bytes without NUL')
+    return this.mutate(document => {
+      const current = document.items.find(item => item.id === id)
+      if (current === undefined) throw new Error(`memory not found: ${id}`)
+      if (current.status !== 'confirmed') throw new Error('only a confirmed memory can be edited')
+      if (document.items.length >= MAX_ITEMS) throw new Error(`memory store cannot exceed ${MAX_ITEMS} items`)
+      const timestamp = this.timestamp()
+      current.status = 'superseded'
+      current.updatedAt = timestamp
+      const edited: MemoryItem = {
+        ...cloneItem(current), id: this.nextId(), content: normalizedContent,
+        source: { kind: 'owner-edit', reference: current.id }, status: 'confirmed',
+        createdAt: timestamp, updatedAt: timestamp, confirmedAt: timestamp, supersedesId: current.id,
+      }
+      document.items.push(edited)
+      return { result: cloneItem(edited), changed: true }
+    })
+  }
+
+  async delete(id: string): Promise<MemoryItem> {
+    return this.mutate(document => {
+      const index = document.items.findIndex(item => item.id === id)
+      if (index < 0) throw new Error(`memory not found: ${id}`)
+      const [deleted] = document.items.splice(index, 1)
+      return { result: cloneItem(deleted as MemoryItem), changed: true }
+    })
+  }
+
+  async list(): Promise<MemoryItem[]> {
+    return this.mutate(document => ({
+      result: document.items.map(cloneItem).sort((left, right) => left.createdAt.localeCompare(right.createdAt)),
+      changed: false,
+    }))
+  }
+
+  async recall(): Promise<MemoryItem[]> {
+    return this.mutate(document => ({
+      result: document.items.filter(item => item.status === 'confirmed').map(cloneItem)
+        .sort((left, right) => left.createdAt.localeCompare(right.createdAt)),
+      changed: false,
+    }))
+  }
+
+  async export(): Promise<MemoryDocument> {
+    return this.mutate(document => ({ result: structuredClone(document), changed: false }))
+  }
+
+  private async transition(id: string, from: MemoryStatus, to: MemoryStatus, confirmed: boolean): Promise<MemoryItem> {
+    return this.mutate(document => {
+      const item = document.items.find(candidate => candidate.id === id)
+      if (item === undefined) throw new Error(`memory not found: ${id}`)
+      if (item.status !== from) throw new Error(`memory must be ${from} before becoming ${to}`)
+      const timestamp = this.timestamp()
+      item.status = to
+      item.updatedAt = timestamp
+      if (confirmed) item.confirmedAt = timestamp
+      return { result: cloneItem(item), changed: true }
+    })
+  }
+
+  private timestamp(): string {
+    return this.now().toISOString()
+  }
+
+  private nextId(): string {
+    const id = this.createId()
+    if (!ID_PATTERN.test(id)) throw new Error('memory id generator returned an invalid id')
+    return id
+  }
+
+  private expire(document: MemoryDocument): boolean {
+    const now = this.now().getTime()
+    let changed = false
+    for (const item of document.items) {
+      if ((item.status === 'proposed' || item.status === 'confirmed') && item.retention.kind === 'expires-at'
+        && new Date(item.retention.expiresAt as string).getTime() <= now) {
+        item.status = 'expired'
+        item.updatedAt = new Date(now).toISOString()
+        changed = true
+      }
+    }
+    return changed
+  }
+
+  private async mutate<T>(operation: (document: MemoryDocument) => { result: T; changed: boolean }): Promise<T> {
+    let result: T | undefined
+    const queued = this.pending.then(async () => {
+      const document = await this.readDocument()
+      const expired = this.expire(document)
+      const outcome = operation(document)
+      result = outcome.result
+      if (expired || outcome.changed) await this.writeDocument(document)
+    })
+    this.pending = queued.catch(() => undefined)
+    await queued
+    return result as T
+  }
+
+  private async readDocument(): Promise<MemoryDocument> {
+    const handle = await open(this.path, constants.O_RDONLY | constants.O_NOFOLLOW)
+    let content: Buffer
+    try {
+      const before = await handle.stat()
+      if (!before.isFile()) throw new Error('memory file must be a regular file')
+      if (before.size > MAX_FILE_BYTES) throw new Error(`memory file exceeds ${MAX_FILE_BYTES} bytes`)
+      content = await handle.readFile()
+      const after = await handle.stat()
+      if (before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || before.mtimeMs !== after.mtimeMs) {
+        throw new Error('memory file changed while being read')
+      }
+    } finally {
+      await handle.close()
+    }
+    try {
+      return validateMemoryDocument(JSON.parse(content.toString('utf8')) as unknown)
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new Error('memory file is not valid JSON')
+      throw error
+    }
+  }
+
+  private async writeDocument(document: MemoryDocument): Promise<void> {
+    validateMemoryDocument(document)
+    const content = `${JSON.stringify(document, null, 2)}\n`
+    if (Buffer.byteLength(content, 'utf8') > MAX_FILE_BYTES) throw new Error(`memory file exceeds ${MAX_FILE_BYTES} bytes`)
+    const temporary = `${this.path}.${process.pid}.${this.nextId()}.tmp`
+    try {
+      await writeFile(temporary, content, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+      await rename(temporary, this.path)
+      await chmod(this.path, 0o600)
+    } finally {
+      await rm(temporary, { force: true })
+    }
+  }
+}

--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -28,12 +29,22 @@ async function seedState(root) {
   await privateFile(join(dshHome, 'settings.yaml'), 'settings-canary-must-not-be-backed-up\n')
   await privateFile(join(dshHome, '.credentials.yaml'), 'credential-canary-must-not-be-backed-up\n')
   await privateFile(join(dataDir, 'reminders.json'), `${JSON.stringify([{ id: 'reminder-one', text: 'one reminder' }])}\n`)
+  await privateFile(join(dataDir, 'memory.json'), `${JSON.stringify({
+    version: 1,
+    items: [{
+      id: 'memory-one', ownerId: 'local-owner', class: 'profile', content: 'Preferred language is Chinese',
+      sensitivity: 'standard', confidence: 1, source: { kind: 'explicit-user', reference: 'message-one' },
+      retention: { kind: 'until-deleted', expiresAt: null }, status: 'confirmed',
+      createdAt: '2030-01-01T00:00:00.000Z', updatedAt: '2030-01-01T00:00:00.000Z',
+      confirmedAt: '2030-01-01T00:00:00.000Z', supersedesId: null,
+    }],
+  })}\n`)
   await privateFile(join(dataDir, 'audit.jsonl'), '{"id":"audit-one","phase":"policy"}\n{"id":"audit-two","phase":"result"}\n')
   await privateFile(join(root, '.env'), 'DEEPSEEK_API_KEY=environment-canary-must-not-be-backed-up\n')
   return { dshHome, dataDir, sessionPath }
 }
 
-test('backs up and restores one conversation, reminder, and audit chain without secrets', async () => {
+test('backs up and restores one conversation, reminder, memory, and audit chain without secrets', async () => {
   const root = await mkdtemp(join(tmpdir(), 'jarvis-backup-'))
   try {
     const source = await seedState(join(root, 'source'))
@@ -58,12 +69,31 @@ test('backs up and restores one conversation, reminder, and audit chain without 
       'one committed conversation',
     )
     assert.deepEqual(JSON.parse(await readFile(join(restoredData, 'reminders.json'), 'utf8')), [{ id: 'reminder-one', text: 'one reminder' }])
+    assert.deepEqual(
+      JSON.parse(await readFile(join(restoredData, 'memory.json'), 'utf8')),
+      JSON.parse(await readFile(join(source.dataDir, 'memory.json'), 'utf8')),
+    )
     assert.equal((await readFile(join(restoredData, 'audit.jsonl'), 'utf8')).trim().split('\n').length, 2)
     assert.equal(await readFile(join(restoredDsh, '.credentials.yaml'), 'utf8'), 'destination-credential-remains-local\n')
     assert.equal(await readFile(join(restoredDsh, 'settings.yaml'), 'utf8'), 'destination-settings-remain-local\n')
     assert.equal(await readFile(join(restoredData, 'service.log'), 'utf8'), 'unmanaged log remains local\n')
     assert.equal((await stat(join(restoredDsh, 'sessions'))).mode & 0o777, 0o700)
     assert.equal((await stat(join(restoredData, 'reminders.json'))).mode & 0o777, 0o600)
+    assert.equal((await stat(join(restoredData, 'memory.json'))).mode & 0o777, 0o600)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('backs up legacy state before the memory store is first initialized', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'jarvis-backup-legacy-'))
+  try {
+    const source = await seedState(join(root, 'source'))
+    await rm(join(source.dataDir, 'memory.json'))
+    const archivePath = join(root, 'legacy-backup.jarvis')
+    await createBackup({ outputPath: archivePath, dshHome: source.dshHome, dataDir: source.dataDir, runtimeDir: join(root, 'runtime') })
+    const archive = JSON.parse(await readFile(archivePath, 'utf8'))
+    assert.equal(archive.files.some(file => file.path === 'data/memory.json'), false)
   } finally {
     await rm(root, { recursive: true, force: true })
   }
@@ -103,6 +133,19 @@ test('rejects corrupted or unsafe archives before replacing existing state', asy
     await assert.rejects(
       restoreBackup({ archivePath: unsafeEntryPath, dshHome: targetDsh, dataDir: targetData, runtimeDir }),
       /unsafe permissions/,
+    )
+
+    const invalidMemory = structuredClone(document)
+    const memoryFile = invalidMemory.files.find(file => file.path === 'data/memory.json')
+    const invalidMemoryContent = Buffer.from('{"version":1,"items":[],"unexpected":true}\n')
+    memoryFile.size = invalidMemoryContent.byteLength
+    memoryFile.sha256 = createHash('sha256').update(invalidMemoryContent).digest('hex')
+    memoryFile.contentBase64 = invalidMemoryContent.toString('base64')
+    const invalidMemoryPath = join(root, 'invalid-memory.jarvis')
+    await privateFile(invalidMemoryPath, `${JSON.stringify(invalidMemory)}\n`)
+    await assert.rejects(
+      restoreBackup({ archivePath: invalidMemoryPath, dshHome: targetDsh, dataDir: targetData, runtimeDir }),
+      /memory document is invalid/,
     )
 
     await chmod(archivePath, 0o644)

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict'
+import { chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { MemoryStore, validateMemoryDocument } from '../dist/memory.js'
+
+function deterministicStore(directory, clock) {
+  let nextId = 0
+  return new MemoryStore(directory, {
+    now: () => new Date(clock.value),
+    randomUUID: () => `memory-${++nextId}`,
+  })
+}
+
+const persistentRetention = { kind: 'until-deleted', expiresAt: null }
+
+test('persists an owner-controlled memory lifecycle and recalls only confirmed current facts', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-memory-'))
+  const clock = { value: '2030-01-01T00:00:00.000Z' }
+  try {
+    const store = deterministicStore(directory, clock)
+    await store.initialize()
+    const proposed = await store.propose({
+      class: 'profile', content: '  Preferred language is Chinese  ', sensitivity: 'standard', confidence: 1,
+      source: { kind: 'explicit-user', reference: 'conversation-one:message-one' }, retention: persistentRetention,
+    })
+    const duplicate = await store.propose({
+      class: 'profile', content: 'Preferred language is Chinese', sensitivity: 'standard', confidence: 1,
+      source: { kind: 'explicit-user', reference: 'conversation-one:message-one' }, retention: persistentRetention,
+    })
+    assert.equal(duplicate.id, proposed.id)
+    assert.deepEqual(await store.recall(), [])
+
+    clock.value = '2030-01-01T00:01:00.000Z'
+    const confirmed = await store.confirm(proposed.id)
+    assert.equal(confirmed.status, 'confirmed')
+    assert.equal((await store.recall())[0].id, proposed.id)
+
+    const candidate = await store.propose({
+      class: 'episodic', content: 'Unconfirmed model candidate', sensitivity: 'sensitive', confidence: 0.7,
+      source: { kind: 'model-candidate', reference: 'conversation-one:turn-two' }, retention: persistentRetention,
+    })
+    await store.reject(candidate.id)
+    clock.value = '2030-01-01T00:02:00.000Z'
+    const edited = await store.editConfirmed(proposed.id, 'Preferred language is Simplified Chinese')
+    assert.equal(edited.status, 'confirmed')
+    assert.equal(edited.supersedesId, proposed.id)
+    assert.deepEqual(edited.source, { kind: 'owner-edit', reference: proposed.id })
+    assert.deepEqual((await store.recall()).map(item => item.id), [edited.id])
+
+    const exported = await store.export()
+    assert.equal(exported.version, 1)
+    assert.throws(() => validateMemoryDocument({ ...exported, items: [exported.items[0], exported.items[0]] }), /duplicate/)
+    assert.equal(exported.items.find(item => item.id === proposed.id).status, 'superseded')
+    assert.equal(exported.items.find(item => item.id === candidate.id).status, 'rejected')
+    await store.delete(edited.id)
+    assert.deepEqual(await store.recall(), [])
+    assert.equal((await store.export()).items.some(item => item.id === edited.id), false)
+    assert.equal((await stat(store.path)).mode & 0o777, 0o600)
+    assert.equal((await stat(directory)).mode & 0o777, 0o700)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('expires bounded memories deterministically and refuses late confirmation', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-memory-expiry-'))
+  const clock = { value: '2030-01-01T00:00:00.000Z' }
+  try {
+    const store = deterministicStore(directory, clock)
+    await store.initialize()
+    const confirmed = await store.propose({
+      class: 'episodic', content: 'Temporary project decision', sensitivity: 'standard', confidence: 0.9,
+      source: { kind: 'explicit-user', reference: null },
+      retention: { kind: 'expires-at', expiresAt: '2030-01-02T00:00:00.000Z' },
+    })
+    await store.confirm(confirmed.id)
+    const unconfirmed = await store.propose({
+      class: 'episodic', content: 'Temporary candidate', sensitivity: 'standard', confidence: 0.5,
+      source: { kind: 'model-candidate', reference: null },
+      retention: { kind: 'expires-at', expiresAt: '2030-01-02T00:00:00.000Z' },
+    })
+    clock.value = '2030-01-02T00:00:00.000Z'
+    assert.deepEqual(await store.recall(), [])
+    await assert.rejects(store.confirm(unconfirmed.id), /must be proposed/)
+    assert.deepEqual((await store.list()).map(item => item.status), ['expired', 'expired'])
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('serializes concurrent proposals and rejects malformed or unsafe state', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-memory-validation-'))
+  const clock = { value: '2030-01-01T00:00:00.000Z' }
+  try {
+    const store = deterministicStore(directory, clock)
+    await store.initialize()
+    await Promise.all(Array.from({ length: 20 }, (_, index) => store.propose({
+      class: 'profile', content: `Fact ${index}`, sensitivity: 'standard', confidence: 1,
+      source: { kind: 'explicit-user', reference: `message-${index}` }, retention: persistentRetention,
+    })))
+    assert.equal((await store.list()).length, 20)
+    await assert.rejects(store.propose({
+      class: 'profile', content: 'x'.repeat(4_097), sensitivity: 'standard', confidence: 1,
+      source: { kind: 'explicit-user', reference: null }, retention: persistentRetention,
+    }), /4096/)
+    await assert.rejects(store.propose({
+      class: 'profile', content: 'Already expired', sensitivity: 'standard', confidence: 1,
+      source: { kind: 'explicit-user', reference: null },
+      retention: { kind: 'expires-at', expiresAt: '2029-12-31T23:59:59.000Z' },
+    }), /future/)
+    const invalidIds = new MemoryStore(directory, {
+      now: () => new Date(clock.value), randomUUID: () => '../outside',
+    })
+    await assert.rejects(invalidIds.propose({
+      class: 'profile', content: 'Unsafe id', sensitivity: 'standard', confidence: 1,
+      source: { kind: 'explicit-user', reference: null }, retention: persistentRetention,
+    }), /id generator/)
+    assert.throws(() => validateMemoryDocument({ version: 1, items: [], extra: true }), /invalid/)
+
+    await writeFile(store.path, '{"version":1,"items":[{"id":"duplicate"},{"id":"duplicate"}]}\n')
+    await chmod(store.path, 0o600)
+    await assert.rejects(store.list(), /invalid|duplicate/)
+    await rm(store.path)
+    const target = join(directory, 'outside-memory.json')
+    await writeFile(target, '{"version":1,"items":[]}\n', { mode: 0o600 })
+    await symlink(target, store.path)
+    await assert.rejects(store.initialize(), /regular file/)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add a bounded versioned private memory source store with provenance, sensitivity, confidence, retention, and lifecycle state
- keep candidates proposed until an explicit owner-facing caller confirms or rejects them
- support exact duplicate reuse, superseding edits, deterministic expiry, stable export, recall filtering, and physical deletion
- reject malformed schemas, unsafe IDs, symbolic-link reads, oversized state, and concurrent write loss
- initialize the store at runtime and include existing memory state in validated offline backup/restore
- preserve backup compatibility for installations that have not initialized the new file yet

## Verification
- `npm run verify` (185/185)
- `npm run verify:runtime` including version 1 empty memory file and 0600 permission assertion
- `npm run verify:release`

## Evidence boundary
- This PR does not add model extraction, prompt-context retrieval, embeddings, proactive triggers, a confirmation tool, or memory UI.
- Confirmed recall behavior is covered at the store boundary only; no live model conversation used memory context.

Closes #88