### PR TITLE
Add owner device lifecycle workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,16 @@ JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run pair:approve -- --code 1
 
 Owner Token 只提交给 loopback Gateway，不进入手机。Gateway 只持久化一次性领取密钥和设备凭据的 SHA-256 摘要；设备凭据通过领取密钥派生的 AES-256-GCM 密钥加密返回，重复领取返回同一密文。浏览器将不可导出的 P-256 私钥、设备凭据和短期 Session 保存在同源 IndexedDB；离线时只显示本地身份为非当前状态。清除站点数据会移除本地访问材料，但不会替代服务端设备撤销。
 
-短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages`、`POST /v1/conversations/:id/cancel`、`GET /v1/approvals`、`POST /v1/approvals/:id/decision`、`GET /v1/device-approvals`、`POST /v1/device-approvals/:id/decision` 以及 `GET/DELETE /v1/devices/current`。配对后的 PWA 可列出、新建、选择和继续文字对话，处理当前审批和智能设备审批，并查看或撤销当前设备；设备状态响应只含名称、平台、凭据代次、配对时间和会话时限，不含公钥、凭据摘要或任何令牌。消息只接受最多 16 KiB 的纯文本，发送期间会锁定重复提交，远程 slash command 被拒绝。审批决定使用客户端幂等键，Gateway 将上游 `rpcId` 保留在 loopback 桥接层，手机只能提交 `allowed-once` 或 `rejected`；取消本轮沿用会话取消接口并由 Harness 产生 `cancelled`。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；设备审批的请求和结果也会以不含服务数据或凭据的标准化事件进入 retained stream。若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会先要求重新读取权威会话与审批快照，刷新失败时不会推进游标。
+配对后可在 PWA“设置 > 设备身份”中轮换当前设备凭证。浏览器先生成并暂存下一代随机凭证，Gateway 只保存摘要；请求或响应中断时会分别用旧凭证和下一代凭证收敛，不删除会话、对话快照或设备私钥。Mac Owner 可查看脱敏设备清单并撤销丢失或疑似泄露的设备：
+
+```bash
+JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run devices -- list
+JARVIS_OWNER_TOKEN='the-same-local-owner-token' npm run devices -- revoke --id <device-id>
+```
+
+撤销命令默认要求在终端输入 `REVOKE` 二次确认；自动化环境必须显式传入 `--yes`。清单只含设备 ID、名称、平台、凭据代次、签发时间和撤销状态，不含公钥、凭据摘要、设备凭据或 Session token。Owner Token 只发送到 `127.0.0.1` Gateway，命令拒绝远端地址和 URL 内嵌凭据。
+
+短期 Session token 可访问 `GET/POST /v1/conversations`、`GET /v1/conversations/:id`、`POST /v1/conversations/:id/messages`、`POST /v1/conversations/:id/cancel`、`GET /v1/approvals`、`POST /v1/approvals/:id/decision`、`GET /v1/device-approvals`、`POST /v1/device-approvals/:id/decision` 以及 `GET/DELETE /v1/devices/current`。设备凭据可调用可重试的 `PUT /v1/devices/:id/credential`，Owner 可调用 `GET /v1/devices` 和 `DELETE /v1/devices/:id`。配对后的 PWA 可列出、新建、选择和继续文字对话，处理当前审批和智能设备审批，并查看、轮换或撤销当前设备；设备状态响应只含名称、平台、凭据代次、配对时间和会话时限，不含公钥、凭据摘要或任何令牌。消息只接受最多 16 KiB 的纯文本，发送期间会锁定重复提交，远程 slash command 被拒绝。审批决定使用客户端幂等键，Gateway 将上游 `rpcId` 保留在 loopback 桥接层，手机只能提交 `allowed-once` 或 `rejected`；取消本轮沿用会话取消接口并由 Harness 产生 `cancelled`。`/v1/events` 不在 URL 携带令牌，第一条消息必须是 `events.authenticate`；同源浏览器或无 Origin 的受信客户端可连接。客户端保存每个事件的 `cursor`，重连时提交该游标；设备审批的请求和结果也会以不含服务数据或凭据的标准化事件进入 retained stream。若缓冲已淘汰、Gateway 重启或上游连续性丢失，`events.ready`/`sync.required` 会先要求重新读取权威会话与审批快照，刷新失败时不会推进游标。
 
 PWA 只在同源 IndexedDB 保存最近一次规范化对话列表、当前最多 50 条文字消息和事件游标，不缓存审批、API 响应或 Owner Token。Gateway 不可达时，离线壳可只读显示对话快照并明确标记为“旧数据”，审批详情会从页面内存清除；所有新建、发送和审批操作保持禁用，恢复连接并重新验证 Session 后才切回实时状态。
 

--- a/docs/operations/private-network-recovery.md
+++ b/docs/operations/private-network-recovery.md
@@ -49,6 +49,11 @@ path/query is rejected before any network request.
    Gateway rejects the refresh, start a new owner-approved pairing flow.
 7. **Revoked device**: do not retry old credentials. Pair the browser again
    through the Mac owner approval flow; no phone-side Owner Token is needed.
+8. **Lost or compromised device**: on the Mac, run `npm run devices -- list`,
+   identify the device by its owner-assigned name, then run
+   `npm run devices -- revoke --id <device-id>` and confirm with `REVOKE`.
+   Keep `JARVIS_OWNER_TOKEN` on the Mac and do not send the device list to a
+   public issue or support channel.
 
 ## Failure Meaning
 

--- a/docs/verification/v1-release-qualification.md
+++ b/docs/verification/v1-release-qualification.md
@@ -68,6 +68,14 @@ an active access session remains usable, and a revoked device session remains
 invalid. The normal test suite separately covers refresh-token reuse detection,
 active WebSocket closure, owner revocation, and device self-revocation.
 
+The release artifact also includes an owner-facing `devices` command that
+lists only sanitized metadata and requires destructive confirmation before
+revocation. The PWA uses a client-generated, digest-only, retryable credential
+rotation protocol; tests cover normal completion and convergence after the
+first response is lost without clearing the active session or cached
+conversation data. Automated and synthetic-browser evidence does not replace
+the named physical-phone observation in the manual gate below.
+
 Keychain items, Owner Tokens, model credentials, TLS private keys, and raw
 device/session credentials are not backed up. Replacement-host recovery must
 provision those secrets separately and re-pair devices when their local secret

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "memory": "npm run build --silent && node dist/memory-main.js",
     "pair:node": "npm run build --silent && node dist/node-pairing-main.js",
     "pair:approve": "npm run build --silent && node dist/pairing-approval-main.js",
+    "devices": "npm run build --silent && node dist/device-management-main.js",
     "verify": "npm run typecheck && npm test",
     "verify:runtime": "./scripts/verify-local-runtime.sh",
     "verify:recovery": "npm run build --silent && ./scripts/verify-recovery-macos.sh",

--- a/src/device-management-main.ts
+++ b/src/device-management-main.ts
@@ -1,0 +1,78 @@
+import { stdin, stdout } from 'node:process'
+import { createInterface } from 'node:readline/promises'
+import { parseArgs } from 'node:util'
+import { DeviceManagementClient } from './device-management.js'
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  npm run devices -- list',
+    '  npm run devices -- revoke --id <device-id> [--yes]',
+    '',
+    'Required environment:',
+    '  JARVIS_OWNER_TOKEN   Gateway owner token',
+    '',
+    'Optional environment:',
+    '  JARVIS_GATEWAY_URL   Loopback Gateway origin (default http://127.0.0.1:3090)',
+  ].join('\n')
+}
+
+async function confirmRevocation(displayName: string, nodeId: string): Promise<void> {
+  if (!stdin.isTTY || !stdout.isTTY) throw new Error('device revocation requires --yes or an interactive terminal')
+  const prompt = createInterface({ input: stdin, output: stdout })
+  try {
+    const answer = (await prompt.question(`Revoke ${displayName} (${nodeId})? Type REVOKE to continue: `)).trim()
+    if (answer !== 'REVOKE') throw new Error('device revocation cancelled')
+  } finally {
+    prompt.close()
+  }
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    options: {
+      help: { type: 'boolean', default: false },
+      id: { type: 'string' },
+      yes: { type: 'boolean', default: false },
+    },
+    strict: true,
+    allowPositionals: true,
+  })
+  if (values.help) {
+    stdout.write(`${usage()}\n`)
+    return
+  }
+  const ownerToken = process.env.JARVIS_OWNER_TOKEN
+  if (ownerToken === undefined) throw new Error('JARVIS_OWNER_TOKEN is required')
+  const client = new DeviceManagementClient(
+    process.env.JARVIS_GATEWAY_URL ?? 'http://127.0.0.1:3090',
+    ownerToken,
+  )
+  const command = positionals[0]
+  if (positionals.length !== 1 || (command !== 'list' && command !== 'revoke')) throw new Error(usage())
+  if (command === 'list') {
+    if (values.id !== undefined || values.yes) throw new Error('list does not accept --id or --yes')
+    stdout.write(`${JSON.stringify({ devices: await client.list() })}\n`)
+    return
+  }
+  const nodeId = values.id
+  if (nodeId === undefined) throw new Error('revoke requires --id <device-id>')
+  const device = (await client.list()).find(item => item.nodeId === nodeId && !item.revoked)
+  if (device === undefined) throw new Error('device was not found or was already revoked')
+  if (!values.yes) await confirmRevocation(device.displayName, device.nodeId)
+  await client.revoke(device.nodeId)
+  stdout.write(`${JSON.stringify({ revoked: true, device: {
+    nodeId: device.nodeId,
+    displayName: device.displayName,
+    platform: device.platform,
+    generation: device.generation,
+  } })}\n`)
+}
+
+try {
+  await main()
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'device management failed'
+  process.stderr.write(`Device management failed: ${message}\n`)
+  process.exitCode = 1
+}

--- a/src/device-management.ts
+++ b/src/device-management.ts
@@ -1,0 +1,96 @@
+const MAX_RESPONSE_BYTES = 64 * 1024
+
+export interface ManagedDevice {
+  nodeId: string
+  displayName: string
+  platform: 'macos' | 'pwa'
+  generation: number
+  issuedAt: number
+  revoked: boolean
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function exactFields(value: Record<string, unknown>, fields: string[]): boolean {
+  return Object.keys(value).every(key => fields.includes(key)) && fields.every(key => Object.hasOwn(value, key))
+}
+
+function validateIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)
+}
+
+function parseDevice(value: unknown): ManagedDevice {
+  if (!record(value) || !exactFields(value, ['nodeId', 'displayName', 'platform', 'generation', 'issuedAt', 'revoked'])
+    || !validateIdentifier(value.nodeId)
+    || typeof value.displayName !== 'string' || value.displayName.length < 1 || value.displayName.length > 128
+    || /[\u0000-\u001f\u007f]/.test(value.displayName)
+    || (value.platform !== 'macos' && value.platform !== 'pwa')
+    || !Number.isInteger(value.generation) || (value.generation as number) < 1
+    || typeof value.issuedAt !== 'number' || !Number.isFinite(value.issuedAt)
+    || typeof value.revoked !== 'boolean') {
+    throw new Error('Gateway returned an invalid device record')
+  }
+  return value as unknown as ManagedDevice
+}
+
+function loopbackOrigin(value: string): string {
+  const url = new URL(value)
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.hostname !== '127.0.0.1'
+    || url.username !== '' || url.password !== '' || (url.pathname !== '' && url.pathname !== '/')
+    || url.search !== '' || url.hash !== '') {
+    throw new Error('device management gateway must be an HTTP(S) 127.0.0.1 origin')
+  }
+  return url.origin
+}
+
+function validateOwnerToken(value: string): string {
+  if (value.length < 16 || value.length > 4_096 || /[\r\n]/.test(value)) {
+    throw new TypeError('ownerToken must be 16 to 4096 characters without line breaks')
+  }
+  return value
+}
+
+export class DeviceManagementClient {
+  private readonly origin: string
+  private readonly ownerToken: string
+
+  constructor(gatewayUrl: string, ownerToken: string, private readonly fetchValue: typeof fetch = fetch) {
+    this.origin = loopbackOrigin(gatewayUrl)
+    this.ownerToken = validateOwnerToken(ownerToken)
+  }
+
+  async list(): Promise<ManagedDevice[]> {
+    const { response, body } = await this.request('/v1/devices', { method: 'GET' })
+    if (!response.ok) throw new Error(`Gateway device list failed with status ${response.status}`)
+    let value: unknown
+    try {
+      value = JSON.parse(body)
+    } catch {
+      throw new Error('Gateway returned invalid JSON')
+    }
+    if (!record(value) || !exactFields(value, ['devices']) || !Array.isArray(value.devices)) {
+      throw new Error('Gateway returned an invalid device list')
+    }
+    return value.devices.map(parseDevice)
+  }
+
+  async revoke(nodeId: string): Promise<void> {
+    if (!validateIdentifier(nodeId)) throw new Error('device id contains unsupported characters')
+    const { response } = await this.request(`/v1/devices/${encodeURIComponent(nodeId)}`, { method: 'DELETE' })
+    if (response.status === 204) return
+    if (response.status === 404) throw new Error('device was not found or was already revoked')
+    throw new Error(`Gateway device revocation failed with status ${response.status}`)
+  }
+
+  private async request(path: string, init: RequestInit): Promise<{ response: Response, body: string }> {
+    const response = await this.fetchValue(new URL(path, this.origin), {
+      ...init,
+      headers: { authorization: `Bearer ${this.ownerToken}` },
+    })
+    const body = await response.text()
+    if (Buffer.byteLength(body) > MAX_RESPONSE_BYTES) throw new Error('Gateway response is too large')
+    return { response, body }
+  }
+}

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -980,6 +980,15 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
         sendJson(response, 204, correlationId, {})
         return
       }
+      if (request.method === 'GET' && parts.length === 2 && parts[1] === 'devices') {
+        if (!ownerAuthenticated) {
+          sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
+          return
+        }
+        if ([...requestQuery(request).keys()].length !== 0) throw new Error('device list query is invalid')
+        sendJson(response, 200, correlationId, { devices: authority.listDevices() })
+        return
+      }
       if (request.method === 'POST' && parts.length === 3 && parts[1] === 'pairing' && parts[2] === 'requests') {
         if (!ownerAuthenticated) {
           sendJson(response, 403, correlationId, { error: 'owner authentication required', correlationId })
@@ -1018,6 +1027,23 @@ export function createJarvisGateway(options: JarvisGatewayOptions): JarvisGatewa
           throw new Error('pairing approval body is invalid')
         }
         sendJson(response, 200, correlationId, authority.approveClaimable(body.verificationCode))
+        return
+      }
+      if (request.method === 'PUT' && parts.length === 4 && parts[1] === 'devices'
+        && typeof parts[2] === 'string' && parts[3] === 'credential') {
+        const nodeId = parts[2]
+        if (deviceNodeId === undefined || deviceCredential === undefined || deviceNodeId !== nodeId) {
+          sendJson(response, 401, correlationId, { error: 'device authentication required', correlationId })
+          return
+        }
+        const body = await readJson(request, maxBodyBytes)
+        if (!record(body) || !exactFields(body, ['nextCredential', 'expectedGeneration'])
+          || typeof body.nextCredential !== 'string' || typeof body.expectedGeneration !== 'number') {
+          throw new Error('device credential rotation body is invalid')
+        }
+        const device = authority.rotateTo(nodeId, deviceCredential, body.nextCredential, body.expectedGeneration)
+        sendJson(response, 200, correlationId, { device })
+        disconnectNode(nodeId, 'device credential rotated')
         return
       }
       if (parts.length === 3 && parts[1] === 'devices' && typeof parts[2] === 'string') {

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -40,6 +40,10 @@ export interface DeviceView {
   issuedAt: number
 }
 
+export interface OwnerDeviceView extends DeviceView {
+  revoked: boolean
+}
+
 export interface BrowserPairingChallenge extends PairingRequest {
   claimToken: string
 }
@@ -385,9 +389,48 @@ export class PairingAuthority {
     }
   }
 
+  listDevices(): OwnerDeviceView[] {
+    return [...this.devices.values()]
+      .map(record => ({
+        nodeId: record.nodeId,
+        displayName: record.displayName,
+        platform: record.platform,
+        generation: record.generation,
+        issuedAt: record.issuedAt,
+        revoked: record.revoked,
+      }))
+      .sort((left, right) => left.displayName.localeCompare(right.displayName) || left.nodeId.localeCompare(right.nodeId))
+  }
+
   rotate(nodeId: string, currentCredential: string): IssuedCredential {
     const record = this.requireAuthenticated(nodeId, currentCredential)
     return this.issue(record.nodeId, record.publicKey, record.displayName, record.platform, record.generation + 1)
+  }
+
+  rotateTo(nodeId: string, currentCredential: string, nextCredential: string, expectedGeneration: number): DeviceView {
+    if (!/^[A-Za-z0-9_-]{43}$/.test(nextCredential)) throw new Error('next device credential is invalid')
+    if (!Number.isInteger(expectedGeneration) || expectedGeneration < 1) throw new Error('expected device generation is invalid')
+    const record = this.requireAuthenticated(nodeId, currentCredential)
+    if (record.generation === expectedGeneration + 1 && currentCredential === nextCredential) {
+      return this.getDevice(nodeId) as DeviceView
+    }
+    if (record.generation !== expectedGeneration) throw new Error('device credential generation has changed')
+    if (currentCredential === nextCredential) throw new Error('next device credential must be new')
+    const previousDigest = record.credentialDigest
+    const previousGeneration = record.generation
+    const previousIssuedAt = record.issuedAt
+    record.credentialDigest = credentialDigest(nextCredential)
+    record.generation += 1
+    record.issuedAt = this.now()
+    try {
+      this.persist()
+    } catch (error) {
+      record.credentialDigest = previousDigest
+      record.generation = previousGeneration
+      record.issuedAt = previousIssuedAt
+      throw error
+    }
+    return this.getDevice(nodeId) as DeviceView
   }
 
   revoke(nodeId: string): boolean {

--- a/test/device-management.test.js
+++ b/test/device-management.test.js
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { join } from 'node:path'
+import test from 'node:test'
+import { DeviceManagementClient } from '../dist/device-management.js'
+import { createJarvisGateway } from '../dist/gateway.js'
+import { PairingAuthority, createDeviceIdentity } from '../dist/pairing.js'
+
+const ownerToken = 'owner-token-for-device-management'
+const entrypoint = join(process.cwd(), 'dist', 'device-management-main.js')
+
+function runCli(args, environment) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [entrypoint, ...args], {
+      env: { ...process.env, ...environment },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', chunk => { stdout += chunk })
+    child.stderr.on('data', chunk => { stderr += chunk })
+    child.once('error', reject)
+    child.once('close', code => resolve({ code, stdout, stderr }))
+  })
+}
+
+test('lists sanitized devices and revokes one device through loopback owner authentication', async () => {
+  const calls = []
+  const client = new DeviceManagementClient('http://127.0.0.1:3090', ownerToken, async (url, init) => {
+    calls.push({ url: url.toString(), init })
+    if (init.method === 'DELETE') return new Response(undefined, { status: 204 })
+    return new Response(JSON.stringify({ devices: [{
+      nodeId: 'pwa-phone', displayName: 'Owner Phone', platform: 'pwa', generation: 3,
+      issuedAt: 1_000, revoked: false,
+    }] }), { status: 200 })
+  })
+  assert.deepEqual(await client.list(), [{
+    nodeId: 'pwa-phone', displayName: 'Owner Phone', platform: 'pwa', generation: 3,
+    issuedAt: 1_000, revoked: false,
+  }])
+  await client.revoke('pwa-phone')
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0].url, 'http://127.0.0.1:3090/v1/devices')
+  assert.equal(calls[1].url, 'http://127.0.0.1:3090/v1/devices/pwa-phone')
+  assert.equal(calls[0].init.headers.authorization, `Bearer ${ownerToken}`)
+})
+
+test('rejects remote origins, malformed device records, and oversized responses', async () => {
+  assert.throws(() => new DeviceManagementClient('https://gateway.example', ownerToken), /127\.0\.0\.1/)
+  const malformed = new DeviceManagementClient('http://127.0.0.1:3090', ownerToken, async () => new Response(JSON.stringify({
+    devices: [{ nodeId: 'phone', displayName: 'Phone', platform: 'pwa', generation: 1, issuedAt: 1, revoked: false,
+      credentialDigest: 'private' }],
+  }), { status: 200 }))
+  await assert.rejects(malformed.list(), /invalid device record/)
+  const oversized = new DeviceManagementClient('http://127.0.0.1:3090', ownerToken, async () => new Response('x'.repeat(65 * 1024)))
+  await assert.rejects(oversized.list(), /too large/)
+})
+
+test('runs the owner CLI without printing credentials and requires destructive confirmation', async () => {
+  const authority = new PairingAuthority()
+  const identity = createDeviceIdentity()
+  const pairing = authority.createRequest({
+    nodeId: 'owner-phone', publicKey: identity.publicKey, displayName: 'Owner Phone', platform: 'macos',
+  })
+  const credential = authority.confirm(pairing.requestId, pairing.verificationCode).credential
+  const service = createJarvisGateway({ ownerToken, authority })
+  const gateway = await service.start()
+  const environment = { JARVIS_OWNER_TOKEN: ownerToken, JARVIS_GATEWAY_URL: gateway.origin }
+  try {
+    const listed = await runCli(['list'], environment)
+    assert.equal(listed.code, 0, listed.stderr)
+    assert.equal(listed.stderr, '')
+    assert.deepEqual(JSON.parse(listed.stdout).devices, [{
+      nodeId: 'owner-phone', displayName: 'Owner Phone', platform: 'macos', generation: 1,
+      issuedAt: JSON.parse(listed.stdout).devices[0].issuedAt, revoked: false,
+    }])
+    assert.doesNotMatch(listed.stdout, new RegExp(credential))
+    assert.doesNotMatch(listed.stdout, new RegExp(ownerToken))
+
+    const unconfirmed = await runCli(['revoke', '--id', 'owner-phone'], environment)
+    assert.notEqual(unconfirmed.code, 0)
+    assert.match(unconfirmed.stderr, /requires --yes/)
+    assert.equal(authority.isActive('owner-phone'), true)
+
+    const revoked = await runCli(['revoke', '--id', 'owner-phone', '--yes'], environment)
+    assert.equal(revoked.code, 0, revoked.stderr)
+    assert.deepEqual(JSON.parse(revoked.stdout).revoked, true)
+    assert.equal(authority.isActive('owner-phone'), false)
+    assert.doesNotMatch(revoked.stdout + revoked.stderr, new RegExp(credential))
+    assert.doesNotMatch(revoked.stdout + revoked.stderr, new RegExp(ownerToken))
+  } finally {
+    await service.stop()
+  }
+})

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -335,6 +335,18 @@ test('runs authenticated pairing, device rotation, and owner revocation over ver
     })
     assert.equal(confirmed.status, 200)
     const first = await confirmed.json()
+    const listed = await request(gateway, '/v1/devices', { headers: { authorization: `Bearer ${ownerToken}` } })
+    assert.equal(listed.status, 200)
+    const listedText = await listed.text()
+    assert.deepEqual(JSON.parse(listedText), { devices: [{
+      nodeId: 'node-1', displayName: 'Test Mac', platform: 'macos', generation: 1, issuedAt: 1_000, revoked: false,
+    }] })
+    assert.doesNotMatch(listedText, /publicKey|credentialDigest|credential/)
+    assert.doesNotMatch(listedText, new RegExp(first.credential))
+    assert.equal((await request(gateway, '/v1/devices')).status, 401)
+    assert.equal((await request(gateway, '/v1/devices', {
+      headers: { authorization: `Device ${first.credential}` },
+    })).status, 403)
     const rotated = await request(gateway, '/v1/devices/node-1', {
       method: 'POST', headers: { authorization: `Device ${first.credential}` },
     })
@@ -349,6 +361,40 @@ test('runs authenticated pairing, device rotation, and owner revocation over ver
       method: 'POST', headers: { authorization: `Device ${second.credential}` },
     })
     assert.equal(rejectedRotation.status, 401)
+  } finally {
+    await service.stop()
+  }
+})
+
+test('retries client-generated device credential rotation without exposing the credential', async () => {
+  const authority = new PairingAuthority(() => 2_000, 60_000)
+  const first = issueCredential(authority, 'pwa-phone')
+  const next = 'n'.repeat(43)
+  const service = createJarvisGateway({ ownerToken, authority })
+  const gateway = await service.start()
+  const body = JSON.stringify({ nextCredential: next, expectedGeneration: 1 })
+  try {
+    const rotated = await request(gateway, '/v1/devices/pwa-phone/credential', {
+      method: 'PUT', headers: { authorization: `Device ${first}`, 'content-type': 'application/json' }, body,
+    })
+    assert.equal(rotated.status, 200)
+    const rotatedText = await rotated.text()
+    assert.deepEqual(JSON.parse(rotatedText), { device: {
+      nodeId: 'pwa-phone', displayName: 'Test Mac', platform: 'macos', generation: 2, issuedAt: 2_000,
+    } })
+    assert.doesNotMatch(rotatedText, new RegExp(next))
+    assert.equal(authority.authenticate('pwa-phone', first), false)
+    assert.equal(authority.authenticate('pwa-phone', next), true)
+    assert.equal((await request(gateway, '/v1/devices/pwa-phone/credential', {
+      method: 'PUT', headers: { authorization: `Device ${first}`, 'content-type': 'application/json' }, body,
+    })).status, 401)
+    const retried = await request(gateway, '/v1/devices/pwa-phone/credential', {
+      method: 'PUT', headers: { authorization: `Device ${next}`, 'content-type': 'application/json' }, body,
+    })
+    assert.equal(retried.status, 200)
+    assert.deepEqual(await retried.json(), { device: {
+      nodeId: 'pwa-phone', displayName: 'Test Mac', platform: 'macos', generation: 2, issuedAt: 2_000,
+    } })
   } finally {
     await service.stop()
   }

--- a/test/pairing.test.js
+++ b/test/pairing.test.js
@@ -152,9 +152,38 @@ test('returns only normalized active device metadata', () => {
   assert.deepEqual(authority.getDevice('node-view'), {
     nodeId: 'node-view', displayName: 'Visible Mac', platform: 'macos', generation: 1, issuedAt: 1_000,
   })
+  assert.deepEqual(authority.listDevices(), [{
+    nodeId: 'node-view', displayName: 'Visible Mac', platform: 'macos', generation: 1, issuedAt: 1_000, revoked: false,
+  }])
   assert.doesNotMatch(JSON.stringify(authority.getDevice('node-view')), new RegExp(issued.credential))
   authority.revoke('node-view')
   assert.equal(authority.getDevice('node-view'), undefined)
+  assert.equal(authority.listDevices()[0].revoked, true)
+})
+
+test('persists a client-generated rotation and retries it idempotently with the new credential', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'jarvis-pairing-rotation-'))
+  try {
+    const path = join(directory, 'pairing-state.json')
+    const identity = createDeviceIdentity()
+    const authority = new PairingAuthority(() => 2_000, 60_000, new FilePairingStateStore(path))
+    const request = authority.createRequest(requestInput(identity))
+    const first = authority.confirm(request.requestId, request.verificationCode)
+    const next = 'z'.repeat(43)
+    assert.deepEqual(authority.rotateTo('node-1', first.credential, next, 1), {
+      nodeId: 'node-1', displayName: 'MacBook Air', platform: 'macos', generation: 2, issuedAt: 2_000,
+    })
+    const stored = await readFile(path, 'utf8')
+    assert.doesNotMatch(stored, new RegExp(first.credential))
+    assert.doesNotMatch(stored, new RegExp(next))
+
+    const restarted = new PairingAuthority(() => 3_000, 60_000, new FilePairingStateStore(path))
+    assert.equal(restarted.authenticate('node-1', first.credential), false)
+    assert.equal(restarted.authenticate('node-1', next), true)
+    assert.equal(restarted.rotateTo('node-1', next, next, 1).generation, 2)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 })
 
 test('revocation blocks current and future authentication', () => {

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -24,8 +24,8 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js?v=17', '/app/pairing.js?v=17', '/app/device-store.js?v=17',
-    '/app/conversations.js?v=17', '/app/gateway-health.js?v=17', '/app/notifications.js?v=17', '/app/voice.js?v=17',
+    '/app/', '/app/app.css', '/app/app.js?v=18', '/app/pairing.js?v=18', '/app/device-store.js?v=18',
+    '/app/conversations.js?v=18', '/app/gateway-health.js?v=18', '/app/notifications.js?v=18', '/app/voice.js?v=18',
     '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {
@@ -98,6 +98,8 @@ test('keeps the browser client on the public Gateway contract', async () => {
   assert.doesNotMatch(notificationsSource, /arguments|message|rpcId|accessToken|refreshToken/)
   assert.match(htmlSource, /id="approval-list"/)
   assert.match(htmlSource, /id="disconnect-device-dialog"/)
+  assert.match(htmlSource, /id="rotate-device-credential-dialog"/)
+  assert.match(htmlSource, /id="rotate-device-credential-button"[^>]+hidden disabled/)
   assert.match(htmlSource, /id="disconnect-device-button"[^>]+hidden disabled/)
   assert.match(htmlSource, /id="pair-button"[^>]+disabled/)
   assert.match(htmlSource, /id="voice-button"[^>]+disabled/)
@@ -193,6 +195,73 @@ test('shows authoritative device status and clears all browser state after self-
   assert.equal(store.values.size, 0)
   assert.equal(states.at(-1).phase, 'unpaired')
   assert.equal(calls.at(-1).init.headers.authorization, `Session ${initial.session.accessToken}`)
+})
+
+test('rotates the browser credential without clearing sessions or cached data', async () => {
+  const initial = pairedBrowserState()
+  const store = memoryDeviceStore(initial)
+  const states = []
+  const calls = []
+  let generation = 2
+  let issuedAt = initial.credential.issuedAt
+  const pairing = new BrowserPairing(state => states.push(state), async (path, init = {}) => {
+    calls.push({ path, init })
+    if (path.endsWith('/credential') && init.method === 'PUT') {
+      const requestBody = JSON.parse(init.body)
+      assert.equal(requestBody.expectedGeneration, 2)
+      assert.match(requestBody.nextCredential, /^[A-Za-z0-9_-]{43}$/)
+      generation = 3
+      issuedAt = Date.now()
+      return response(200, { device: {
+        nodeId: initial.identity.nodeId, displayName: initial.identity.displayName,
+        platform: 'pwa', generation, issuedAt,
+      } })
+    }
+    const current = currentDevice(initial)
+    current.device.generation = generation
+    current.device.issuedAt = issuedAt
+    return response(200, current)
+  }, store)
+
+  await pairing.initialize()
+  const previousCredential = store.values.get('credential').credential
+  await pairing.rotateCurrentCredential()
+  const rotated = store.values.get('credential')
+  assert.notEqual(rotated.credential, previousCredential)
+  assert.equal(rotated.generation, 3)
+  assert.equal(store.values.has('credential-rotation'), false)
+  assert.deepEqual(store.values.get('session'), initial.session)
+  assert.deepEqual(store.values.get('conversation-cache'), initial['conversation-cache'])
+  assert.equal(states.at(-1).generation, 3)
+  assert.equal(calls.find(call => call.path.endsWith('/credential')).init.headers.authorization, `Device ${previousCredential}`)
+})
+
+test('converges credential rotation after the first response is lost', async () => {
+  const initial = pairedBrowserState()
+  const store = memoryDeviceStore(initial)
+  const authorizations = []
+  let attempts = 0
+  const pairing = new BrowserPairing(() => {}, async (path, init = {}) => {
+    if (!path.endsWith('/credential')) return response(200, currentDevice(initial))
+    attempts += 1
+    authorizations.push(init.headers.authorization)
+    if (attempts === 1) throw new Error('response lost')
+    const requestBody = JSON.parse(init.body)
+    return response(200, { device: {
+      nodeId: initial.identity.nodeId, displayName: initial.identity.displayName,
+      platform: 'pwa', generation: 3, issuedAt: Date.now(),
+    } })
+  }, store)
+
+  await pairing.initialize()
+  const previousCredential = store.values.get('credential').credential
+  await pairing.rotateCurrentCredential()
+  const nextCredential = store.values.get('credential').credential
+  assert.equal(attempts, 2)
+  assert.equal(authorizations[0], `Device ${previousCredential}`)
+  assert.equal(authorizations[1], `Device ${nextCredential}`)
+  assert.equal(store.values.has('credential-rotation'), false)
+  assert.deepEqual(store.values.get('conversation-cache'), initial['conversation-cache'])
 })
 
 test('converges to revoked and clears cached data after a self-revocation response is lost', async () => {

--- a/web/app.js
+++ b/web/app.js
@@ -1,8 +1,8 @@
-import { ConversationsClient } from './conversations.js?v=17'
-import { fetchGatewayHealth } from './gateway-health.js?v=17'
-import { BrowserPairing } from './pairing.js?v=17'
-import { NotificationCenter } from './notifications.js?v=17'
-import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=17'
+import { ConversationsClient } from './conversations.js?v=18'
+import { fetchGatewayHealth } from './gateway-health.js?v=18'
+import { BrowserPairing } from './pairing.js?v=18'
+import { NotificationCenter } from './notifications.js?v=18'
+import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=18'
 
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')
@@ -19,6 +19,10 @@ const devicePlatform = document.querySelector('#device-platform')
 const deviceGeneration = document.querySelector('#device-generation')
 const deviceIssuedAt = document.querySelector('#device-issued-at')
 const deviceSessionExpiry = document.querySelector('#device-session-expiry')
+const rotateDeviceCredentialButton = document.querySelector('#rotate-device-credential-button')
+const rotateDeviceCredentialDialog = document.querySelector('#rotate-device-credential-dialog')
+const confirmRotateDeviceCredentialButton = document.querySelector('#confirm-rotate-device-credential-button')
+const rotateDeviceCredentialError = document.querySelector('#rotate-device-credential-error')
 const disconnectDeviceButton = document.querySelector('#disconnect-device-button')
 const disconnectDeviceDialog = document.querySelector('#disconnect-device-dialog')
 const confirmDisconnectDeviceButton = document.querySelector('#confirm-disconnect-device-button')
@@ -79,6 +83,7 @@ let gatewayReachable = false
 let pairingPhase = 'loading'
 let pairingExpiresAt
 let disconnectBusy = false
+let credentialRotationBusy = false
 let conversationsClient
 let stateForRendering = { conversations: [], approvals: [], deviceApprovals: [], approvalSubmittedIds: [], deviceApprovalSubmittedIds: [] }
 let notificationState = { history: [], unreadCount: 0, preferences: undefined, permission: 'default' }
@@ -264,10 +269,13 @@ function setDeviceValue(label, className = 'is-muted') {
 
 function updateDisconnectControl() {
   const visible = pairingPhase === 'paired'
+  const mutable = visible && !disconnectBusy && !credentialRotationBusy && navigator.onLine && gatewayReachable
+  rotateDeviceCredentialButton.hidden = !visible
+  rotateDeviceCredentialButton.disabled = !mutable
   disconnectDeviceButton.hidden = !visible
-  disconnectDeviceButton.disabled = !visible || disconnectBusy || !navigator.onLine || !gatewayReachable
-    || stateForRendering.phase !== 'ready'
+  disconnectDeviceButton.disabled = !mutable
   confirmDisconnectDeviceButton.disabled = disconnectBusy
+  confirmRotateDeviceCredentialButton.disabled = credentialRotationBusy
 }
 
 function handlePairingState(state) {
@@ -688,6 +696,27 @@ pairButton.addEventListener('click', async () => {
   }
 })
 cancelPairingButton.addEventListener('click', () => { void pairing.cancel() })
+rotateDeviceCredentialButton.addEventListener('click', () => {
+  rotateDeviceCredentialError.hidden = true
+  rotateDeviceCredentialError.textContent = ''
+  rotateDeviceCredentialDialog.showModal()
+})
+confirmRotateDeviceCredentialButton.addEventListener('click', async () => {
+  if (credentialRotationBusy) return
+  credentialRotationBusy = true
+  updateDisconnectControl()
+  rotateDeviceCredentialError.hidden = true
+  try {
+    await pairing.rotateCurrentCredential()
+    rotateDeviceCredentialDialog.close()
+  } catch (error) {
+    rotateDeviceCredentialError.textContent = error instanceof Error ? error.message : '无法轮换设备凭证'
+    rotateDeviceCredentialError.hidden = false
+  } finally {
+    credentialRotationBusy = false
+    updateDisconnectControl()
+  }
+})
 disconnectDeviceButton.addEventListener('click', () => {
   disconnectDeviceError.hidden = true
   disconnectDeviceError.textContent = ''

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=17'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=18'
 
 const CACHE_KEY = 'conversation-cache'
 const CURSOR_KEY = 'event-cursor'

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js?v=17" type="module"></script>
+    <script src="./app.js?v=18" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>
@@ -164,6 +164,7 @@
               </div>
               <div class="settings-actions">
                 <span id="device-value" class="value-label is-muted">未配对</span>
+                <button id="rotate-device-credential-button" class="secondary-button" type="button" hidden disabled>轮换凭证</button>
                 <button id="disconnect-device-button" class="danger-button" type="button" hidden disabled>断开此设备</button>
               </div>
             </section>
@@ -249,6 +250,17 @@
         <div class="dialog-actions">
           <button class="secondary-button" type="submit" value="cancel">取消</button>
           <button id="confirm-disconnect-device-button" class="danger-button" type="button">断开设备</button>
+        </div>
+      </form>
+    </dialog>
+    <dialog id="rotate-device-credential-dialog" class="confirmation-dialog" aria-labelledby="rotate-device-credential-title">
+      <form method="dialog">
+        <h2 id="rotate-device-credential-title">轮换设备凭证？</h2>
+        <p>Gateway 将撤销当前设备凭证并启用新凭证。对话和本地数据不会删除，当前会话会继续使用。</p>
+        <p id="rotate-device-credential-error" class="dialog-error" role="alert" hidden></p>
+        <div class="dialog-actions">
+          <button class="secondary-button" type="submit" value="cancel">取消</button>
+          <button id="confirm-rotate-device-credential-button" class="primary-button" type="button">轮换凭证</button>
         </div>
       </form>
     </dialog>

--- a/web/notifications.js
+++ b/web/notifications.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=17'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=18'
 
 export const NOTIFICATION_HISTORY_KEY = 'notification-history'
 export const NOTIFICATION_PREFERENCES_KEY = 'notification-preferences'

--- a/web/pairing.js
+++ b/web/pairing.js
@@ -1,4 +1,4 @@
-import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=17'
+import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=18'
 
 const MAX_RESPONSE_CHARS = 2 * 1024 * 1024
 
@@ -70,7 +70,7 @@ function parseCurrentDevice(value, identity, session) {
     || !Number.isInteger(value.device.generation) || value.device.generation < 1
     || !Number.isFinite(value.device.issuedAt) || value.session.sessionId !== session.sessionId
     || !Number.isFinite(value.session.issuedAt) || !Number.isFinite(value.session.refreshedAt)
-    || value.device.issuedAt > value.session.issuedAt || value.session.refreshedAt < value.session.issuedAt
+    || value.session.refreshedAt < value.session.issuedAt
     || value.session.accessExpiresAt <= value.session.refreshedAt
     || value.session.refreshExpiresAt <= value.session.issuedAt
     || value.session.accessExpiresAt !== session.accessExpiresAt
@@ -78,6 +78,21 @@ function parseCurrentDevice(value, identity, session) {
     throw new Error('Gateway returned an invalid current device')
   }
   return value
+}
+
+function parseRotatedDevice(value, identity, expectedGeneration) {
+  const fields = ['nodeId', 'displayName', 'platform', 'generation', 'issuedAt']
+  if (!exactFields(value, ['device']) || !exactFields(value.device, fields)
+    || value.device.nodeId !== identity.nodeId || value.device.displayName !== identity.displayName
+    || value.device.platform !== 'pwa' || value.device.generation !== expectedGeneration + 1
+    || !Number.isFinite(value.device.issuedAt)) {
+    throw new Error('Gateway returned an invalid credential rotation')
+  }
+  return value.device
+}
+
+function createCredential() {
+  return encodeBase64Url(crypto.getRandomValues(new Uint8Array(32)))
 }
 
 async function createIdentity(displayName) {
@@ -120,9 +135,17 @@ export class BrowserPairing {
   async initializeState() {
     try {
       const identity = await this.store.read('identity')
-      const credential = await this.store.read('credential')
+      let credential = await this.store.read('credential')
       const pending = await this.store.read('pending')
       if (identity !== undefined && credential !== undefined) {
+        const rotation = await this.store.read('credential-rotation')
+        if (rotation !== undefined) {
+          try {
+            credential = await this.completeCredentialRotation(identity, credential, rotation)
+          } catch (error) {
+            if (!(error instanceof GatewayUnavailableError)) throw error
+          }
+        }
         await this.ensureSession(identity, credential)
         return
       }
@@ -347,6 +370,85 @@ export class BrowserPairing {
     await this.store.clear()
     this.initializationPromise = undefined
     this.onState({ phase: 'unpaired' })
+  }
+
+  async rotateCurrentCredential() {
+    await this.initialize()
+    const identity = await this.store.read('identity')
+    const credential = await this.store.read('credential')
+    if (identity === undefined || credential === undefined) throw new Error('此设备尚未配对')
+    let rotation = await this.store.read('credential-rotation')
+    if (rotation === undefined) {
+      rotation = {
+        nodeId: identity.nodeId,
+        nextCredential: createCredential(),
+        expectedGeneration: credential.generation,
+      }
+      await this.store.write('credential-rotation', rotation)
+    }
+    const rotated = await this.completeCredentialRotation(identity, credential, rotation)
+    const session = await this.store.read('session')
+    if (session === undefined) throw new Error('Gateway 会话不可用')
+    const activeSession = parseSession(session, identity.nodeId)
+    this.emitPaired({
+      device: {
+        nodeId: identity.nodeId,
+        displayName: identity.displayName,
+        platform: 'pwa',
+        generation: rotated.generation,
+        issuedAt: rotated.issuedAt,
+      },
+      session: activeSession,
+    })
+    return rotated
+  }
+
+  async completeCredentialRotation(identity, credential, rotation) {
+    const activeIsNext = credential?.credential === rotation?.nextCredential
+      && credential?.generation === rotation?.expectedGeneration + 1
+    if (rotation?.nodeId !== identity.nodeId || !validToken(rotation.nextCredential)
+      || !Number.isInteger(rotation.expectedGeneration)
+      || (!activeIsNext && rotation.expectedGeneration !== credential.generation)) {
+      throw new Error('本地凭证轮换状态无效')
+    }
+    const path = `/v1/devices/${encodeURIComponent(identity.nodeId)}/credential`
+    const body = JSON.stringify({
+      nextCredential: rotation.nextCredential,
+      expectedGeneration: rotation.expectedGeneration,
+    })
+    let response
+    try {
+      response = await this.request(path, {
+        method: 'PUT',
+        headers: { authorization: `Device ${credential.credential}` },
+        body,
+      })
+    } catch (error) {
+      if (!(error instanceof GatewayUnavailableError)) throw error
+      response = await this.request(path, {
+        method: 'PUT',
+        headers: { authorization: `Device ${rotation.nextCredential}` },
+        body,
+      })
+    }
+    if (response.status === 401) {
+      response = await this.request(path, {
+        method: 'PUT',
+        headers: { authorization: `Device ${rotation.nextCredential}` },
+        body,
+      })
+    }
+    if (!response.ok) throw new Error(`无法轮换设备凭证 (${response.status})`)
+    const device = parseRotatedDevice(response.value, identity, rotation.expectedGeneration)
+    const next = {
+      nodeId: identity.nodeId,
+      credential: rotation.nextCredential,
+      generation: device.generation,
+      issuedAt: device.issuedAt,
+    }
+    await this.store.write('credential', next)
+    await this.store.delete('credential-rotation')
+    return next
   }
 
   async handleRemoteRevocation() {

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,14 +1,14 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v17'
+const CACHE_NAME = 'jarvis-pwa-shell-v18'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js?v=17',
-  '/app/pairing.js?v=17',
-  '/app/device-store.js?v=17',
-  '/app/conversations.js?v=17',
-  '/app/gateway-health.js?v=17',
-  '/app/notifications.js?v=17',
-  '/app/voice.js?v=17',
+  '/app/app.js?v=18',
+  '/app/pairing.js?v=18',
+  '/app/device-store.js?v=18',
+  '/app/conversations.js?v=18',
+  '/app/gateway-health.js?v=18',
+  '/app/notifications.js?v=18',
+  '/app/voice.js?v=18',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',


### PR DESCRIPTION
## Summary
- add a loopback-only Owner device inventory and confirmation-gated revocation CLI
- add client-generated, digest-only, retryable PWA credential rotation
- preserve active sessions and cached conversations across rotation
- document the owner workflow and recovery boundary

## Security properties
- device inventory excludes public keys, credential digests, credentials, and session tokens
- Owner Token is accepted only by the loopback management client
- rotation survives a lost first response by converging with the old or next credential
- persisted pairing state retains credential digests only

## Verification
- `npm run verify`: 201 tests passed
- temporary real-browser pairing and rotation: generation 1 to 2, dialog closed, session retained
- desktop 1280px and mobile 390px layout checks: no horizontal overflow
- `npm run verify:release`: checksum-verified archive, artifact tests, runtime, recovery, LaunchAgent crash restart, persistence, uninstall, and cleanup passed

Issue #11 remains open until the owner performs the workflow on the named physical phone and the other unchecked v1.0 gates are complete.