### PR TITLE
Add explicit local Owner memory management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,22 @@ npm run restore -- --archive backups/jarvis-backup.jarvis
 
 归档包含 Harness 会话、工作区映射、提醒、用户记忆、审计和已有 Gateway 状态，文件权限为 `0600`。它不包含 `.env`、Harness 模型凭据、Keychain 项、Owner Token 或 TLS 私钥。当前归档未加密，应只保存在受保护磁盘；完整停止、验证和跨机器恢复步骤见[备份与恢复指南](docs/operations/backup-restore.md)。
 
+## 本机记忆管理
+
+记忆内容从交互提示或标准输入读取，不作为命令参数传入。新记忆先进入 `proposed`，确认后才会出现在 `recall` 结果中：
+
+```bash
+printf '%s\n' '偏好使用简体中文' | npm run memory -- propose --class profile
+npm run memory -- list --status proposed
+npm run memory -- confirm --id <memory-id>
+npm run memory -- recall
+printf '%s\n' '偏好使用中文回答' | npm run memory -- edit --id <memory-id>
+npm run memory -- export --output backups/jarvis-memory.json
+npm run memory -- delete --id <memory-id>
+```
+
+导出文件以 `0600` 新建且不会覆盖已有路径。该入口仅面向本机 Owner，不是 Harness 工具；当前仍未把确认记忆自动加入模型提示词。
+
 ## 数据与安全
 
 - Harness 会话：`.dsh/sessions/`

--- a/docs/plan/07-stage-6-memory-proactivity.md
+++ b/docs/plan/07-stage-6-memory-proactivity.md
@@ -26,11 +26,12 @@ Raw model reasoning is never a memory authority.
 
 ## Current Increment
 
