### PR TITLE
Back off failed PWA event reconnects

### DIFF
--- a/test/conversations.test.js
+++ b/test/conversations.test.js
@@ -371,6 +371,57 @@ test('does not advance the event cursor when a required snapshot fails', async (
   assert.equal(sockets[0].closeCode, 4002)
 })
 
+test('backs off failed event reconnects and resets after synchronization', async () => {
+  const calls = []
+  const sockets = []
+  const timers = []
+  let failSnapshot = false
+  const pairing = gatewayPairing(calls, {
+    request: async path => {
+      if (failSnapshot && path === '/v1/conversations') return { ok: false, status: 503, value: {} }
+      return undefined
+    },
+  })
+  const client = new ConversationsClient(pairing, () => {}, {
+    store: memoryStore(),
+    location: { origin: 'https://jarvis.internal' },
+    socketFactory: url => {
+      const socket = new FakeSocket(url)
+      sockets.push(socket)
+      return socket
+    },
+    setTimeout: (callback, delay) => {
+      timers.push({ callback, delay })
+      return timers.length
+    },
+    clearTimeout: () => {},
+  })
+  await client.start()
+  await tick()
+
+  failSnapshot = true
+  sockets[0].message({ type: 'events.ready', cursor, replayCount: 0, requiresSnapshot: true, reason: 'initial' })
+  await tick()
+  await tick()
+  assert.equal(timers[0].delay, 2_000)
+
+  timers.shift().callback()
+  await tick()
+  sockets[1].message({ type: 'events.ready', cursor, replayCount: 0, requiresSnapshot: true, reason: 'initial' })
+  await tick()
+  await tick()
+  assert.equal(timers[0].delay, 4_000)
+
+  failSnapshot = false
+  timers.shift().callback()
+  await tick()
+  sockets[2].message({ type: 'events.ready', cursor, replayCount: 0, requiresSnapshot: true, reason: 'initial' })
+  await tick()
+  await tick()
+  sockets[2].close()
+  assert.equal(timers[0].delay, 2_000)
+})
+
 test('keeps approvals memory-only and reuses a decision key after a transport retry', async () => {
   const calls = []
   const states = []

--- a/test/pwa.test.js
+++ b/test/pwa.test.js
@@ -24,8 +24,8 @@ test('declares a scoped installable manifest and complete offline shell', async 
 
   const serviceWorker = await readFile(join(webRoot, 'sw.js'), 'utf8')
   for (const path of [
-    '/app/', '/app/app.css', '/app/app.js?v=18', '/app/pairing.js?v=18', '/app/device-store.js?v=18',
-    '/app/conversations.js?v=18', '/app/gateway-health.js?v=18', '/app/notifications.js?v=18', '/app/voice.js?v=18',
+    '/app/', '/app/app.css', '/app/app.js?v=19', '/app/pairing.js?v=19', '/app/device-store.js?v=19',
+    '/app/conversations.js?v=19', '/app/gateway-health.js?v=19', '/app/notifications.js?v=19', '/app/voice.js?v=19',
     '/app/apple-touch-icon.png', '/app/icon.svg',
     '/app/icon-192.png', '/app/icon-512.png', '/app/manifest.webmanifest',
   ]) {

--- a/web/app.js
+++ b/web/app.js
@@ -1,8 +1,8 @@
-import { ConversationsClient } from './conversations.js?v=18'
-import { fetchGatewayHealth } from './gateway-health.js?v=18'
-import { BrowserPairing } from './pairing.js?v=18'
-import { NotificationCenter } from './notifications.js?v=18'
-import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=18'
+import { ConversationsClient } from './conversations.js?v=19'
+import { fetchGatewayHealth } from './gateway-health.js?v=19'
+import { BrowserPairing } from './pairing.js?v=19'
+import { NotificationCenter } from './notifications.js?v=19'
+import { PushToTalkController, SpeechPlaybackController } from './voice.js?v=19'
 
 const connectionLabel = document.querySelector('#connection-label')
 const gatewayDetail = document.querySelector('#gateway-detail')

--- a/web/conversations.js
+++ b/web/conversations.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=18'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=19'
 
 const CACHE_KEY = 'conversation-cache'
 const CURSOR_KEY = 'event-cursor'
@@ -10,6 +10,8 @@ const MAX_EVENT_CHARS = 64 * 1024
 const CLOSE_PROTOCOL = 4000
 const CLOSE_AUTHENTICATION = 4001
 const CLOSE_PROCESSING = 4002
+const INITIAL_RECONNECT_DELAY_MS = 2_000
+const MAX_RECONNECT_DELAY_MS = 30_000
 
 function validSummary(value) {
   return value !== null && typeof value === 'object' && ID_PATTERN.test(value.id)
@@ -161,12 +163,14 @@ export class ConversationsClient {
     this.cachedAt = undefined
     this.socket = undefined
     this.reconnectTimer = undefined
+    this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
     this.forceRenewSession = false
   }
 
   async start() {
     if (this.active) return
     this.active = true
+    this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
     let cached
     try {
       cached = parseCache(await this.store.read(CACHE_KEY))
@@ -248,6 +252,7 @@ export class ConversationsClient {
       return
     }
     if (this.active) {
+      this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
       void this.refresh().then(() => this.connectEvents())
     }
   }
@@ -583,6 +588,7 @@ export class ConversationsClient {
         return
       }
       await this.store.write(CURSOR_KEY, event.cursor)
+      this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
       return
     }
     if (event?.version !== 1 || typeof event.cursor !== 'string' || !CURSOR_PATTERN.test(event.cursor)
@@ -648,6 +654,7 @@ export class ConversationsClient {
     this.cachedAt = Date.now()
     await this.persistCache()
     await this.store.write(CURSOR_KEY, event.cursor)
+    this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
     if (socket.readyState === 1) socket.send(JSON.stringify({ type: 'events.ack', cursor: event.cursor }))
     this.emit('ready', eventNotice)
   }
@@ -673,10 +680,12 @@ export class ConversationsClient {
 
   scheduleReconnect() {
     if (!this.active || !this.online || this.reconnectTimer !== undefined) return
+    const delay = this.reconnectDelayMs
+    this.reconnectDelayMs = Math.min(MAX_RECONNECT_DELAY_MS, delay * 2)
     this.reconnectTimer = this.setTimeoutValue(() => {
       this.reconnectTimer = undefined
       void this.connectEvents()
-    }, 2_000)
+    }, delay)
   }
 
   clearReconnect() {

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="./icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="stylesheet" href="./app.css">
-    <script src="./app.js?v=18" type="module"></script>
+    <script src="./app.js?v=19" type="module"></script>
   </head>
   <body data-connection="checking">
     <a class="skip-link" href="#main-content">跳到主要内容</a>

--- a/web/notifications.js
+++ b/web/notifications.js
@@ -1,4 +1,4 @@
-import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=18'
+import { deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=19'
 
 export const NOTIFICATION_HISTORY_KEY = 'notification-history'
 export const NOTIFICATION_PREFERENCES_KEY = 'notification-preferences'

--- a/web/pairing.js
+++ b/web/pairing.js
@@ -1,4 +1,4 @@
-import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=18'
+import { clearDeviceState, deleteDeviceState, readDeviceState, writeDeviceState } from './device-store.js?v=19'
 
 const MAX_RESPONSE_CHARS = 2 * 1024 * 1024
 

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,14 +1,14 @@
-const CACHE_NAME = 'jarvis-pwa-shell-v18'
+const CACHE_NAME = 'jarvis-pwa-shell-v19'
 const SHELL_PATHS = [
   '/app/',
   '/app/app.css',
-  '/app/app.js?v=18',
-  '/app/pairing.js?v=18',
-  '/app/device-store.js?v=18',
-  '/app/conversations.js?v=18',
-  '/app/gateway-health.js?v=18',
-  '/app/notifications.js?v=18',
-  '/app/voice.js?v=18',
+  '/app/app.js?v=19',
+  '/app/pairing.js?v=19',
+  '/app/device-store.js?v=19',
+  '/app/conversations.js?v=19',
+  '/app/gateway-health.js?v=19',
+  '/app/notifications.js?v=19',
+  '/app/voice.js?v=19',
   '/app/apple-touch-icon.png',
   '/app/icon.svg',
   '/app/icon-192.png',


### PR DESCRIPTION
## Summary
- add bounded exponential backoff for failed PWA event reconnects
- reset the delay after successful synchronization or a valid event
- bump the offline shell to v19 and cover failure/recovery timing

## Verification
- `npm run verify` (202 tests passed)
- physical Honor Android Chrome: paired at generation 1, rotated to generation 2 without a 429, and remained paired
- Mac Owner revocation converged to revoked on the phone and cleared private browser state
- re-pairing recovered with a new active generation-1 device while the predecessor remained revoked

No device identifiers, pairing codes, tokens, credentials, or private content are included.