### PR TITLE
Fix failed conversation completion notices

### DIFF
--- a/test/conversations.test.js
+++ b/test/conversations.test.js
@@ -143,6 +143,42 @@ test('refreshes the authoritative snapshot when the event stream requires synchr
   assert.equal(calls.filter(call => call[1] === '/v1/conversations').length, initialLists + 1)
 })
 
+test('does not append completed activity after a failed conversation turn', async () => {
+  const states = []
+  const sockets = []
+  const client = new ConversationsClient(gatewayPairing([]), state => states.push(state), {
+    store: memoryStore(),
+    location: { origin: 'https://jarvis.internal' },
+    socketFactory: url => {
+      const socket = new FakeSocket(url)
+      sockets.push(socket)
+      return socket
+    },
+  })
+  await client.start()
+  await tick()
+  sockets[0].open()
+  sockets[0].message({ type: 'events.ready', cursor, replayCount: 0, requiresSnapshot: false })
+  await tick()
+  sockets[0].message({
+    version: 1, type: 'conversation.status', cursor: `${'A'.repeat(22)}.2`, occurredAt: 2_000,
+    conversationId: conversation.id, running: true,
+  })
+  await tick()
+  sockets[0].message({
+    version: 1, type: 'conversation.error', cursor: `${'A'.repeat(22)}.3`, occurredAt: 3_000,
+    conversationId: conversation.id, code: 'harness_agent_error',
+  })
+  await tick()
+  sockets[0].message({
+    version: 1, type: 'conversation.status', cursor: `${'A'.repeat(22)}.4`, occurredAt: 4_000,
+    conversationId: conversation.id, running: false,
+  })
+  await tick()
+  assert.deepEqual(states.at(-1).activity.map(item => item.label), ['对话执行失败', 'Jarvis 正在回复'])
+  assert.match(states.at(-1).message, /未能完成/)
+})
+
 test('shows a cached snapshot as stale while offline without contacting the Gateway', async () => {
   const store = memoryStore()
   await store.write('conversation-cache', {

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -23,8 +23,8 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js?v=15', '/app/pairing.js?v=15', '/app/device-store.js?v=15',
-    '/app/conversations.js?v=15', '/app/notifications.js?v=15', '/app/voice.js?v=15', '/app/apple-touch-icon.png', '/app/icon.svg',
+    '/app/', '/app/app.css', '/app/app.js?v=16', '/app/pairing.js?v=16', '/app/device-store.js?v=16',
+    '/app/conversations.js?v=16', '/app/notifications.js?v=16', '/app/voice.js?v=16', '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {
     assert.ok(serviceWorker.includes(`'${path}'`), `${path} must be pre-cached`)
@@ -275,6 +275,31 @@ test('quiet hours and rate limits suppress system presentation but retain histor
   assert.equal(systemNotifications.length, 1)
   await center.ingestEvent({ ...base, cursor: 'B'.repeat(22) + '.3', conversationId: 'conversation-3' })
   assert.equal(systemNotifications.length, 1)
+})
+
+test('reports failed turns without emitting a false completion notification', async () => {
+  const store = memoryDeviceStore()
+  const center = new NotificationCenter({ store, permission: 'default' })
+  await center.initialize()
+  const base = { version: 1, occurredAt: 1_700_000_000_000, conversationId: 'conversation-1' }
+  assert.equal(await center.ingestEvent({
+    ...base, cursor: 'D'.repeat(22) + '.1', type: 'conversation.status', running: true,
+  }), false)
+  assert.equal(await center.ingestEvent({
+    ...base, cursor: 'D'.repeat(22) + '.2', type: 'conversation.error', code: 'harness_agent_error',
+  }), true)
+  assert.equal(await center.ingestEvent({
+    ...base, cursor: 'D'.repeat(22) + '.3', type: 'conversation.status', running: false,
+  }), false)
+  assert.equal(center.history.length, 1)
+  assert.equal(center.history[0].title, 'Jarvis 回复失败')
+  assert.deepEqual(center.history[0].resource, { view: 'chat', conversationId: 'conversation-1' })
+
+  assert.equal(await center.ingestEvent({
+    ...base, conversationId: 'conversation-2', cursor: 'D'.repeat(22) + '.4',
+    type: 'conversation.status', running: false,
+  }), true)
+  assert.equal(center.history[0].title, 'Jarvis 已完成回复')
 })
 
 test('notification history is bounded, persisted, and cleared on revocation', async () => {

--- a/web/app.js
+++ b/web/app.js
@@ -1,7 +1,7 @@
-import { ConversationsClient } from './conversations.js?v=15'
-import { BrowserPairing } from './pairing.js?v=15'
-import { NotificationCenter } from './notifications.js?v=15'
-import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=15'
+import { ConversationsClient } from './conversations.js?v=16'
+import { BrowserPairing } from './pairing.js?v=16'
+import { NotificationCenter } from './notifications.js?v=16'
+import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=16'
 
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -156,6 +156,7 @@ export class ConversationsClient {
     this.approvalSubmittedIds = new Set()
     this.deviceApprovalSubmittedIds = new Set()
     this.cancellationPendingIds = new Set()
+    this.failedConversationIds = new Set()
     this.cancellationGeneration = 0
     this.cachedAt = undefined
     this.socket = undefined
@@ -201,6 +202,7 @@ export class ConversationsClient {
     this.approvalSubmittedIds.clear()
     this.deviceApprovalSubmittedIds.clear()
     this.cancellationPendingIds.clear()
+    this.failedConversationIds.clear()
     this.cancellationGeneration += 1
     this.clearReconnect()
     if (this.socket !== undefined) {
@@ -589,6 +591,7 @@ export class ConversationsClient {
       return
     }
     let eventNotice
+    let eventActivity = eventDescription(event)
     if (event.type === 'sync.required') {
       this.emit('stale')
       if (!await this.refresh()) return
@@ -596,6 +599,11 @@ export class ConversationsClient {
       if (!await this.refresh()) return
     } else if (event.type === 'conversation.status' && ID_PATTERN.test(event.conversationId)
       && typeof event.running === 'boolean') {
+      if (event.running) this.failedConversationIds.delete(event.conversationId)
+      if (!event.running && this.failedConversationIds.delete(event.conversationId)) {
+        eventActivity = undefined
+        eventNotice = 'Jarvis 未能完成本次回复'
+      }
       this.conversations = this.conversations.map(item => item.id === event.conversationId
         ? { ...item, running: event.running, updatedAt: event.occurredAt }
         : item).sort((left, right) => right.updatedAt - left.updatedAt)
@@ -609,6 +617,7 @@ export class ConversationsClient {
         this.messages = [...this.messages, event.message].sort((left, right) => left.sequence - right.sequence).slice(-MAX_MESSAGES)
       }
     } else if (event.type === 'conversation.error' && ID_PATTERN.test(event.conversationId)) {
+      this.failedConversationIds.add(event.conversationId)
       eventNotice = 'Jarvis 未能完成本次回复'
     } else if (event.type === 'approval.pending' && validApproval(event.approval)) {
       this.approvals = [event.approval, ...this.approvals.filter(item => item.id !== event.approval.id)]
@@ -635,7 +644,7 @@ export class ConversationsClient {
       return
     }
     await this.onEvent(event)
-    this.addActivity(eventDescription(event))
+    if (eventActivity !== undefined) this.addActivity(eventActivity)
     this.cachedAt = Date.now()
     await this.persistCache()
     await this.store.write(CURSOR_KEY, event.cursor)

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js?v=15" type="module"></script>
+    <script src="./app.js?v=16" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>

--- a/web/notifications.js
+++ b/web/notifications.js
@@ -99,6 +99,13 @@ function notificationForEvent(event) {
       resource: { view: 'chat', conversationId: event.conversationId },
     }
   }
+  if (event.type === 'conversation.error' && RESOURCE_ID_PATTERN.test(event.conversationId ?? '')) {
+    return {
+      id: `conversation:${event.conversationId}:failed:${event.cursor}`, category: 'conversation',
+      title: 'Jarvis 回复失败', body: '本次回复未能完成，请返回对话后重试。',
+      resource: { view: 'chat', conversationId: event.conversationId },
+    }
+  }
   if (event.type === 'sync.required') {
     return {
       id: `connection:${event.cursor}`, category: 'connection',
@@ -135,6 +142,7 @@ export class NotificationCenter {
     this.permission = options.permission ?? (typeof Notification === 'undefined' ? 'unsupported' : Notification.permission)
     this.history = []
     this.preferences = clonePreferences(DEFAULT_NOTIFICATION_PREFERENCES)
+    this.failedConversationIds = new Set()
   }
 
   async initialize() {
@@ -144,6 +152,12 @@ export class NotificationCenter {
   }
 
   async ingestEvent(event) {
+    if (event?.type === 'conversation.status' && RESOURCE_ID_PATTERN.test(event.conversationId ?? '')) {
+      if (event.running === true) this.failedConversationIds.delete(event.conversationId)
+      if (event.running === false && this.failedConversationIds.delete(event.conversationId)) return false
+    } else if (event?.type === 'conversation.error' && RESOURCE_ID_PATTERN.test(event.conversationId ?? '')) {
+      this.failedConversationIds.add(event.conversationId)
+    }
     const candidate = notificationForEvent(event)
     if (candidate === null || this.history.some(item => item.id === candidate.id)) return false
     const notification = {
@@ -203,6 +217,7 @@ export class NotificationCenter {
 
   async clear() {
     this.history = []
+    this.failedConversationIds.clear()
     await this.store.delete(NOTIFICATION_HISTORY_KEY)
     await this.store.delete(NOTIFICATION_PREFERENCES_KEY)
     this.preferences = clonePreferences(DEFAULT_NOTIFICATION_PREFERENCES)

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,13 +1,13 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v15'
+const CACHE_NAME = 'jarvis-pwa-shell-v16'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js?v=15',
-  '/app/pairing.js?v=15',
-  '/app/device-store.js?v=15',
-  '/app/conversations.js?v=15',
-  '/app/notifications.js?v=15',
-  '/app/voice.js?v=15',
+  '/app/app.js?v=16',
+  '/app/pairing.js?v=16',
+  '/app/device-store.js?v=16',
+  '/app/conversations.js?v=16',
+  '/app/notifications.js?v=16',
+  '/app/voice.js?v=16',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',


### PR DESCRIPTION
## Summary

- emit a redacted failure notification for failed conversation turns
- suppress false completion notifications and activity after `conversation.error`
- preserve the failure notice through the terminal stopped event
- bump the PWA shell cache version so installed clients receive the fix

## Verification

- `npm run verify` (191/191)
- `npm run verify:runtime`
- `npm run verify:release` (191/191 plus clean macOS install/startup/uninstall)
- physical HONOR ALP-AN00 reproduction recorded on #16

Closes #95
