### PR TITLE
Add bounded model memory recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ npm run memory -- export --output backups/jarvis-memory.json
 npm run memory -- delete --id <memory-id>
 ```
 
-导出文件以 `0600` 新建且不会覆盖已有路径。该入口仅面向本机 Owner，不是 Harness 工具；当前仍未把确认记忆自动加入模型提示词。
+导出文件以 `0600` 新建且不会覆盖已有路径。该管理入口仅面向本机 Owner。Harness 的只读 `jarvis_memory_recall` 工具可按分类读取已确认、未过期且非敏感的记忆，并返回来源、置信度和确认时间；默认最多 10 条，硬上限 20 条和 16 KiB。该工具不能提议、确认、编辑或删除记忆，敏感记忆不会提交给模型。模型是否调用该工具取决于当前对话，它不是自动提示词注入，也不代表远端模型不会保留已提交的上下文。
 
 ## 数据与安全
 

--- a/docs/plan/07-stage-6-memory-proactivity.md
+++ b/docs/plan/07-stage-6-memory-proactivity.md
@@ -26,13 +26,14 @@ Raw model reasoning is never a memory authority.
 
 ## Current Increment
 
-The versioned owner-controlled source store and local management CLI are tracked by [#88](https://github.com/gh503/jarvis/issues/88) and [#90](https://github.com/gh503/jarvis/issues/90).
+The versioned owner-controlled source store, local management CLI, and bounded read-only model recall are tracked by [#88](https://github.com/gh503/jarvis/issues/88), [#90](https://github.com/gh503/jarvis/issues/90), and [#92](https://github.com/gh503/jarvis/issues/92).
 
 - Candidates enter only the proposed state and cannot become confirmed through model authority in this increment.
 - Confirmed edits supersede the previous source item; rejected, superseded, expired, and physically deleted items are excluded from recall.
 - The bounded private source file is initialized by Jarvis and included in offline backup/restore with semantic validation.
 - The local owner can manage every lifecycle transition and create a private full export without granting the model confirmation authority.
-- Automatic extraction, prompt-context retrieval, derived indexes, owner management UI, and proactive rules remain deferred.
+- A read-only Harness tool can return only confirmed, current, standard-sensitivity items with provenance under item-count and byte limits.
+- Automatic extraction, prompt-wide injection, derived indexes, owner management UI, and proactive rules remain deferred.
 
 ## Modules
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { ApprovalLedger } from './approval.js'
 import { AppRegistry } from './apps.js'
 import { AuditLog } from './audit.js'
 import { DeviceCommandGatewayClient } from './device-command-client.js'
+import { recallForModel } from './memory-recall.js'
 import { MemoryStore } from './memory.js'
 import { MqttCommandGatewayClient } from './mqtt-command-client.js'
 import { ReminderStore, type Reminder } from './reminders.js'
@@ -15,7 +16,10 @@ import { readSystemStatus } from './system-status.js'
 export const name = 'jarvis-mac-mvp'
 export const inject = ['tools', 'webServer']
 
-const JARVIS_TOOLS = new Set(['jarvis_system_status', 'jarvis_open_app', 'jarvis_reminder', 'jarvis_device_control', 'jarvis_mqtt_device_control'])
+const JARVIS_TOOLS = new Set([
+  'jarvis_system_status', 'jarvis_open_app', 'jarvis_reminder', 'jarvis_memory_recall',
+  'jarvis_device_control', 'jarvis_mqtt_device_control',
+])
 
 function reminderOutput(reminders: Reminder[]) {
   return { reminders }
@@ -26,6 +30,8 @@ function safeAuditDetail(tool: string, argumentsValue: unknown): Record<string, 
   const detail: Record<string, string> = {}
   const keys = tool === 'jarvis_open_app'
     ? ['application']
+    : tool === 'jarvis_memory_recall'
+      ? ['class', 'limit']
     : tool === 'jarvis_device_control'
       ? ['capability', 'externalEntityId', 'service', 'expectedState']
       : tool === 'jarvis_mqtt_device_control'
@@ -175,6 +181,55 @@ export async function apply(ctx: Context): Promise<void> {
     },
     async execute() {
       return readSystemStatus()
+    },
+  }))
+
+  ctx.tools.register(defineTool({
+    name: 'jarvis_memory_recall',
+    description: 'Recall bounded owner-confirmed, non-sensitive personal memory. This tool is read-only and may omit results because of privacy or output limits.',
+    parameters: {
+      class: { type: 'string', enum: ['profile', 'episodic'], description: 'Optional memory class filter' },
+      limit: { type: 'integer', description: 'Maximum memories to return from 1 to 20; defaults to 10' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          memories: {
+            type: 'array',
+            required: true,
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                id: { type: 'string', required: true },
+                class: { type: 'string', required: true, enum: ['profile', 'episodic'] },
+                content: { type: 'string', required: true },
+                confidence: { type: 'number', required: true },
+                source: {
+                  type: 'object',
+                  required: true,
+                  additionalProperties: false,
+                  properties: {
+                    kind: { type: 'string', required: true, enum: ['explicit-user', 'model-candidate', 'owner-edit'] },
+                    reference: { oneOf: [{ type: 'string' }, { type: 'null' }], required: true },
+                  },
+                },
+                confirmedAt: { type: 'string', required: true },
+              },
+            },
+          },
+          truncated: { type: 'boolean', required: true },
+        },
+      },
+      render: (_args, value) => [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    },
+    async execute(args) {
+      return recallForModel(memories, {
+        ...(args.class === undefined ? {} : { class: args.class }),
+        ...(args.limit === undefined ? {} : { limit: args.limit }),
+      })
     },
   }))
 

--- a/src/memory-recall.ts
+++ b/src/memory-recall.ts
@@ -1,0 +1,66 @@
+import { type MemoryClass, type MemoryItem, type MemorySource, MemoryStore } from './memory.js'
+
+export const MODEL_MEMORY_DEFAULT_LIMIT = 10
+export const MODEL_MEMORY_MAX_ITEMS = 20
+export const MODEL_MEMORY_MAX_BYTES = 16 * 1024
+
+export interface ModelMemory {
+  id: string
+  class: MemoryClass
+  content: string
+  confidence: number
+  source: MemorySource
+  confirmedAt: string
+}
+
+export interface ModelMemoryRecall {
+  memories: ModelMemory[]
+  truncated: boolean
+}
+
+export interface ModelMemoryRecallOptions {
+  class?: MemoryClass
+  limit?: number
+}
+
+function project(item: MemoryItem): ModelMemory {
+  return {
+    id: item.id,
+    class: item.class,
+    content: item.content,
+    confidence: item.confidence,
+    source: structuredClone(item.source),
+    confirmedAt: item.confirmedAt as string,
+  }
+}
+
+function outputBytes(memories: ModelMemory[]): number {
+  return Buffer.byteLength(JSON.stringify({ memories, truncated: false }), 'utf8')
+}
+
+export async function recallForModel(
+  store: MemoryStore,
+  options: ModelMemoryRecallOptions = {},
+): Promise<ModelMemoryRecall> {
+  if (options.class !== undefined && options.class !== 'profile' && options.class !== 'episodic') {
+    throw new Error('memory class filter is invalid')
+  }
+  const limit = options.limit ?? MODEL_MEMORY_DEFAULT_LIMIT
+  if (!Number.isInteger(limit) || limit < 1 || limit > MODEL_MEMORY_MAX_ITEMS) {
+    throw new Error(`memory recall limit must be an integer from 1 to ${MODEL_MEMORY_MAX_ITEMS}`)
+  }
+
+  const candidates = (await store.recallReadOnly())
+    .filter(item => item.ownerId === 'local-owner' && item.sensitivity === 'standard'
+      && (options.class === undefined || item.class === options.class))
+    .sort((left, right) => (right.confirmedAt as string).localeCompare(left.confirmedAt as string)
+      || left.id.localeCompare(right.id))
+    .map(project)
+
+  const memories: ModelMemory[] = []
+  for (const candidate of candidates) {
+    if (memories.length === limit || outputBytes([...memories, candidate]) > MODEL_MEMORY_MAX_BYTES) break
+    memories.push(candidate)
+  }
+  return { memories, truncated: memories.length < candidates.length }
+}

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -259,6 +259,21 @@ export class MemoryStore {
     }))
   }
 
+  async recallReadOnly(): Promise<MemoryItem[]> {
+    let result: MemoryItem[] = []
+    const queued = this.pending.then(async () => {
+      const now = this.now().getTime()
+      const document = await this.readDocument()
+      result = document.items.filter(item => item.status === 'confirmed'
+        && (item.retention.kind === 'until-deleted'
+          || new Date(item.retention.expiresAt as string).getTime() > now))
+        .map(cloneItem).sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    })
+    this.pending = queued.catch(() => undefined)
+    await queued
+    return result
+  }
+
   async export(): Promise<MemoryDocument> {
     return this.mutate(document => ({ result: structuredClone(document), changed: false }))
   }

--- a/test/memory-recall.test.js
+++ b/test/memory-recall.test.js
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { MODEL_MEMORY_MAX_BYTES, recallForModel } from '../dist/memory-recall.js'
+import { MemoryStore } from '../dist/memory.js'
+
+const persistentRetention = { kind: 'until-deleted', expiresAt: null }
+
+function deterministicStore(directory, clock) {
+  let nextId = 0
+  return new MemoryStore(directory, {
+    now: () => new Date(clock.value),
+    randomUUID: () => `memory-${String(++nextId).padStart(3, '0')}`,
+  })
+}
+
+async function addMemory(store, input) {
+  const item = await store.propose({
+    class: input.class ?? 'profile',
+    content: input.content,
+    sensitivity: input.sensitivity ?? 'standard',
+    confidence: input.confidence ?? 1,
+    source: input.source ?? { kind: 'explicit-user', reference: null },
+    retention: input.retention ?? persistentRetention,
+  })
+  return store.confirm(item.id)
+}
+
+test('recalls only current confirmed standard memories with provenance', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-model-memory-'))
+  const clock = { value: '2030-01-01T00:00:00.000Z' }
+  try {
+    const store = deterministicStore(directory, clock)
+    await store.initialize()
+    const profile = await addMemory(store, {
+      content: 'Preferred language is Chinese',
+      source: { kind: 'explicit-user', reference: 'conversation-one:message-one' },
+    })
+    clock.value = '2030-01-01T00:01:00.000Z'
+    const episodic = await addMemory(store, { class: 'episodic', content: 'Project uses the MIT license', confidence: 0.9 })
+    await addMemory(store, { content: 'Private account detail', sensitivity: 'sensitive' })
+    const expiring = await addMemory(store, {
+      content: 'Temporary preference',
+      retention: { kind: 'expires-at', expiresAt: '2030-01-01T00:02:00.000Z' },
+    })
+    const proposed = await store.propose({
+      class: 'profile', content: 'Unconfirmed candidate', sensitivity: 'standard', confidence: 0.5,
+      source: { kind: 'model-candidate', reference: null }, retention: persistentRetention,
+    })
+    await store.reject(proposed.id)
+    const edited = await store.editConfirmed(profile.id, 'Preferred language is Simplified Chinese')
+
+    clock.value = '2030-01-01T00:02:00.000Z'
+    assert.deepEqual((await recallForModel(store)).memories.map(item => item.id), [episodic.id, edited.id])
+    assert.deepEqual((await recallForModel(store, { class: 'profile' })).memories, [{
+      id: edited.id,
+      class: 'profile',
+      content: 'Preferred language is Simplified Chinese',
+      confidence: 1,
+      source: { kind: 'owner-edit', reference: profile.id },
+      confirmedAt: edited.confirmedAt,
+    }])
+    assert.equal((await recallForModel(store)).memories.some(item => item.id === proposed.id), false)
+    const persisted = JSON.parse(await readFile(store.path, 'utf8'))
+    assert.equal(persisted.items.find(item => item.id === expiring.id).status, 'confirmed')
+
+    await store.delete(edited.id)
+    assert.deepEqual((await recallForModel(store, { class: 'profile' })).memories, [])
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('validates recall filters and bounds deterministic model output', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-model-memory-bounds-'))
+  const clock = { value: '2030-01-01T00:00:00.000Z' }
+  try {
+    const store = deterministicStore(directory, clock)
+    await store.initialize()
+    for (let index = 0; index < 8; index += 1) {
+      clock.value = new Date(Date.parse(clock.value) + 1_000).toISOString()
+      await addMemory(store, { content: `${index}:${'x'.repeat(3_900)}` })
+    }
+
+    const limited = await recallForModel(store, { limit: 2 })
+    assert.equal(limited.memories.length, 2)
+    assert.equal(limited.truncated, true)
+    assert.ok(Buffer.byteLength(JSON.stringify(limited), 'utf8') <= MODEL_MEMORY_MAX_BYTES)
+    assert.deepEqual(limited.memories.map(item => item.content.slice(0, 1)), ['7', '6'])
+
+    const byteBounded = await recallForModel(store, { limit: 20 })
+    assert.equal(byteBounded.truncated, true)
+    assert.ok(byteBounded.memories.length < 8)
+    assert.ok(Buffer.byteLength(JSON.stringify(byteBounded), 'utf8') <= MODEL_MEMORY_MAX_BYTES)
+    await assert.rejects(recallForModel(store, { limit: 0 }), /integer from 1 to 20/)
+    await assert.rejects(recallForModel(store, { limit: 21 }), /integer from 1 to 20/)
+    await assert.rejects(recallForModel(store, { class: 'secret' }), /class filter/)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add a read-only Harness tool for owner-confirmed standard memory
- return provenance and confidence under class, item-count, and UTF-8 byte limits
- keep sensitive and every non-confirmed lifecycle state out of model-visible results
- use a non-mutating store snapshot so Harness recall does not become a second lifecycle writer
- document the model and privacy boundary

## Verification
- `npm run verify` (189/189)
- `npm run verify:runtime`
- `npm run verify:release` after commit `4e84e47`

## Evidence boundary
- The tool is read-only and cannot propose, confirm, edit, reject, export, or delete memory.
- It is model-invoked, not automatic prompt-wide injection.
- No extraction, embeddings, PWA memory UI, cross-process mutation, or remote-provider retention claim is added.

Closes #92