-The versioned owner-controlled source store is tracked by [#88](https://github.com/gh503/jarvis/issues/88).
+The versioned owner-controlled source store and local management CLI are tracked by [#88](https://github.com/gh503/jarvis/issues/88) and [#90](https://github.com/gh503/jarvis/issues/90).
 
 - Candidates enter only the proposed state and cannot become confirmed through model authority in this increment.
 - Confirmed edits supersede the previous source item; rejected, superseded, expired, and physically deleted items are excluded from recall.
 - The bounded private source file is initialized by Jarvis and included in offline backup/restore with semantic validation.
+- The local owner can manage every lifecycle transition and create a private full export without granting the model confirmation authority.
 - Automatic extraction, prompt-context retrieval, derived indexes, owner management UI, and proactive rules remain deferred.
 
 ## Modules

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start:gateway": "./scripts/start-gateway.sh",
     "backup": "npm run build --silent && node dist/backup-main.js backup",
     "restore": "npm run build --silent && node dist/backup-main.js restore",
+    "memory": "npm run build --silent && node dist/memory-main.js",
     "pair:node": "npm run build --silent && node dist/node-pairing-main.js",
     "pair:approve": "npm run build --silent && node dist/pairing-approval-main.js",
     "verify": "npm run typecheck && npm test",

--- a/src/memory-main.ts
+++ b/src/memory-main.ts
@@ -1,0 +1,179 @@
+import { chmod, mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { stdin, stdout } from 'node:process'
+import { createInterface } from 'node:readline/promises'
+import { parseArgs } from 'node:util'
+import { MemoryStore, type MemoryClass, type MemorySensitivity, type MemoryStatus } from './memory.js'
+
+const MAX_INPUT_BYTES = 8 * 1024
+const STATUSES: MemoryStatus[] = ['proposed', 'confirmed', 'rejected', 'superseded', 'expired']
+
+function usage(): string {
+  return [
+    'Usage: npm run memory -- <command> [options]',
+    '',
+    'Commands:',
+    '  propose --class <profile|episodic> [--sensitivity <standard|sensitive>] [--confidence <0..1>]',
+    '  list [--status <status>]',
+    '  recall',
+    '  confirm --id <memory-id>',
+    '  reject --id <memory-id>',
+    '  edit --id <memory-id>',
+    '  delete --id <memory-id>',
+    '  export --output <new-file>',
+    '',
+    'New and edited content is read from an interactive prompt or standard input.',
+    'All commands accept --data-dir <directory>.',
+  ].join('\n')
+}
+
+function onlyOptions(values: Record<string, boolean | string | undefined>, allowed: readonly string[]): void {
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined && value !== false && !allowed.includes(key)) throw new Error(`option --${key} is not valid for this command`)
+  }
+}
+
+function required(values: Record<string, boolean | string | undefined>, name: string): string {
+  const value = values[name]
+  if (typeof value !== 'string' || value.trim().length === 0) throw new Error(`--${name} is required`)
+  return value.trim()
+}
+
+async function readContent(label: string): Promise<string> {
+  if (stdin.isTTY && stdout.isTTY) {
+    const prompt = createInterface({ input: stdin, output: stdout })
+    try {
+      return await prompt.question(`${label}: `)
+    } finally {
+      prompt.close()
+    }
+  }
+  const chunks: Buffer[] = []
+  let size = 0
+  for await (const chunk of stdin) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    size += bytes.byteLength
+    if (size > MAX_INPUT_BYTES) throw new Error(`standard input exceeds ${MAX_INPUT_BYTES} bytes`)
+    chunks.push(bytes)
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function print(value: unknown): void {
+  stdout.write(`${JSON.stringify(value)}\n`)
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs({
+    options: {
+      help: { type: 'boolean' },
+      'data-dir': { type: 'string' },
+      id: { type: 'string' },
+      class: { type: 'string' },
+      sensitivity: { type: 'string' },
+      confidence: { type: 'string' },
+      'source-reference': { type: 'string' },
+      'expires-at': { type: 'string' },
+      status: { type: 'string' },
+      output: { type: 'string' },
+    },
+    strict: true,
+    allowPositionals: true,
+  })
+  if (parsed.values.help === true) {
+    stdout.write(`${usage()}\n`)
+    return
+  }
+  if (parsed.positionals.length !== 1) throw new Error(usage())
+  const command = parsed.positionals[0] as string
+  const dataDir = resolve(parsed.values['data-dir'] ?? process.env.JARVIS_DATA_DIR ?? resolve(import.meta.dirname, '..', 'data'))
+  const common = ['data-dir']
+  const optionsByCommand: Record<string, string[]> = {
+    propose: [...common, 'class', 'sensitivity', 'confidence', 'source-reference', 'expires-at'],
+    list: [...common, 'status'],
+    recall: common,
+    confirm: [...common, 'id'],
+    reject: [...common, 'id'],
+    edit: [...common, 'id'],
+    delete: [...common, 'id'],
+    export: [...common, 'output'],
+  }
+  const allowed = optionsByCommand[command]
+  if (allowed === undefined) throw new Error(`unknown memory command: ${command}`)
+  onlyOptions(parsed.values, allowed)
+  if (['confirm', 'reject', 'edit', 'delete'].includes(command)) required(parsed.values, 'id')
+  if (command === 'propose') {
+    const classValue = required(parsed.values, 'class')
+    if (classValue !== 'profile' && classValue !== 'episodic') throw new Error('--class must be profile or episodic')
+    const sensitivity = parsed.values.sensitivity ?? 'standard'
+    if (sensitivity !== 'standard' && sensitivity !== 'sensitive') throw new Error('--sensitivity must be standard or sensitive')
+    const confidence = parsed.values.confidence === undefined ? 1 : Number(parsed.values.confidence)
+    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) throw new Error('--confidence must be between 0 and 1')
+  }
+  if (command === 'list' && parsed.values.status !== undefined
+    && !STATUSES.includes(parsed.values.status as MemoryStatus)) throw new Error('--status is invalid')
+  if (command === 'export') required(parsed.values, 'output')
+  const content = command === 'propose' ? await readContent('Memory content')
+    : command === 'edit' ? await readContent('Updated memory content') : undefined
+  const store = new MemoryStore(dataDir)
+  await store.initialize()
+
+  if (command === 'propose') {
+    const classValue = required(parsed.values, 'class')
+    if (classValue !== 'profile' && classValue !== 'episodic') throw new Error('--class must be profile or episodic')
+    const sensitivity = parsed.values.sensitivity ?? 'standard'
+    if (sensitivity !== 'standard' && sensitivity !== 'sensitive') throw new Error('--sensitivity must be standard or sensitive')
+    const confidence = parsed.values.confidence === undefined ? 1 : Number(parsed.values.confidence)
+    const expiresAt = parsed.values['expires-at']
+    const item = await store.propose({
+      class: classValue as MemoryClass,
+      content: content as string,
+      sensitivity: sensitivity as MemorySensitivity,
+      confidence,
+      source: { kind: 'explicit-user', reference: parsed.values['source-reference'] ?? null },
+      retention: expiresAt === undefined
+        ? { kind: 'until-deleted', expiresAt: null }
+        : { kind: 'expires-at', expiresAt },
+    })
+    print({ item })
+    return
+  }
+  if (command === 'list') {
+    const status = parsed.values.status
+    const items = await store.list()
+    print({ items: status === undefined ? items : items.filter(item => item.status === status) })
+    return
+  }
+  if (command === 'recall') {
+    print({ items: await store.recall() })
+    return
+  }
+  if (command === 'export') {
+    const output = resolve(required(parsed.values, 'output'))
+    await mkdir(dirname(output), { recursive: true, mode: 0o700 })
+    const document = await store.export()
+    await writeFile(output, `${JSON.stringify(document, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    await chmod(output, 0o600)
+    print({ path: output, itemCount: document.items.length })
+    return
+  }
+
+  const id = required(parsed.values, 'id')
+  if (command === 'confirm') {
+    print({ item: await store.confirm(id) })
+  } else if (command === 'reject') {
+    print({ item: await store.reject(id) })
+  } else if (command === 'edit') {
+    print({ item: await store.editConfirmed(id, content as string) })
+  } else if (command === 'delete') {
+    print({ item: await store.delete(id) })
+  }
+}
+
+try {
+  await main()
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'memory command failed'
+  process.stderr.write(`Memory command failed: ${message}\n`)
+  process.exitCode = 1
+}

--- a/test/memory-cli.test.js
+++ b/test/memory-cli.test.js
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import { access, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import test from 'node:test'
+
+const entrypoint = join(process.cwd(), 'dist', 'memory-main.js')
+
+function run(args, input = '') {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [entrypoint, ...args], { stdio: ['pipe', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', chunk => { stdout += chunk })
+    child.stderr.on('data', chunk => { stderr += chunk })
+    child.once('error', reject)
+    child.once('close', code => resolve({ code, stdout, stderr }))
+    child.stdin.end(input)
+  })
+}
+
+function value(result) {
+  assert.equal(result.code, 0, result.stderr)
+  assert.equal(result.stderr, '')
+  return JSON.parse(result.stdout)
+}
+
+test('manages the complete owner memory lifecycle without content arguments', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-memory-cli-'))
+  const dataArgs = ['--data-dir', directory]
+  try {
+    const proposed = value(await run(['propose', '--class', 'profile', ...dataArgs], 'Preferred language is Chinese\n')).item
+    assert.equal(proposed.status, 'proposed')
+    assert.equal(proposed.content, 'Preferred language is Chinese')
+
+    const pending = value(await run(['list', '--status', 'proposed', ...dataArgs])).items
+    assert.deepEqual(pending.map(item => item.id), [proposed.id])
+    assert.equal(value(await run(['recall', ...dataArgs])).items.length, 0)
+    assert.equal(value(await run(['confirm', '--id', proposed.id, ...dataArgs])).item.status, 'confirmed')
+    assert.deepEqual(value(await run(['recall', ...dataArgs])).items.map(item => item.id), [proposed.id])
+
+    const edited = value(await run(['edit', '--id', proposed.id, ...dataArgs], 'Preferred language is Simplified Chinese\n')).item
+    assert.equal(edited.supersedesId, proposed.id)
+    assert.deepEqual(value(await run(['recall', ...dataArgs])).items.map(item => item.id), [edited.id])
+
+    const rejectedCandidate = value(await run([
+      'propose', '--class', 'episodic', '--sensitivity', 'sensitive', '--confidence', '0.7', ...dataArgs,
+    ], 'Candidate to reject')).item
+    assert.equal(value(await run(['reject', '--id', rejectedCandidate.id, ...dataArgs])).item.status, 'rejected')
+
+    const exportPath = join(directory, 'exports', 'memory.json')
+    const exported = value(await run(['export', '--output', exportPath, ...dataArgs]))
+    assert.equal(exported.itemCount, 3)
+    assert.equal((await stat(exportPath)).mode & 0o777, 0o600)
+    assert.deepEqual(JSON.parse(await readFile(exportPath, 'utf8')), JSON.parse(await readFile(join(directory, 'memory.json'), 'utf8')))
+    const overwrite = await run(['export', '--output', exportPath, ...dataArgs])
+    assert.notEqual(overwrite.code, 0)
+
+    assert.equal(value(await run(['delete', '--id', edited.id, ...dataArgs])).item.id, edited.id)
+    assert.deepEqual(value(await run(['recall', ...dataArgs])).items, [])
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects invalid CLI combinations and bounded stdin without echoing content', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-memory-cli-invalid-'))
+  const dataArgs = ['--data-dir', directory]
+  try {
+    const unknown = await run(['unknown', ...dataArgs])
+    assert.notEqual(unknown.code, 0)
+    assert.match(unknown.stderr, /unknown memory command/)
+    await assert.rejects(access(join(directory, 'memory.json')))
+    const invalidStatus = await run(['list', '--status', 'private', ...dataArgs])
+    assert.notEqual(invalidStatus.code, 0)
+    assert.match(invalidStatus.stderr, /status is invalid/)
+    const missingId = await run(['confirm', ...dataArgs])
+    assert.notEqual(missingId.code, 0)
+    assert.match(missingId.stderr, /--id is required/)
+    const secret = 'private-value-that-must-not-be-echoed'
+    const oversized = await run(['propose', '--class', 'profile', ...dataArgs], secret.repeat(300))
+    assert.notEqual(oversized.code, 0)
+    assert.match(oversized.stderr, /8192 bytes/)
+    assert.doesNotMatch(oversized.stderr, /private-value/)
+    const contentOption = await run(['propose', '--class', 'profile', '--content', secret, ...dataArgs])
+    assert.notEqual(contentOption.code, 0)
+    assert.doesNotMatch(contentOption.stderr, new RegExp(secret))
+    await writeFile(join(directory, 'sentinel'), 'unchanged')
+    assert.equal(await readFile(join(directory, 'sentinel'), 'utf8'), 'unchanged')
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add local owner commands to propose, list, recall, confirm, reject, edit, export, and physically delete memory
- read new and edited content only from an interactive prompt or bounded stdin
- validate commands and options before state initialization
- emit machine-readable JSON and create private exports without overwriting existing files
- keep the CLI outside Harness tool authority

## Verification
- `npm run verify` (187/187)
- `npm run verify:runtime`
- `npm run verify:release`

## Evidence boundary
- This is a local Owner CLI, not a PWA memory UI or Harness tool.
- Confirmed memory is not yet injected into model prompts.
- Automatic extraction, retrieval indexing, proactive rules, and multi-process memory mutation remain deferred.

Closes #90