### PR TITLE
Fix offline Gateway health convergence

### DIFF
--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -20,6 +20,7 @@ const ASSET_DEFINITIONS = new Map<string, PwaAssetDefinition>([
   ['/app/pairing.js', { file: 'pairing.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/device-store.js', { file: 'device-store.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/conversations.js', { file: 'conversations.js', contentType: 'text/javascript; charset=utf-8' }],
+  ['/app/gateway-health.js', { file: 'gateway-health.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/notifications.js', { file: 'notifications.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/voice.js', { file: 'voice.js', contentType: 'text/javascript; charset=utf-8' }],
   ['/app/manifest.webmanifest', { file: 'manifest.webmanifest', contentType: 'application/manifest+json; charset=utf-8' }],

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -215,6 +215,11 @@ test('serves the exact PWA shell routes with restrictive browser headers', async
     assert.equal(voice.status, 200)
     assert.match(voice.headers.get('content-type') ?? '', /^text\/javascript/)
 
+    const gatewayHealth = await request(gateway, '/app/gateway-health.js?v=17')
+    assert.equal(gatewayHealth.status, 200)
+    assert.match(gatewayHealth.headers.get('content-type') ?? '', /^text\/javascript/)
+    assert.match(await gatewayHealth.text(), /fetchGatewayHealth/)
+
     const head = await request(gateway, '/app/app.css', { method: 'HEAD' })
     assert.equal(head.status, 200)
     assert.match(head.headers.get('content-type') ?? '', /^text\/css/)

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import test from 'node:test'
 import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
 import { BrowserPairing, decryptPairingCredential } from '../web/pairing.js'
+import { fetchGatewayHealth } from '../web/gateway-health.js'
 import { NotificationCenter } from '../web/notifications.js'
 
 const webRoot = join(process.cwd(), 'web')
@@ -23,14 +24,22 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js?v=16', '/app/pairing.js?v=16', '/app/device-store.js?v=16',
-    '/app/conversations.js?v=16', '/app/notifications.js?v=16', '/app/voice.js?v=16', '/app/apple-touch-icon.png', '/app/icon.svg',
+    '/app/', '/app/app.css', '/app/app.js?v=17', '/app/pairing.js?v=17', '/app/device-store.js?v=17',
+    '/app/conversations.js?v=17', '/app/gateway-health.js?v=17', '/app/notifications.js?v=17', '/app/voice.js?v=17',
+    '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {
     assert.ok(serviceWorker.includes(`'${path}'`), `${path} must be pre-cached`)
   }
   assert.match(serviceWorker, /event\.request\.mode === 'navigate'/)
   assert.match(serviceWorker, /caches\.match\('\/app\/'\)/)
+
+  for (const file of ['app.js', 'conversations.js', 'notifications.js', 'pairing.js']) {
+    const source = await readFile(join(webRoot, file), 'utf8')
+    for (const match of source.matchAll(/from '\.\/(.+?\?v=\d+)'/g)) {
+      assert.ok(serviceWorker.includes(`'/app/${match[1]}'`), `${file} dependency ${match[1]} must be pre-cached`)
+    }
+  }
 })
 
 test('ships valid standard and Apple PNG icon dimensions', async () => {
@@ -42,15 +51,38 @@ test('ships valid standard and Apple PNG icon dimensions', async () => {
   }
 })
 
+test('bounds Gateway health checks even when fetch ignores abort', async () => {
+  let aborted = false
+  const never = (_url, options) => {
+    options.signal.addEventListener('abort', () => { aborted = true })
+    return new Promise(() => {})
+  }
+  const timers = []
+  const request = fetchGatewayHealth(never, {
+    timeoutMs: 10,
+    setTimeout: callback => { timers.push(callback); return 1 },
+    clearTimeout: () => {},
+  })
+  timers[0]()
+  await assert.rejects(request, /timed out/)
+  assert.equal(aborted, true)
+
+  const health = await fetchGatewayHealth(async () => ({
+    ok: true, json: async () => ({ service: 'jarvis-gateway', status: 'ok', scope: 'loopback-only' }),
+  }), { setTimeout: () => 1, clearTimeout: () => {} })
+  assert.equal(health.status, 'ok')
+})
+
 test('keeps the browser client on the public Gateway contract', async () => {
   const appSource = await readFile(join(webRoot, 'app.js'), 'utf8')
+  const gatewayHealthSource = await readFile(join(webRoot, 'gateway-health.js'), 'utf8')
   const pairingSource = await readFile(join(webRoot, 'pairing.js'), 'utf8')
   const conversationsSource = await readFile(join(webRoot, 'conversations.js'), 'utf8')
   const notificationsSource = await readFile(join(webRoot, 'notifications.js'), 'utf8')
   const voiceSource = await readFile(join(webRoot, 'voice.js'), 'utf8')
   const deviceStoreSource = await readFile(join(webRoot, 'device-store.js'), 'utf8')
   const htmlSource = await readFile(join(webRoot, 'index.html'), 'utf8')
-  assert.match(appSource, /fetch\('\.\.\/v1\/health'/)
+  assert.match(gatewayHealthSource, /fetchValue\('\.\.\/v1\/health'/)
   assert.match(appSource, /handlePairingState\(\{ phase: 'loading' \}\)/)
   assert.match(deviceStoreSource, /indexedDB\.open/)
   assert.match(pairingSource, /await this\.initialize\(\)/)
@@ -74,8 +106,8 @@ test('keeps the browser client on the public Gateway contract', async () => {
   assert.match(appSource, /data-speech-key|speechKey/)
   assert.match(appSource, /playbackController\.cancel\(\)/)
   assert.match(appSource, /conversationsClient\.cancelActive\(\)/)
-  assert.doesNotMatch(`${appSource}\n${pairingSource}\n${conversationsSource}`, /@deepseek-ai|dsh|Harness|\/api\//i)
-  assert.doesNotMatch(`${appSource}\n${pairingSource}\n${conversationsSource}`, /localStorage|sessionStorage/)
+  assert.doesNotMatch(`${appSource}\n${gatewayHealthSource}\n${pairingSource}\n${conversationsSource}`, /@deepseek-ai|dsh|Harness|\/api\//i)
+  assert.doesNotMatch(`${appSource}\n${gatewayHealthSource}\n${pairingSource}\n${conversationsSource}`, /localStorage|sessionStorage/)
   assert.doesNotMatch(conversationsSource, /\.close\((1002|1008|1011)/)
 })
 

--- a/web/app.js
+++ b/web/app.js
@@ -1,7 +1,8 @@
-import { ConversationsClient } from './conversations.js?v=16'
-import { BrowserPairing } from './pairing.js?v=16'
-import { NotificationCenter } from './notifications.js?v=16'
-import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=16'
+import { ConversationsClient } from './conversations.js?v=17'
+import { fetchGatewayHealth } from './gateway-health.js?v=17'
+import { BrowserPairing } from './pairing.js?v=17'
+import { NotificationCenter } from './notifications.js?v=17'
+import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=17'
 
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')
@@ -635,16 +636,8 @@ async function probeGateway() {
   probeInProgress = true
   refreshButton.disabled = true
   setConnection('checking', '正在检查', '正在连接 Jarvis Gateway')
-  const controller = new AbortController()
-  const timeout = window.setTimeout(() => controller.abort(), 5_000)
   try {
-    const response = await fetch('../v1/health', {
-      cache: 'no-store',
-      headers: { accept: 'application/json' },
-      signal: controller.signal,
-    })
-    const health = await response.json()
-    if (!response.ok || health.service !== 'jarvis-gateway' || health.status !== 'ok') throw new Error('invalid gateway response')
+    const health = await fetchGatewayHealth()
     setConnection('online', '网关可用', `安全范围：${health.scope === 'loopback-only' ? '仅本机' : '私有网络'}`)
     if (pairingPhase === 'paired-offline') void pairing.accessSession(true).catch(() => {})
     if (pairingPhase !== 'paired') {
@@ -653,7 +646,6 @@ async function probeGateway() {
   } catch {
     setConnection('unavailable', '无法连接', 'Jarvis Gateway 暂时不可用')
   } finally {
-    window.clearTimeout(timeout)
     refreshButton.disabled = false
     probeInProgress = false
   }

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=12'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=17'
 
 const CACHE_KEY = 'conversation-cache'
 const CURSOR_KEY = 'event-cursor'

--- a/web/gateway-health.js
+++ b/web/gateway-health.js
@@ -1,0 +1,32 @@
+export const GATEWAY_HEALTH_TIMEOUT_MS = 5_000
+
+export async function fetchGatewayHealth(fetchValue = fetch, options = {}) {
+  const timeoutMs = options.timeoutMs ?? GATEWAY_HEALTH_TIMEOUT_MS
+  const setTimeoutValue = options.setTimeout ?? setTimeout
+  const clearTimeoutValue = options.clearTimeout ?? clearTimeout
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) throw new Error('gateway health timeout is invalid')
+  const controller = new AbortController()
+  let timer
+  const deadline = new Promise((_, reject) => {
+    timer = setTimeoutValue(() => {
+      controller.abort()
+      reject(new Error('gateway health request timed out'))
+    }, timeoutMs)
+  })
+  const request = (async () => {
+    const response = await fetchValue('../v1/health', {
+      cache: 'no-store', headers: { accept: 'application/json' }, signal: controller.signal,
+    })
+    const health = await response.json()
+    if (!response.ok || health?.service !== 'jarvis-gateway' || health.status !== 'ok'
+      || (health.scope !== 'loopback-only' && health.scope !== 'private-network')) {
+      throw new Error('invalid gateway response')
+    }
+    return health
+  })()
+  try {
+    return await Promise.race([request, deadline])
+  } finally {
+    clearTimeoutValue(timer)
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js?v=16" type="module"></script>
+    <script src="./app.js?v=17" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>

--- a/web/notifications.js
+++ b/web/notifications.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=11'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=17'
 
 export const NOTIFICATION_HISTORY_KEY = 'notification-history'
 export const NOTIFICATION_PREFERENCES_KEY = 'notification-preferences'

--- a/web/pairing.js
+++ b/web/pairing.js
@@ -1,4 +1,4 @@
-import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=11'
+import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=17'
 
 const MAX_RESPONSE_CHARS = 2 * 1024 * 1024
 

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,13 +1,14 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v16'
+const CACHE_NAME = 'jarvis-pwa-shell-v17'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js?v=16',
-  '/app/pairing.js?v=16',
-  '/app/device-store.js?v=16',
-  '/app/conversations.js?v=16',
-  '/app/notifications.js?v=16',
-  '/app/voice.js?v=16',
+  '/app/app.js?v=17',
+  '/app/pairing.js?v=17',
+  '/app/device-store.js?v=17',
+  '/app/conversations.js?v=17',
+  '/app/gateway-health.js?v=17',
+  '/app/notifications.js?v=17',
+  '/app/voice.js?v=17',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',


### PR DESCRIPTION
Closes #98

## Summary
- bound PWA Gateway health probes with a hard deadline even when fetch ignores AbortController
- pre-cache the new health module and align the complete module graph to cache version v17
- add regression coverage for hanging fetches and uncached versioned module dependencies

## Verification
- `npm run verify` (194 tests)
- physical HONOR Android 14: loaded online, removed USB port forwarding, force-stopped Chrome, reopened the cached app shell, and observed `无法连接` after 12 seconds

The physical test proves cached browser startup and health-state convergence. It does not claim standalone launcher-icon availability or microphone/speaker acceptance.